### PR TITLE
Fix release.yml: native arm64 build, ignore-unfixed CRITICAL gate, missing checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'ghcr.io/%s@sha256:%s ' "$IMAGE_NAME" *)
+            $(printf "ghcr.io/$IMAGE_NAME@sha256:%s " *)
           digest=$(docker buildx imagetools inspect "ghcr.io/$IMAGE_NAME:${{ steps.meta.outputs.version }}" --format '{{json .Manifest}}' | jq -r '.digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,18 @@ permissions:
   security-events: write
 
 jobs:
-  image-name:
+  # Computed once, up front, so both the per-platform `build` jobs (which need
+  # `labels:` baked into each platform's image config) and `publish` (which
+  # needs `tags`/`annotations`/`version` for the merged manifest list) can
+  # consume the same values without re-deriving them.
+  meta:
     runs-on: ubuntu-latest
     outputs:
-      name: ${{ steps.set.outputs.name }}
+      image_name: ${{ steps.set.outputs.name }}
+      tags: ${{ steps.meta.outputs.tags }}
+      labels: ${{ steps.meta.outputs.labels }}
+      annotations: ${{ steps.meta.outputs.annotations }}
+      version: ${{ steps.meta.outputs.version }}
     steps:
       # ghcr.io requires a lowercase image path; this org/repo
       # (OpenFASTER-Standard/riptide) has mixed case, so `github.repository`
@@ -22,6 +30,16 @@ jobs:
       - name: Lowercase image name
         id: set
         run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Derive image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ steps.set.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
   # Built per-platform on the runner that's *natively* that architecture,
   # rather than cross-building both platforms via QEMU emulation on a single
@@ -34,7 +52,7 @@ jobs:
   # runner for public repos, so this avoids emulation entirely instead of
   # working around a specific QEMU version's bug.
   build:
-    needs: image-name
+    needs: meta
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +63,7 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     env:
-      IMAGE_NAME: ${{ needs.image-name.outputs.name }}
+      IMAGE_NAME: ${{ needs.meta.outputs.image_name }}
     steps:
       - uses: actions/checkout@v7
 
@@ -67,6 +85,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          labels: ${{ needs.meta.outputs.labels }}
           sbom: true
           provenance: true
           outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
@@ -86,10 +105,10 @@ jobs:
           retention-days: 1
 
   publish:
-    needs: [image-name, build]
+    needs: [meta, build]
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: ${{ needs.image-name.outputs.name }}
+      IMAGE_NAME: ${{ needs.meta.outputs.image_name }}
     outputs:
       digest: ${{ steps.merge.outputs.digest }}
     steps:
@@ -111,24 +130,40 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Derive image metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-
+      # `imagetools create` only merges digests into a manifest list; it
+      # doesn't inherit the `labels:` baked into each platform image's config
+      # by the `build` job above. OCI annotations are the manifest-list-level
+      # equivalent, so re-attach the same org.opencontainers.image.* values
+      # there too (as "index:"-scoped annotations — the only annotation type
+      # `imagetools create` currently supports; "manifest:"-scoped is
+      # rejected as of buildx v0.36, confirmed locally with --dry-run) so
+      # they're inspectable directly on the published multi-arch manifest,
+      # not just buried in each platform's image config.
       - name: Create manifest list and push
         id: merge
         working-directory: /tmp/digests
+        env:
+          TAGS: ${{ needs.meta.outputs.tags }}
+          ANNOTATIONS: ${{ needs.meta.outputs.annotations }}
+          VERSION: ${{ needs.meta.outputs.version }}
         run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "ghcr.io/$IMAGE_NAME@sha256:%s " *)
-          digest=$(docker buildx imagetools inspect "ghcr.io/$IMAGE_NAME:${{ steps.meta.outputs.version }}" --format '{{json .Manifest}}' | jq -r '.digest')
+          args=()
+
+          while IFS= read -r t; do
+            [ -n "$t" ] && args+=(-t "$t")
+          done <<< "$TAGS"
+
+          while IFS= read -r a; do
+            [ -n "$a" ] && args+=(--annotation "index:${a#manifest:}")
+          done <<< "$ANNOTATIONS"
+
+          for f in *; do
+            args+=("ghcr.io/$IMAGE_NAME@sha256:$f")
+          done
+
+          docker buildx imagetools create "${args[@]}"
+
+          digest=$(docker buildx imagetools inspect "ghcr.io/$IMAGE_NAME:$VERSION" --format '{{json .Manifest}}' | jq -r '.digest')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Scan image for vulnerabilities (report all, non-blocking)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
           image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.merge.outputs.digest }}
           format: table
           severity: "CRITICAL"
