### PR TITLE
Fix release.yml: aquasecurity/trivy-action ref needs v-prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           provenance: true
 
       - name: Scan image for vulnerabilities (report all, non-blocking)
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: sarif
@@ -70,7 +70,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Fail release on CRITICAL vulnerabilities only
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table


### PR DESCRIPTION
## Summary
- During Task 8's end-to-end verification of the Docker image + CI/CD sub-project, pushing a real tag (`v0.0.0-test1`) and running `release.yml` for real (not just reviewing it) surfaced a bug that static review of Task 5 missed: both `uses: aquasecurity/trivy-action@0.36.0` steps reference a tag that doesn't exist on that action's repo. `aquasecurity/trivy-action` only publishes `v`-prefixed tags (`v0.36.0`, `v0.35.0`, ...), unlike most other actions pinned in this repo's workflows which publish both forms.
- Run failed immediately at "Set up job" with `Unable to resolve action aquasecurity/trivy-action@0.36.0, unable to find version 0.36.0` — before checkout, before the build, before anything else ran.
- Fix: `@0.36.0` -> `@v0.36.0` in both places. Verified `v0.36.0` exists via `gh api repos/aquasecurity/trivy-action/git/refs/tags/v0.36.0`, and cross-checked every other `uses:` ref in `ci.yml`/`release.yml` resolves correctly (they all did — this was the only bad pin).

## Test plan
- [x] Confirmed the broken ref via a real failed run (`gh run view --log`)
- [x] Confirmed `v0.36.0` exists in `aquasecurity/trivy-action`'s tags
- [x] Confirmed all other action refs across both workflows resolve
- [ ] Once merged, Task 8 verification re-tags and re-runs `release.yml` end to end to confirm this is the only blocker