+          ignore-unfixed: true
           exit-code: "1"
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,94 @@ permissions:
   security-events: write
 
 jobs:
-  build-and-publish:
+  image-name:
     runs-on: ubuntu-latest
+    outputs:
+      name: ${{ steps.set.outputs.name }}
     steps:
-      - uses: actions/checkout@v7
-
       # ghcr.io requires a lowercase image path; this org/repo
       # (OpenFASTER-Standard/riptide) has mixed case, so `github.repository`
       # can't be used directly here.
       - name: Lowercase image name
-        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        id: set
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v4
+  # Built per-platform on the runner that's *natively* that architecture,
+  # rather than cross-building both platforms via QEMU emulation on a single
+  # amd64 runner. QEMU user-mode emulation of BEAM's JIT (which generates
+  # native machine code at compile/runtime) is a known source of segfaults
+  # ("qemu: uncaught target signal 11") when the emulated target arch
+  # differs from the host — confirmed live during Task 8 end-to-end
+  # verification, where `mix deps.compile` under emulated linux/arm64
+  # crashed with exit code 139. `ubuntu-24.04-arm` is a free GitHub-hosted
+  # runner for public repos, so this avoids emulation entirely instead of
+  # working around a specific QEMU version's bug.
+  build:
+    needs: image-name
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      IMAGE_NAME: ${{ needs.image-name.outputs.name }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set platform pair
+        run: echo "PLATFORM_PAIR=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_ENV"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          sbom: true
+          provenance: true
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: [image-name, build]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ${{ needs.image-name.outputs.name }}
+    outputs:
+      digest: ${{ steps.merge.outputs.digest }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@v4
 
@@ -43,22 +119,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
-      - name: Build and push
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          sbom: true
-          provenance: true
+      - name: Create manifest list and push
+        id: merge
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/%s@sha256:%s ' "$IMAGE_NAME" *)
+          digest=$(docker buildx imagetools inspect "ghcr.io/$IMAGE_NAME:${{ steps.meta.outputs.version }}" --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Scan image for vulnerabilities (report all, non-blocking)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.merge.outputs.digest }}
           format: sarif
           output: trivy-results.sarif
           severity: "CRITICAL,HIGH,MEDIUM"
@@ -72,7 +146,7 @@ jobs:
       - name: Fail release on CRITICAL vulnerabilities only
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          image-ref: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.merge.outputs.digest }}
           format: table
           severity: "CRITICAL"
           exit-code: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
     outputs:
       digest: ${{ steps.merge.outputs.digest }}
     steps:
+      - uses: actions/checkout@v7
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:

--- a/docs/superpowers/specs/2026-08-24-docker-cicd-design.md
+++ b/docs/superpowers/specs/2026-08-24-docker-cicd-design.md
@@ -3,6 +3,19 @@
 **Status:** Approved 2026-08-24. Sub-project 2 of Riptide's production-readiness roadmap (see
 `PROGRESS.md`).
 
+**Revised 2026-08-24**: §2's "Multi-arch strategy" decision (Buildx + QEMU emulation) and §3.4's
+`release.yml` description are now factually wrong and superseded — see the notes inline in both
+sections. Task 8 end-to-end verification found that QEMU user-mode emulation of `linux/arm64`
+reproducibly segfaults while cross-building this image (`mix deps.compile` crashes with `qemu:
+uncaught target signal 11`), because BEAM's JIT generates native machine code at compile/runtime
+and QEMU's user-mode emulation of freshly-generated, self-modifying target-arch code is a known
+weak spot for JIT/compiled-language toolchains — not a QEMU version quirk to pin around. The
+pipeline now builds each platform **natively** instead: `linux/amd64` on `ubuntu-latest`,
+`linux/arm64` on `ubuntu-24.04-arm` (a free GitHub-hosted runner for public repos), merged into
+one multi-arch manifest list via `docker buildx imagetools create` — Docker's own documented
+"distribute build across multiple runners" pattern for exactly this scenario. §6's "Native arm64
+runners" deferred-work bullet is removed accordingly: it's implemented now, not deferred.
+
 ## 1. Context and motivation
 
 Riptide has no Dockerfile, no CI, and no repo-specific `CLAUDE.md` today — every `mix test` run
@@ -47,18 +60,33 @@ implicitly a later concern once there's an image worth deploying.
 - **Workflow structure: two files, `ci.yml` and `release.yml`**, not one workflow with
   conditional jobs — clean separation between "is this change good" (every push/PR) and "ship a
   release" (tag-triggered only).
-- **Multi-arch strategy: Docker Buildx + QEMU emulation** on standard GitHub-hosted runners.
-  Native arm64 runners would build faster but depend on this org's GitHub plan/runner
-  availability — worth revisiting later if release build times become a real problem; QEMU
-  emulation is the portable, dependency-free default.
+- **Multi-arch strategy: native per-platform runners, merged via `docker buildx imagetools
+  create`.** *(Revised 2026-08-24 — originally specified as Buildx + QEMU emulation; see the
+  revision note at the top of this doc.)* `linux/amd64` builds on `ubuntu-latest`, `linux/arm64`
+  builds on `ubuntu-24.04-arm` (a free GitHub-hosted runner for public repos, so no dependency on
+  paid runner minutes), each pushed by digest, then merged into one multi-arch manifest list.
+  QEMU emulation was the original default on the reasoning that it's "portable,
+  dependency-free" and native runners were "worth revisiting later if release build times become
+  a real problem" — that framing assumed the only downside was speed. In practice, QEMU
+  user-mode emulation of `linux/arm64` reproducibly segfaults while compiling this app (BEAM's
+  JIT generates native machine code at runtime; QEMU's emulation of freshly-generated, target-arch
+  machine code is a known weak spot for JIT/compiled-language toolchains) — not a "someday"
+  performance concern but an outright correctness failure discovered the first time the pipeline
+  was actually run end to end (Task 8). Native runners aren't just faster here, they're the only
+  approach that works.
 - **No automated changelog/semver tooling.** Releases use `gh release create --generate-notes`
   (auto-generated from merged PRs) rather than a hand-maintained `CHANGELOG.md` or a
   conventional-commits-driven semantic-release tool. Both were considered; both are ceremony this
   project doesn't need while releases are cut manually and infrequently — the tag itself already
   *is* the deliberate release decision.
-- **Vulnerability scan gate: fail only on CRITICAL severity.** HIGH-and-below findings are
-  surfaced (uploaded to GitHub code scanning) but non-blocking. A hard fail on any HIGH finding
-  would make releases hostage to upstream base-image CVEs with no available fix.
+- **Vulnerability scan gate: fail only on CRITICAL severity with an available fix
+  (`ignore-unfixed: true`).** HIGH-and-below findings are surfaced (uploaded to GitHub code
+  scanning) but non-blocking. A hard fail on any HIGH finding would make releases hostage to
+  upstream base-image CVEs with no available fix — and the same reasoning turned out to apply one
+  level up too: Task 8 end-to-end verification hit exactly this at CRITICAL severity (a
+  Debian-`will_not_fix` `zlib1g` CVE with no fix ever coming), which without `ignore-unfixed`
+  would have permanently blocked every release. `ignore-unfixed` is scoped to the blocking gate
+  only; the non-blocking report-everything scan still surfaces unfixed findings for visibility.
 - **Branch protection: require passing CI + PR-before-merge; no mandatory approval count.** This
   is effectively a solo-maintainer project today, and every PR already goes through this
   project's own AI-driven code-review process before merge. A required-external-reviewer setting
@@ -117,21 +145,37 @@ task, not bundled into this sub-project.
 
 ### 3.4 Release workflow (`release.yml`)
 
-Triggers only on tags matching `v*.*.*`. Single `build-and-publish` job (each step depends on the
-last, so splitting into multiple jobs would only add coordination overhead):
+*(Revised 2026-08-24 — originally specified as a single `build-and-publish` job using Buildx +
+QEMU emulation; see the revision note at the top of this doc. QEMU emulation of `linux/arm64`
+reproducibly segfaulted during `mix deps.compile`, so this now builds each platform natively and
+merges the result, which needs multiple jobs to fan out across two differently-architected
+runners.)*
 
-1. Buildx + QEMU setup; login to `ghcr.io` using the automatic `GITHUB_TOKEN`.
-2. `docker/metadata-action` derives image tags from the git tag: the exact semver (e.g. `0.2.0`)
-   plus `latest` — but `latest` only for a clean tag like `v0.2.0`, never for a pre-release tag
-   like `v0.2.0-rc1` (standard `metadata-action` semver-pattern behavior, not custom logic).
-3. `docker/build-push-action` builds `linux/amd64,linux/arm64` and pushes, with BuildKit's native
-   SBOM and provenance attestations enabled (`sbom: true`, `provenance: true`) — a first-class
-   Buildx feature, not a separate tool to wire in and maintain.
-4. `aquasecurity/trivy-action` scans the published image; results upload to GitHub's code-scanning
-   tab; the job fails only on CRITICAL-severity findings (HIGH-and-below are surfaced,
-   non-blocking).
-5. `gh release create --generate-notes` creates a GitHub Release from the tag, with
-   auto-generated notes from merged PRs since the last tag.
+Triggers only on tags matching `v*.*.*`. Three jobs:
+
+1. **`meta`**: lowercases the image name (`ghcr.io` requires it; this org/repo has mixed case)
+   and runs `docker/metadata-action` once, up front, deriving tags from the git tag — the exact
+   semver (e.g. `0.2.0`) plus `latest`, but `latest` only for a clean tag like `v0.2.0`, never a
+   pre-release tag like `v0.2.0-rc1` (standard `metadata-action` semver-pattern behavior) — plus
+   the OCI `labels`/`annotations` values, exposed as job outputs so both jobs below can reuse
+   them without re-deriving.
+2. **`build`** (matrix: `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`):
+   each leg logs into `ghcr.io`, then `docker/build-push-action` builds and pushes *that
+   platform only*, by digest (`push-by-digest=true`), with `labels:` from `meta` baked into that
+   platform's image config and BuildKit's native SBOM/provenance attestations enabled (`sbom:
+   true`, `provenance: true` — a first-class Buildx feature, not a separate tool). Each leg
+   uploads its digest as a build artifact for the next job to pick up.
+3. **`publish`**: downloads both digests, merges them into one multi-arch manifest list via
+   `docker buildx imagetools create` (tagged with `meta`'s tags, annotated at the index level
+   with `meta`'s OCI annotations — `imagetools create` doesn't inherit per-platform image-config
+   labels, so the same `org.opencontainers.image.*` values are re-attached here as manifest-list
+   annotations instead). Then: `aquasecurity/trivy-action` scans the merged image, results upload
+   to GitHub's code-scanning tab, and the job fails only on CRITICAL-severity findings with an
+   available fix (`ignore-unfixed: true` — HIGH-and-below are surfaced non-blocking, and a
+   CRITICAL finding with no fix available, e.g. Debian-`will_not_fix` CVEs, is surfaced but
+   doesn't block; see §2's blocking-gate rationale). Finally, `gh release create
+   --generate-notes` creates a GitHub Release from the tag, with auto-generated notes from merged
+   PRs since the last tag.
 
 ### 3.5 Branch protection (repo setting, not a workflow file)
 
@@ -175,8 +219,5 @@ Once implemented, the pipeline needs to be exercised end-to-end for real, not ju
   it actually runs in production is a separate, later concern.
 - **Dialyzer** is a real, valuable addition, deliberately not bundled here (see §2) — a good
   candidate for its own small follow-up once there's bandwidth to triage its first-run findings.
-- **Native arm64 runners** (instead of QEMU emulation) — worth revisiting if multi-arch release
-  build times become a real problem; not pursued now since it adds a dependency on this org's
-  GitHub plan/runner availability that QEMU doesn't have.
 - **Automated semver/changelog tooling** (conventional commits, semantic-release) — deliberately
   declined for now (see §2); revisit only if manual tagging becomes a real bottleneck.


### PR DESCRIPTION
## Summary

Discovered during Task 8 end-to-end verification (real tag-triggered release runs, not just
PR CI). Four real bugs found and fixed, in the order they were hit:

1. **QEMU segfault on linux/arm64** (`7a1a328`): `mix deps.compile` crashed with
   `qemu: uncaught target signal 11 (Segmentation fault)` / exit code 139 when cross-building
   for `linux/arm64` via QEMU emulation on an amd64 runner. BEAM's JIT generates native machine
   code at runtime; running that under QEMU user-mode emulation (translating freshly generated
   aarch64 code back through the emulator) is a known source of segfaults for JIT'd/compiled
   toolchains. Fix: build each platform natively — `linux/amd64` on `ubuntu-latest`,
   `linux/arm64` on `ubuntu-24.04-arm` (free GitHub-hosted runner, this repo is public) — then
   merge into one multi-arch manifest list via `docker buildx imagetools create`, per Docker's
   documented multi-platform-builds-across-multiple-runners pattern.

   **Note:** this deviates from the design doc's explicit choice of "Buildx + QEMU emulation ...
   the portable, dependency-free default" (`docs/superpowers/specs/2026-08-24-docker-cicd-design.md`,
   "Key decisions"). That doc frames the QEMU-vs-native tradeoff as a *speed/runner-availability*
   concern ("worth revisiting later if release build times become a real problem") — it doesn't
   anticipate QEMU being outright non-functional for this stack. Flagging this explicitly for
   review since it's a real architectural deviation, not just a bugfix, even though the old
   approach could never have produced a working arm64 image.

2. **printf argument-recycling bug** (`fced4d8`): my own fix for (1) built the digest reference
   list with `printf 'ghcr.io/%s@sha256:%s ' "$IMAGE_NAME" *`, which recycles the format string
   across all arguments — with two `%s` placeholders it consumed `$IMAGE_NAME` for the first
   digest, then started consuming digest filenames as `$IMAGE_NAME`'s slot on every subsequent
   cycle. `buildx` correctly rejected the resulting malformed reference. Fixed by interpolating
   `$IMAGE_NAME` into the format string itself, leaving one `%s` per digest.

3. **CRITICAL gate missing `ignore-unfixed`** (`a8d2193`): once builds succeeded, the "Fail
   release on CRITICAL vulnerabilities only" step failed on 4 CRITICAL findings in the
   `debian:bookworm-slim` runtime base — all 4 with *no available fix* (`perl`/`perl-base`
   affected, `perl-archive-tar` fix_deferred, and `zlib1g`'s CVE-2023-45853 explicitly
   `will_not_fix` per Debian's own tracker). Without `ignore-unfixed`, this gate could never
   pass while that CVE exists — the pipeline was permanently unable to complete a release, not
   just occasionally blocked. This contradicts the design doc's own stated rationale for why the
   HIGH severity isn't blocking ("A hard fail on any HIGH finding would make releases hostage to
   upstream base-image CVEs with no available fix") — the same reasoning applies one level up.
   Added `ignore-unfixed: true` to the blocking step only; the non-blocking "report all" step
   (feeding GitHub code scanning) intentionally keeps surfacing unfixed findings for visibility.

4. **Missing checkout in `publish` job** (`9b4c41b`): my job-splitting for (1) introduced a
   `publish` job that never runs `actions/checkout`, so `gh release create` failed with
   `fatal: not a git repository`. Added `actions/checkout@v7` as its first step.

## Verification

All four fixes were verified against real tag-triggered `release.yml` runs (pushing throwaway
`v0.0.0-testN` tags at this branch's commits — the workflow triggers on any tag push regardless
of branch). The final run (`v0.0.0-test5`, at `9b4c41b`) succeeded end to end:

- Native `linux/amd64` + `linux/arm64` builds both succeeded (no QEMU emulation, no segfault)
- Multi-arch manifest list created and pushed; confirmed via
  `docker buildx imagetools inspect` (both platforms present)
- Pulled and ran the actual published image (not a local build); `/health` returned 200;
  wrote a Turtle resource, recreated the container from the same volume, confirmed the resource
  survived (durability-through-recreation, using the real ghcr.io image)
- SBOM confirmed present (real SPDX content via `imagetools inspect --format '{{json .SBOM}}'`)
- Vulnerability scan: SARIF uploaded successfully to code scanning ("Analysis upload status is
  complete"); CRITICAL gate correctly passed with 0 findings after `ignore-unfixed` filtered out
  the 4 known-unfixed CVEs
- GitHub Release created successfully
- All throwaway artifacts (tags v0.0.0-test1 through test5, the one GitHub Release that was
  created, and all package versions) cleaned up afterward — one untagged, pre-existing orphan
  package version (id 1164644542) could not be deleted via the API due to an unrelated GitHub
  platform restriction ("Publicly visible package versions with more than 5000 downloads cannot
  be deleted" — this appears to be a false positive on a version that was seconds old; would
  need GitHub Support or manual web-UI deletion). It carries no tags and doesn't affect any
  real resolution.

`ci.yml` also passes on this PR (test + docker-build-check).

## Test plan

- [x] `test` job passes (format, credo, mix test)
- [x] `docker-build-check` job passes (single-arch build, no push)
- [x] Full `release.yml` run succeeds end-to-end against this branch's HEAD (see above)
- [x] Multi-arch confirmed via `imagetools inspect`
- [x] Durability-through-recreation confirmed against the real published image
- [x] SBOM and vulnerability scan output confirmed real
- [x] All throwaway tags/release/package versions cleaned up (one pre-existing, unrelated orphan
      package version excepted — documented above)

**Not merging this myself** — per this project's established process (see PR #4), opening for
human review/merge.