### PR TITLE
Phase 3d-i: fix HA-proof spike findings

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -233,10 +233,32 @@ sub-projects 1 and 2 did internally):
     assignment and a real cross-pod read.
 - **Phase 3d — HA proof + operator tooling.** Actually kill a node and prove streams keep
   working; manual grow/shrink tooling matching RabbitMQ's own manual-first precedent, deliberately
-  deferring sophisticated auto-rebalancing. **Not yet designed.**
+  deferring sophisticated auto-rebalancing.
+  - **3d-i — HA proof spike.** Live GKE spike (5-pod StatefulSet, RF=3): force-killed placement-
+    cluster pods and a stream replica pod to observe real failure/recovery behavior. **Investigated
+    and fixed 2026-08-25.** Found and fixed 2 real bugs, corrected a stale design-doc claim:
+    1. A fresh, non-placement-ordinal fleet node could lose a startup race and silently never
+       start its replica of a brand-new stream's cluster — `RaCluster.start_or_join_replicated/3`
+       blindly trusted `:ra.start_cluster/2`'s reply even when its `NotStarted` list was
+       non-empty. Fixed: `Riptide.Application.start/2` now starts every node's local `:ra` system
+       unconditionally at boot (closing the race at its root), and `start_or_join_replicated/3`
+       now treats a genuinely-not-alive `NotStarted` member as a retriable error instead of
+       silent partial success — routing through `Riptide.Stream.Placement`'s existing bounded
+       retry loop.
+    2. `Riptide.Placement.assign/2,3`/`lookup/1,2` hardcoded addressing the metadata cluster via
+       only `riptide-0`, no fallback — a de-facto single point of failure for the whole placement
+       layer on every restart of that one pod, even though the underlying 3-member Raft cluster
+       stayed healthy via its other members. Fixed: both now try each placement ordinal in turn.
+    3. Not a bug: confirmed (live + reproduced via a controlled multi-node test + direct `:ra`
+       source reading) that the placement cluster's own membership self-heals automatically after
+       genuine quorum loss, with zero data loss — contradicting 3c-i's own design spec, which was
+       corrected. This holds structurally as long as the placement cluster never snapshots
+       (`PlacementMachine.apply/3` never emits `release_cursor`); a tripwire regression test
+       (`test/riptide/placement_snapshot_recovery_test.exs`) guards against that assumption
+       silently breaking in the future.
 
-**Status**: Phases 3a-3b shipped. Phase 3c (3c-i/3c-ii/3c-iii) fully shipped. Phase 3d
-not yet designed.
+**Status**: Phases 3a-3b shipped. Phase 3c (3c-i/3c-ii/3c-iii) fully shipped. Phase 3d-i (HA
+proof spike + fixes) shipped 2026-08-25. Phase 3d-ii (operator tooling) not yet designed.
 
 ## 4-5. Not yet started
 

--- a/docs/superpowers/specs/2026-08-25-phase-3c-i-placement-metadata-design.md
+++ b/docs/superpowers/specs/2026-08-25-phase-3c-i-placement-metadata-design.md
@@ -71,10 +71,12 @@ depending on Khepri" exists independently in the BEAM ecosystem (`ex_esdb`, `Ram
 - No general N-of-fleet placement algorithm beyond a simple random-selection helper — the
   actual *use* of a placement decision (starting a real multi-member per-stream Ra cluster)
   is 3c-ii's job, not this phase's.
-- No automatic reconciliation of the metadata cluster's own membership after a member's
-  identity drifts (e.g. after a pod restart under a new IP) — manual-only for now, matching
-  Phase 3d's already-established "manual grow/shrink first, deliberately deferring
-  sophisticated auto-rebalancing" philosophy for the whole sub-project.
+- No *deliberately designed* reconciliation of the metadata cluster's own membership after a
+  member's identity drifts (e.g. after a pod restart under a new IP) — this was originally
+  scoped as manual-only, matching Phase 3d's "manual grow/shrink first, deliberately deferring
+  sophisticated auto-rebalancing" philosophy. **Correction, see §5:** this turns out to
+  self-heal automatically anyway, as a side effect of mechanisms this phase and Phase 3b
+  already ship — not because it was designed to.
 - No reassignment/rebalancing of already-assigned streams, ever, in this design — placement
   is permanent once made, matching RabbitMQ's own explicit, deliberate precedent (their core
   team has repeatedly rejected automatic rebalancing, citing SLA/predictability concerns).
@@ -147,12 +149,36 @@ itself already tolerates partial member availability (confirmed against the pinn
 source: it succeeds once a majority — 2 of 3 — are reachable), so the retry only needs to
 keep calling it until that quorum threshold is met.
 
-Post-restart identity drift (one of the 3 ordinals restarts under a new IP) is **not**
-automatically reconciled by this phase — the cluster keeps functioning on 2-of-3 quorum, but
-restoring the third member to healthy requires a manual operator action (`:ra.remove_member`
-+ `:ra.add_member`, or a small script) for now. Automatic self-healing of the metadata
-cluster's own membership is explicitly Phase 3d's job, not this phase's — consistent with the
-sub-project's established "manual-first" philosophy.
+**Correction (Phase 3d-i HA-proof spike, 2026-08-25):** the paragraph above, as originally
+written, was wrong. Post-restart identity drift (one of the 3 ordinals restarts under a new
+IP, having lost real quorum first) turns out to be reconciled automatically, with zero data
+loss, by mechanisms *already present* in this phase and Phase 3b — no manual operator action
+or Phase 3d tooling required. Confirmed via a live GKE spike (kill 2-of-3 placement-cluster
+pods, observe recovery) and reproduced/root-caused via a controlled `:peer`-based test plus
+direct `:ra`/`ra_server` source reading:
+
+- `RaCluster.data_dir/0`'s directory scheme is keyed by Kubernetes `HOSTNAME` (the stable
+  StatefulSet pod name, e.g. `riptide-0`), not by `node()`/pod IP — so a restarted pod, even
+  under a brand-new IP (and therefore a brand-new `node()` identity), recovers its own prior
+  on-disk `:ra` data via the same PVC mount path.
+- `ra_server:init/1`'s cluster-membership recovery branches on whether a snapshot exists: with
+  no snapshot, it trusts the *freshly passed* `initial_members` config (the restarted pod's
+  new identity); with a snapshot, it trusts the snapshot's own recorded membership instead.
+- `PlacementMachine.apply/3` never emits a `{:release_cursor, ...}` effect, so the placement
+  cluster itself never snapshots — meaning the first branch above always applies today, and a
+  freshly-restarted member's `ensure_placement_cluster_started/0` boot-time retry loop
+  (already shipped, originally written only to handle StatefulSet ordinal startup ordering)
+  ends up reconciling membership to the new identity as a side effect, for free.
+
+This is a **real but load-bearing structural assumption, not a coincidence**: it holds only as
+long as the placement cluster never snapshots. If `PlacementMachine` ever gains a
+`release_cursor` effect (e.g. for compaction/performance), this self-healing property would
+silently stop holding. A regression test (`test/riptide/placement_snapshot_recovery_test.exs`)
+exists specifically as a tripwire for that case — see its own moduledoc for the full mechanism
+and citations. The exact mechanism by which the *fresh* replacement peers' local view
+reconciles with the surviving member's committed log (rather than, e.g., forming an
+independent parallel cluster) is empirically confirmed and consistent with the above, though
+not proven exhaustively for every possible interleaving.
 
 ## 6. Testing
 

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -7,6 +7,18 @@ defmodule Riptide.Application do
 
   @impl true
   def start(_type, _args) do
+    # Every fleet node — not just the 3 placement ordinals — can be picked
+    # as a replica for a brand-new stream's real multi-member Ra cluster
+    # (Phase 3c-ii/3c-iii), and forming that cluster requires this node's
+    # own local `:ra` system to already be running by the time a sibling's
+    # `:ra.start_cluster/2` call reaches it over RPC. Doing this here,
+    # synchronously, before `Cluster.Supervisor`/libcluster even starts
+    # connecting to peers, closes that startup race at its root (see Phase
+    # 3d-i HA-proof spike, finding 1) rather than relying only on each
+    # entry point's own lazy, on-demand call to the same idempotent
+    # function.
+    Riptide.RaCluster.ensure_system_started()
+
     children =
       [
         {Phoenix.PubSub, name: Riptide.PubSub},

--- a/lib/riptide/placement.ex
+++ b/lib/riptide/placement.ex
@@ -5,13 +5,16 @@ defmodule Riptide.Placement do
   `Riptide.Placement.PlacementMachine` via a small, fixed-membership Ra
   cluster (see `Riptide.RaCluster.placement_server_id/1,2`).
 
-  `assign/2,3` and `lookup/1,2` currently always address the metadata cluster
-  via its first fixed ordinal (`RaCluster.placement_ordinals() |> hd()`) —
-  `:ra`'s own leader-redirect means this works whether or not that specific
-  ordinal happens to be the current leader, but if that one ordinal's own pod
-  is unreachable, these calls fail outright rather than falling back to a
-  different ordinal. Acceptable for this phase's narrow scope; revisit if it
-  proves to matter in practice.
+  `assign/2,3` and `lookup/1,2` address the metadata cluster by trying each
+  fixed ordinal in turn (starting from `RaCluster.placement_ordinals()`'s
+  first entry) until one succeeds — `:ra`'s own leader-redirect already
+  means any live member can serve the request whether or not it happens to
+  be the current leader, so falling back to the next ordinal on failure
+  needs no extra coordination. This used to hardcode the first ordinal only,
+  making it a de-facto single point of failure for the entire placement
+  layer on every restart of that one specific pod (confirmed live, Phase
+  3d-i HA-proof spike, finding 2) even though the underlying 3-member Raft
+  cluster stayed healthy via its other members the whole time.
   """
 
   alias Riptide.Placement.PlacementMachine
@@ -38,21 +41,38 @@ defmodule Riptide.Placement do
 
   @spec assign(String.t(), [node()], (String.t() -> node())) :: [node()]
   def assign(stream_id, proposed_nodes, resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
-    RaCluster.process_command(
-      placement_server_id(resolve_fun),
-      {:assign, stream_id, proposed_nodes}
-    )
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(server_id, {:assign, stream_id, proposed_nodes})
+    end)
   end
 
   @spec lookup(String.t(), (String.t() -> node())) :: [node()] | nil
   def lookup(stream_id, resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
-    RaCluster.consistent_query(
-      placement_server_id(resolve_fun),
-      &PlacementMachine.get(&1, stream_id)
-    )
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.consistent_query(server_id, &PlacementMachine.get(&1, stream_id))
+    end)
   end
 
-  defp placement_server_id(resolve_fun) do
-    RaCluster.placement_server_id(hd(RaCluster.placement_ordinals()), resolve_fun)
+  # Tries each placement ordinal, in `RaCluster.placement_ordinals/0`'s own
+  # fixed order, until one of them answers — `RaCluster.process_command/2`
+  # and `consistent_query/2` both raise on failure/timeout (see their own
+  # moduledoc rationale), so a failing ordinal is caught here and the next
+  # one tried instead of the whole call failing outright. The very last
+  # ordinal's exception is deliberately left to propagate uncaught: if *no*
+  # ordinal in the whole fixed set can serve the request, that's a genuine,
+  # fully-down metadata cluster, not something a caller here can paper over.
+  @spec with_ordinal_fallback((String.t() -> node()), (:ra.server_id() -> term())) :: term()
+  defp with_ordinal_fallback(resolve_fun, fun) do
+    try_ordinals(RaCluster.placement_ordinals(), resolve_fun, fun)
+  end
+
+  defp try_ordinals([ordinal], resolve_fun, fun) do
+    fun.(RaCluster.placement_server_id(ordinal, resolve_fun))
+  end
+
+  defp try_ordinals([ordinal | rest], resolve_fun, fun) do
+    fun.(RaCluster.placement_server_id(ordinal, resolve_fun))
+  rescue
+    _ -> try_ordinals(rest, resolve_fun, fun)
   end
 end

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -202,12 +202,16 @@ defmodule Riptide.RaCluster do
   # tree only brings up `ra_systems_sup`, an *empty* supervisor for
   # dynamically-started systems. Every consuming application is expected to
   # explicitly start (or restart) its Ra system(s) itself; see `ra`'s own
-  # README ("ra:start/0") and `ra_system:start_default/0`. We do it lazily
-  # and idempotently here, rather than in `Riptide.Application.start/2`, so
-  # `RaCluster` remains the sole module that talks to `:ra` at all and every
-  # entry point that needs the system stays self-sufficient.
+  # README ("ra:start/0") and `ra_system:start_default/0`. Idempotent, so
+  # every entry point that needs the system stays self-sufficient by calling
+  # this lazily — but ALSO called unconditionally and synchronously from
+  # `Riptide.Application.start/2` for every fleet node (not just the 3
+  # placement ordinals), closing the startup race where a node picked as a
+  # brand-new stream's replica hadn't started its own local system yet by
+  # the time a sibling's `:ra.start_cluster/2` call tried to reach it over
+  # RPC (see Phase 3d-i HA-proof spike, finding 1).
   @spec ensure_system_started() :: :ok
-  defp ensure_system_started do
+  def ensure_system_started do
     config = system_config()
 
     case :ra_system.start(config) do
@@ -287,12 +291,38 @@ defmodule Riptide.RaCluster do
     Path.join(base, System.get_env("HOSTNAME", "nonode")) |> String.to_charlist()
   end
 
+  # Public (not `defp`) specifically so `member_alive?/1` below can call it
+  # over `:erpc` for a server id on a remote node, not just the local one.
   @spec server_alive?(atom()) :: boolean()
-  defp server_alive?(name) do
+  def server_alive?(name) do
     case Process.whereis(name) do
       nil -> false
       pid -> Process.alive?(pid)
     end
+  end
+
+  # Local-or-remote liveness check for a single Ra server id — used to
+  # distinguish, member by member, "genuinely never started" from "already
+  # running, just not *newly* started by this particular
+  # `:ra.start_cluster/2` call" (see `start_or_join_replicated/3`'s
+  # `NotStarted` handling below). A member unreachable over `:erpc` (network
+  # blip, node still booting) is conservatively treated as not-alive, which
+  # only ever causes a spurious retry of an already-fine formation — never a
+  # silently-accepted broken one.
+  @spec member_alive?(:ra.server_id()) :: boolean()
+  defp member_alive?({name, node}) when node == node() do
+    server_alive?(name)
+  end
+
+  defp member_alive?({name, node}) do
+    case :erpc.call(node, __MODULE__, :server_alive?, [name], 5_000) do
+      true -> true
+      false -> false
+    end
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
   end
 
   # Retries indefinitely until the placement cluster is formed — intended to
@@ -413,6 +443,25 @@ defmodule Riptide.RaCluster do
   # one of `member_nodes`; if it isn't, the local liveness check is always
   # false, and the error correctly propagates (this node has no way to know
   # whether the *actual* members formed successfully elsewhere).
+  #
+  # A non-empty `NotStarted` list on the `{:ok, Started, NotStarted}` branch
+  # is deliberately treated as a retriable failure, not partial success —
+  # `:ra`'s own docs for this return shape say as much ("servers that could
+  # not be started need to be retried periodically"). Blindly returning
+  # `{:ok, member_ids}` regardless of `NotStarted` was a real, already-shipped
+  # bug (Phase 3d-i HA-proof spike, finding 1): a stream whose replica
+  # formation lost a race on one member (e.g. that node's local `:ra` system
+  # genuinely wasn't started yet — closed by the `ensure_system_started/0`
+  # call above being unconditional at application boot now, but this is real
+  # defense in depth against any other reason a member fails to start, e.g.
+  # a momentary network blip) got cached as fully healthy by
+  # `Riptide.Stream.Placement` even though one of its replicas silently never
+  # started — permanently, until an unrelated later request happened to land
+  # on that exact starved node for that exact stream and re-triggered
+  # formation as a side effect. Returning an error here instead routes
+  # through `Riptide.Stream.Placement`'s own existing bounded-retry loop
+  # (`start_with_retry/6`), which already exists precisely to absorb this
+  # kind of transient formation failure.
   @spec start_or_join_replicated(String.t(), [node()], :ra_machine.machine()) ::
           {:ok, [:ra.server_id()]} | {:error, :cluster_not_formed}
   def start_or_join_replicated(uid, member_nodes, machine) do
@@ -433,8 +482,22 @@ defmodule Riptide.RaCluster do
       end)
 
     case :ra.start_cluster(@system, configs) do
-      {:ok, _started, _not_started} ->
+      {:ok, _started, []} ->
         {:ok, member_ids}
+
+      {:ok, _started, [_ | _] = not_started} ->
+        # `NotStarted` also catches members that are already alive but
+        # merely weren't *newly* started by this particular call (e.g. a
+        # concurrent redundant formation attempt from another node already
+        # won for that member) — same false-failure shape as the
+        # `{:error, :cluster_not_formed}` branch below, just per-member
+        # instead of whole-cluster. Only genuinely-dead members should
+        # trigger a retry.
+        if Enum.all?(not_started, &member_alive?/1) do
+          {:ok, member_ids}
+        else
+          {:error, :cluster_not_formed}
+        end
 
       {:error, :cluster_not_formed} ->
         if server_alive?(name) do

--- a/test/riptide/placement_cluster_test.exs
+++ b/test/riptide/placement_cluster_test.exs
@@ -18,152 +18,7 @@ defmodule Riptide.PlacementClusterTest do
   end
 
   test "the placement metadata cluster bootstraps across 3 real nodes and agrees on assignments" do
-    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
-
-    peers =
-      for {alive_name, ordinal, host} <- @peers do
-        {:ok, pid, node} =
-          :peer.start_link(%{
-            name: alive_name,
-            host: host,
-            longnames: true,
-            args: pa_args,
-            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
-          })
-
-        {pid, node, ordinal}
-      end
-
-    on_exit(fn ->
-      Enum.each(peers, fn {pid, _node, _ordinal} ->
-        if Process.alive?(pid) do
-          try do
-            :peer.stop(pid)
-          catch
-            :exit, _ -> :ok
-          end
-        end
-      end)
-
-      # NEW GOTCHA (found empirically while implementing this test, beyond
-      # the brief's own list): `:peer`-spawned nodes don't load this
-      # project's Mix config at all (they're bare `erl` processes booted
-      # with just `-pa <code path>`, no `-config`/release env) — so
-      # `RaCluster.data_dir/0`'s `Application.get_env(:ra, :data_dir,
-      # File.cwd!())` falls through to the `File.cwd!()` default on every
-      # peer, NOT `config/test.exs`'s `priv/ra_data_test`. Each peer
-      # inherits this test-runner's own cwd (the repo root), so `:ra`
-      # durably persists the placement cluster's real on-disk state
-      # directly under `<repo_root>/riptide-0`, `riptide-1`, `riptide-2` —
-      # confirmed by inspecting the filesystem after a run. Left alone, a
-      # second run recovers that stale state at `:ra_system` boot before
-      # this test's own bootstrap logic gets a chance to run, corrupting
-      # the very thing under test (observed: every member showing up
-      # "already started" immediately, before any real interaction).
-      # Clean it up here so the test is idempotent across repeated runs.
-      Enum.each(@peers, fn {_alive_name, ordinal, _host} ->
-        File.rm_rf!(Path.join(File.cwd!(), ordinal))
-      end)
-    end)
-
-    # ExUnit compiles test/ files purely in-memory (only "lib" and
-    # "test/support" are in `elixirc_paths`, per mix.exs) — no .beam for this
-    # module ever lands on disk, so peers spawned with `-pa <code path>`
-    # never see it, even though the full path list is passed. Confirmed
-    # empirically: passing a closure defined in this module as an
-    # `:erpc.call/4` argument fails with `{:exception, :undef, ...}` on the
-    # remote node when the closure is invoked there. Fix: explicitly compile
-    # this file and push the resulting bytecode to each peer via
-    # `:code.load_binary/3` before relying on any closure from this module
-    # crossing the wire — this is the documented fallback's underlying fix
-    # (plain data alone isn't the issue; the module's absence is), applied
-    # without needing to restructure the resolver into non-closure data.
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
-
-    for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
-               :erpc.call(node, :code, :load_binary, [
-                 module,
-                 ~c"placement_cluster_test.ex",
-                 bytecode
-               ])
-    end
-
-    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
-    ordinal_to_node = Map.new(peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
-    resolve_fun = fn ordinal -> Map.fetch!(ordinal_to_node, ordinal) end
-
-    for {n1, n2} <- unique_pairs(nodes) do
-      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
-    end
-
-    # `:ra` must be started as an OTP application on EVERY member before ANY
-    # of them attempts to form the cluster — `attempt_start_placement_cluster/1`
-    # calls `:ra.start_cluster/2`, which reaches out over RPC to start the
-    # *other* members too, not just the local one. Confirmed empirically:
-    # interleaving "start :ra, then immediately attempt to form" per node (as
-    # a single combined loop) races the still-not-started siblings and fails
-    # with `{:error, :system_not_started}` on every remote member the caller
-    # gets to before its own turn comes up — surfacing as
-    # `{:error, :cluster_not_formed}` from `attempt_start_placement_cluster/1`
-    # itself. Splitting into two passes avoids the race.
-    for {_pid, node, _ordinal} <- peers do
-      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
-    end
-
-    # `attempt_start_placement_cluster/1` only starts the *local* `:default`
-    # Ra system (via its own private `ensure_system_started/0`) on whichever
-    # node calls it — but internally it calls `:ra.start_cluster/2`, which
-    # tries to start EVERY member's server, including the ones on the *other*
-    # two nodes, over RPC. Confirmed empirically: without this, calling
-    # `attempt_start_placement_cluster/1` on each node in turn fails with
-    # `{:error, :cluster_not_formed}` every time — `:ra`'s own logs show
-    # `{:error, :system_not_started}` for whichever sibling members haven't
-    # yet run `attempt_start_placement_cluster/1` themselves (so never
-    # started their own local system), which is every sibling except
-    # whichever one is on its own turn. Pre-start every node's local
-    # `:default` system directly (mirroring `RaCluster`'s own private
-    # `ensure_system_started/0`, via its public `system_config/0`) before any
-    # node attempts cluster formation, so no member is ever "not started yet"
-    # when another member's `:ra.start_cluster/2` call tries to reach it.
-    for {_pid, node, _ordinal} <- peers do
-      case :erpc.call(node, :ra_system, :start, [
-             :erpc.call(node, Riptide.RaCluster, :system_config, [])
-           ]) do
-        {:ok, _pid} -> :ok
-        {:ok, _pid, _info} -> :ok
-        {:error, {:already_started, _pid}} -> :ok
-      end
-    end
-
-    # NEW GOTCHA (found empirically while implementing this test, beyond the
-    # brief's own list): `attempt_start_placement_cluster/1`'s moduledoc
-    # comment in `ra_cluster.ex` claims it's "safe to call redundantly from
-    # multiple ordinals concurrently" because `:ra.start_cluster/2` tolerates
-    # `{:error, {:already_started, _pid}}` per member internally — but that
-    # only covers a *remote* member that's already running. Calling it a
-    # second time on a node whose *own local* member is already up (because
-    # an earlier winning call already started every member, this one
-    # included, via RPC) hits a local `ra_server_sup` child-start conflict
-    # that `:ra.start_cluster/2` does NOT treat as equivalent to success —
-    # it reports the whole call as `{:error, :cluster_not_formed}`, same as
-    # a genuine failure-to-form. Confirmed real, not a timing fluke: happens
-    # identically whether the 3 calls are made sequentially (after the
-    # cluster's already fully formed by the first) or concurrently via
-    # `Task.async` (racing each other). So at most one of the 3 calls can
-    # ever observe `:ok` — the redundant callers observing an error is
-    # expected, not proof the cluster failed to form. What actually matters,
-    # and what this asserts, is that (a) at least one ordinal's attempt
-    # genuinely forms the cluster fresh, and (b) the cluster that results is
-    # for real — proven below by successful, replicated assign/lookup calls
-    # across all 3 members, not by this step's return values alone.
-    results =
-      Enum.map(peers, fn {_pid, node, _ordinal} ->
-        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
-      end)
-
-    assert Enum.all?(results, &(&1 in [:ok, {:error, :cluster_not_formed}]))
-    assert Enum.any?(results, &(&1 == :ok))
+    {peers, nodes, resolve_fun} = bootstrap()
 
     {_pid, entry_node, _ordinal} = hd(peers)
     stream_id = "placement-test-" <> Uniq.UUID.uuid4()
@@ -197,6 +52,213 @@ defmodule Riptide.PlacementClusterTest do
       ])
 
     assert Enum.sort(reassigned) == Enum.sort(proposed)
+  end
+
+  # Regression test for Phase 3d-i's HA-proof spike finding 2: `assign/2,3`
+  # and `lookup/1,2` used to always address the metadata cluster via ONLY
+  # `RaCluster.placement_ordinals() |> hd()` ("riptide-0"), with no
+  # fallback — making that one specific ordinal a de-facto single point of
+  # failure for the entire placement layer even though the underlying
+  # 3-member Raft cluster stayed perfectly healthy on its other 2 members.
+  # Stopping riptide-0's peer here reproduces exactly that: the cluster
+  # keeps a live 2-of-3 quorum, but the *client's own addressing*, not
+  # consensus, was the thing that used to break.
+  test "assign/2 and lookup/2 fall back to a surviving ordinal when riptide-0 is unreachable" do
+    {peers, nodes, resolve_fun} = bootstrap()
+
+    [{pid0, node0, _ord0}, {_pid1, node1, _ord1} = peer1, {_pid2, node2, _ord2} = peer2] = peers
+    surviving_peers = [peer1, peer2]
+
+    stop_peer(pid0)
+
+    {_pid, entry_node, _ordinal} = peer1
+    stream_id = "placement-fallback-test-" <> Uniq.UUID.uuid4()
+    proposed = Enum.take(nodes, 2)
+
+    assigned =
+      :erpc.call(entry_node, Riptide.Placement, :assign, [stream_id, proposed, resolve_fun])
+
+    assert Enum.sort(assigned) == Enum.sort(proposed)
+
+    for {_pid, node, _ordinal} <- surviving_peers do
+      looked_up = :erpc.call(node, Riptide.Placement, :lookup, [stream_id, resolve_fun])
+      assert Enum.sort(looked_up) == Enum.sort(proposed)
+    end
+
+    refute node0 in [node1, node2]
+  end
+
+  defp bootstrap do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    peers = spawn_peers(pa_args)
+
+    on_exit(fn -> cleanup_peers(peers) end)
+
+    push_module_to_peers(peers)
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+    ordinal_to_node = Map.new(peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
+    resolve_fun = fn ordinal -> Map.fetch!(ordinal_to_node, ordinal) end
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    bootstrap_ra_on_peers(peers)
+    form_placement_cluster(peers, resolve_fun)
+
+    {peers, nodes, resolve_fun}
+  end
+
+  defp spawn_peers(pa_args) do
+    for {alive_name, ordinal, host} <- @peers do
+      {:ok, pid, node} =
+        :peer.start_link(%{
+          name: alive_name,
+          host: host,
+          longnames: true,
+          args: pa_args,
+          env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+        })
+
+      {pid, node, ordinal}
+    end
+  end
+
+  defp cleanup_peers(peers) do
+    Enum.each(peers, fn {pid, _node, _ordinal} -> stop_peer(pid) end)
+
+    # NEW GOTCHA (found empirically while implementing this test, beyond
+    # the brief's own list): `:peer`-spawned nodes don't load this
+    # project's Mix config at all (they're bare `erl` processes booted
+    # with just `-pa <code path>`, no `-config`/release env) — so
+    # `RaCluster.data_dir/0`'s `Application.get_env(:ra, :data_dir,
+    # File.cwd!())` falls through to the `File.cwd!()` default on every
+    # peer, NOT `config/test.exs`'s `priv/ra_data_test`. Each peer
+    # inherits this test-runner's own cwd (the repo root), so `:ra`
+    # durably persists the placement cluster's real on-disk state
+    # directly under `<repo_root>/riptide-0`, `riptide-1`, `riptide-2` —
+    # confirmed by inspecting the filesystem after a run. Left alone, a
+    # second run recovers that stale state at `:ra_system` boot before
+    # this test's own bootstrap logic gets a chance to run, corrupting
+    # the very thing under test (observed: every member showing up
+    # "already started" immediately, before any real interaction).
+    # Clean it up here so the test is idempotent across repeated runs.
+    Enum.each(@peers, fn {_alive_name, ordinal, _host} ->
+      File.rm_rf!(Path.join(File.cwd!(), ordinal))
+    end)
+  end
+
+  defp stop_peer(pid) do
+    if Process.alive?(pid), do: do_stop_peer(pid)
+  end
+
+  defp do_stop_peer(pid) do
+    :peer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp push_module_to_peers(peers) do
+    # ExUnit compiles test/ files purely in-memory (only "lib" and
+    # "test/support" are in `elixirc_paths`, per mix.exs) — no .beam for this
+    # module ever lands on disk, so peers spawned with `-pa <code path>`
+    # never see it, even though the full path list is passed. Confirmed
+    # empirically: passing a closure defined in this module as an
+    # `:erpc.call/4` argument fails with `{:exception, :undef, ...}` on the
+    # remote node when the closure is invoked there. Fix: explicitly compile
+    # this file and push the resulting bytecode to each peer via
+    # `:code.load_binary/3` before relying on any closure from this module
+    # crossing the wire — this is the documented fallback's underlying fix
+    # (plain data alone isn't the issue; the module's absence is), applied
+    # without needing to restructure the resolver into non-closure data.
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"placement_cluster_test.ex",
+                 bytecode
+               ])
+    end
+  end
+
+  # `:ra` must be started as an OTP application on EVERY member before ANY
+  # of them attempts to form the cluster — `attempt_start_placement_cluster/1`
+  # calls `:ra.start_cluster/2`, which reaches out over RPC to start the
+  # *other* members too, not just the local one. Confirmed empirically:
+  # interleaving "start :ra, then immediately attempt to form" per node (as
+  # a single combined loop) races the still-not-started siblings and fails
+  # with `{:error, :system_not_started}` on every remote member the caller
+  # gets to before its own turn comes up — surfacing as
+  # `{:error, :cluster_not_formed}` from `attempt_start_placement_cluster/1`
+  # itself. Splitting into two passes avoids the race.
+  #
+  # `attempt_start_placement_cluster/1` only starts the *local* `:default`
+  # Ra system (via its own private `ensure_system_started/0`) on whichever
+  # node calls it — but internally it calls `:ra.start_cluster/2`, which
+  # tries to start EVERY member's server, including the ones on the *other*
+  # two nodes, over RPC. Confirmed empirically: without this, calling
+  # `attempt_start_placement_cluster/1` on each node in turn fails with
+  # `{:error, :cluster_not_formed}` every time — `:ra`'s own logs show
+  # `{:error, :system_not_started}` for whichever sibling members haven't
+  # yet run `attempt_start_placement_cluster/1` themselves (so never
+  # started their own local system), which is every sibling except
+  # whichever one is on its own turn. Pre-start every node's local
+  # `:default` system directly (mirroring `RaCluster`'s own private
+  # `ensure_system_started/0`, via its public `system_config/0`) before any
+  # node attempts cluster formation, so no member is ever "not started yet"
+  # when another member's `:ra.start_cluster/2` call tries to reach it.
+  defp bootstrap_ra_on_peers(peers) do
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      start_ra_system(node)
+    end
+  end
+
+  defp start_ra_system(node) do
+    case :erpc.call(node, :ra_system, :start, [
+           :erpc.call(node, Riptide.RaCluster, :system_config, [])
+         ]) do
+      {:ok, _pid} -> :ok
+      {:ok, _pid, _info} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+  end
+
+  # NEW GOTCHA (found empirically while implementing this test, beyond the
+  # brief's own list): `attempt_start_placement_cluster/1`'s moduledoc
+  # comment in `ra_cluster.ex` claims it's "safe to call redundantly from
+  # multiple ordinals concurrently" because `:ra.start_cluster/2` tolerates
+  # `{:error, {:already_started, _pid}}` per member internally — but that
+  # only covers a *remote* member that's already running. Calling it a
+  # second time on a node whose *own local* member is already up (because
+  # an earlier winning call already started every member, this one
+  # included, via RPC) hits a local `ra_server_sup` child-start conflict
+  # that `:ra.start_cluster/2` does NOT treat as equivalent to success —
+  # it reports the whole call as `{:error, :cluster_not_formed}`, same as
+  # a genuine failure-to-form. Confirmed real, not a timing fluke: happens
+  # identically whether the 3 calls are made sequentially (after the
+  # cluster's already fully formed by the first) or concurrently via
+  # `Task.async` (racing each other). So at most one of the 3 calls can
+  # ever observe `:ok` — the redundant callers observing an error is
+  # expected, not proof the cluster failed to form. What actually matters,
+  # and what this asserts, is that (a) at least one ordinal's attempt
+  # genuinely forms the cluster fresh, and (b) the cluster that results is
+  # for real — proven below by successful, replicated assign/lookup calls
+  # across all 3 members, not by this step's return values alone.
+  defp form_placement_cluster(peers, resolve_fun) do
+    results =
+      Enum.map(peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
+      end)
+
+    assert Enum.all?(results, &(&1 in [:ok, {:error, :cluster_not_formed}]))
+    assert Enum.any?(results, &(&1 == :ok))
   end
 
   defp unique_pairs(list) do

--- a/test/riptide/placement_snapshot_recovery_test.exs
+++ b/test/riptide/placement_snapshot_recovery_test.exs
@@ -1,0 +1,239 @@
+defmodule Riptide.PlacementSnapshotRecoveryTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  # This is a tripwire, not just a regression test — see the design spec
+  # correction in `docs/superpowers/specs/2026-08-25-phase-3c-i-placement-metadata-design.md`
+  # §5 for the full writeup. Short version:
+  #
+  # Losing genuine quorum on the placement metadata cluster (2-of-3 members
+  # killed) and then restarting those members under fresh identities (new
+  # pod IPs, same Kubernetes StatefulSet `HOSTNAME`) turns out to self-heal
+  # automatically, with zero data loss, via the combination of:
+  #
+  #   1. `RaCluster.data_dir/0` keys on `HOSTNAME` (the stable pod name),
+  #      not `node()`/IP — a restarted member recovers its own prior
+  #      on-disk `:ra` data.
+  #   2. `ra_server:init/1`'s cluster-membership recovery trusts the
+  #      *freshly passed* `initial_members` config when no snapshot exists
+  #      on disk, rather than the stale membership from before the restart.
+  #   3. `PlacementMachine.apply/3` never emits a `{:release_cursor, ...}`
+  #      effect, so the placement cluster never snapshots — meaning
+  #      condition 2's "no snapshot exists" branch always applies today.
+  #
+  # If `PlacementMachine` ever gains a `release_cursor` effect (e.g. for
+  # compaction), condition 3 stops holding and this test should start
+  # failing — that failure IS the point: it means whoever made that change
+  # needs to consciously design real membership-reconciliation tooling
+  # (Phase 3d's originally-scoped "manual grow/shrink" territory) rather
+  # than unknowingly losing a self-healing property nothing else guards.
+  @peers [
+    {:snap_a, "riptide-0", ~c"127.0.0.30"},
+    {:snap_b, "riptide-1", ~c"127.0.0.31"},
+    {:snap_c, "riptide-2", ~c"127.0.0.32"}
+  ]
+
+  @replacements [
+    {:snap_a2, "riptide-0", ~c"127.0.0.33"},
+    {:snap_b2, "riptide-1", ~c"127.0.0.34"}
+  ]
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"placement_snapshot_recovery_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "the placement cluster reconciles membership and preserves all data after losing quorum and restarting under fresh identities" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    original_peers = start_peers(@peers, pa_args)
+
+    on_exit(fn ->
+      cleanup_data_dirs(@peers)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    push_module(original_peers, module, bytecode)
+
+    nodes = Enum.map(original_peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    original_resolver =
+      Map.new(original_peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
+
+    original_resolve_fun = fn ordinal -> Map.fetch!(original_resolver, ordinal) end
+
+    bootstrap_ra(original_peers)
+    form_placement_cluster(original_peers, original_resolve_fun)
+
+    [{pid_a, node_a, _}, {pid_b, _node_b, _}, {_pid_c, node_c, _}] = original_peers
+
+    stream_id = "snapshot-recovery-" <> Uniq.UUID.uuid4()
+
+    assigned =
+      :erpc.call(node_a, Riptide.Placement, :assign, [
+        stream_id,
+        [node_a],
+        original_resolve_fun
+      ])
+
+    assert assigned == [node_a]
+
+    assert :erpc.call(node_c, Riptide.Placement, :lookup, [stream_id, original_resolve_fun]) ==
+             [node_a]
+
+    # Kill 2-of-3 — genuine quorum loss, not a graceful shutdown.
+    stop_peer(pid_a)
+    stop_peer(pid_b)
+
+    # Spawn fresh replacement peers for riptide-0/riptide-1 under brand-new
+    # node identities (new IPs) but the SAME `HOSTNAME` env var — mirroring
+    # a real pod restart under a new IP on the same StatefulSet ordinal /
+    # PVC mount.
+    replacement_peers = start_peers(@replacements, pa_args)
+
+    on_exit(fn ->
+      Enum.each(replacement_peers, fn {pid, _node, _ordinal} -> stop_peer(pid) end)
+    end)
+
+    push_module(replacement_peers, module, bytecode)
+
+    [{_pid_a2, node_a2, _}, {_pid_b2, node_b2, _}] = replacement_peers
+
+    for node <- [node_a2, node_b2] do
+      assert :erpc.call(node, :net_kernel, :connect_node, [node_c]) == true
+    end
+
+    bootstrap_ra(replacement_peers)
+
+    fresh_resolver =
+      Map.new([{"riptide-0", node_a2}, {"riptide-1", node_b2}, {"riptide-2", node_c}])
+
+    fresh_resolve_fun = fn ordinal -> Map.fetch!(fresh_resolver, ordinal) end
+
+    # Both fresh replacements attempt to (re)form the placement cluster —
+    # exactly what `RaCluster.ensure_placement_cluster_started/0`'s
+    # boot-time infinite-retry loop already does on every real pod boot,
+    # with no new code needed for this to work.
+    for {_pid, node, _ordinal} <- replacement_peers do
+      _ =
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [
+          fresh_resolve_fun
+        ])
+    end
+
+    # Membership reconciles to the fresh identities, queried from the one
+    # member that was never killed.
+    assert eventually(fn ->
+             case :erpc.call(node_c, :ra, :members, [{:riptide_placement, node_c}]) do
+               {:ok, members, _leader} ->
+                 member_nodes = Enum.map(members, fn {_name, n} -> n end)
+                 Enum.sort(member_nodes) == Enum.sort([node_a2, node_b2, node_c])
+
+               _ ->
+                 false
+             end
+           end)
+
+    # No data loss: the original assignment, made before the quorum loss,
+    # is still there — queried through the fresh resolver, against the
+    # reconciled cluster.
+    assert :erpc.call(node_c, Riptide.Placement, :lookup, [stream_id, fresh_resolve_fun]) ==
+             [node_a]
+  end
+
+  defp start_peers(peer_specs, pa_args) do
+    for {alive_name, ordinal, host} <- peer_specs do
+      {:ok, pid, node} =
+        :peer.start_link(%{
+          name: alive_name,
+          host: host,
+          longnames: true,
+          args: pa_args,
+          env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+        })
+
+      {pid, node, ordinal}
+    end
+  end
+
+  defp push_module(peers, module, bytecode) do
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"placement_snapshot_recovery_test.ex",
+                 bytecode
+               ])
+    end
+  end
+
+  defp bootstrap_ra(peers) do
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+  end
+
+  defp form_placement_cluster(peers, resolve_fun) do
+    results =
+      Enum.map(peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
+      end)
+
+    assert Enum.all?(results, &(&1 in [:ok, {:error, :cluster_not_formed}]))
+    assert Enum.any?(results, &(&1 == :ok))
+  end
+
+  defp stop_peer(pid) do
+    :peer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp cleanup_data_dirs(peer_specs) do
+    Enum.each(peer_specs, fn {_alive_name, ordinal, _host} ->
+      File.rm_rf!(Path.join(File.cwd!(), ordinal))
+    end)
+  end
+
+  # Membership reconciliation isn't instantaneous — it happens as a side
+  # effect of `attempt_start_placement_cluster/1`'s own election/replication
+  # machinery settling, not synchronously within a single call.
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() ->
+        true
+
+      attempts_left <= 1 ->
+        false
+
+      true ->
+        Process.sleep(100)
+        eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end

--- a/test/riptide/ra_cluster_replicated_formation_test.exs
+++ b/test/riptide/ra_cluster_replicated_formation_test.exs
@@ -1,0 +1,140 @@
+defmodule Riptide.RaClusterReplicatedFormationTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  alias Riptide.Test.EchoMachine
+
+  @peers [
+    {:sojr_a, "sojr-a", ~c"127.0.0.11"},
+    {:sojr_b, "sojr-b", ~c"127.0.0.12"},
+    {:sojr_c, "sojr-c", ~c"127.0.0.13"}
+  ]
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"ra_cluster_replicated_formation_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  # Reproduces Phase 3d-i's HA-proof spike finding 1 directly, at the exact
+  # layer where the bug lived: `start_or_join_replicated/3` blindly trusting
+  # `:ra.start_cluster/2`'s `{:ok, Started, NotStarted}` reply even when
+  # `NotStarted` is non-empty. With RF=3, 2-of-3 members starting is already
+  # a quorum — `:ra.start_cluster/2` succeeds and reports the 3rd in
+  # `NotStarted` rather than failing outright, which is exactly what made
+  # the old code's blanket `{:ok, member_ids}` dangerous: the returned
+  # server_ids looked completely healthy even though one replica silently
+  # never started. Node C here stands in for a fleet node whose `:ra` OTP
+  # application is running (an ordinary dependency of `:riptide`, always up)
+  # but whose local `:default` Ra *system* hasn't been started yet — exactly
+  # the gap `Riptide.Application.start/2` now closes proactively in
+  # production; this test proves the lower-level `RaCluster` fix holds even
+  # without that boot-time call, since a momentary reason for a member to be
+  # unreachable (network blip, mid-crash restart) can never be fully ruled
+  # out by a single boot-time call anyway.
+  test "a 2-of-3 quorum with the 3rd member's local Ra system not yet started is not silently accepted as fully replicated" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    peers =
+      for {alive_name, ordinal, host} <- @peers do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(@peers, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"ra_cluster_replicated_formation_test.ex",
+                 bytecode
+               ])
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}] = peers
+
+    for {n1, n2} <- [{node_a, node_b}, {node_a, node_c}, {node_b, node_c}] do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    # `:ra` the OTP application is started on all 3, mirroring how it's
+    # always running as an ordinary dependency of `:riptide` in production —
+    # only the `:default` Ra *system* is what's deliberately left unstarted
+    # on node_c, reproducing the actual gap.
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for node <- [node_a, node_b] do
+      {:ok, _} =
+        :erpc.call(node, :ra_system, :start, [
+          :erpc.call(node, Riptide.RaCluster, :system_config, [])
+        ])
+    end
+
+    uid = "sojr-race-" <> Uniq.UUID.uuid4()
+    machine = {:module, EchoMachine, %{}}
+    member_nodes = [node_a, node_b, node_c]
+
+    # Old behavior: 2-of-3 (a and b) reach quorum, `:ra.start_cluster/2`
+    # returns `{:ok, [a's id, b's id], [c's id]}`, and the pre-fix code
+    # returned `{:ok, member_ids}` for all 3 anyway — silently under-
+    # replicating. The fix must surface this as retriable instead.
+    assert :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+             uid,
+             member_nodes,
+             machine
+           ]) == {:error, :cluster_not_formed}
+
+    refute :erpc.call(node_c, Riptide.RaCluster, :server_alive?, [String.to_atom(uid)])
+
+    # Node C catches up — mirrors what `Riptide.Application.start/2` now
+    # does proactively at boot in production — and a retry (exactly what
+    # `Riptide.Stream.Placement`'s own bounded-retry loop would do) succeeds
+    # for real, with all 3 members genuinely running.
+    {:ok, _} =
+      :erpc.call(node_c, :ra_system, :start, [
+        :erpc.call(node_c, Riptide.RaCluster, :system_config, [])
+      ])
+
+    assert {:ok, server_ids} =
+             :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+               uid,
+               member_nodes,
+               machine
+             ])
+
+    assert length(server_ids) == 3
+    assigned_nodes = Enum.map(server_ids, fn {_name, n} -> n end)
+    assert Enum.sort(assigned_nodes) == Enum.sort(member_nodes)
+    assert :erpc.call(node_c, Riptide.RaCluster, :server_alive?, [String.to_atom(uid)])
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to the Phase 3d-i HA-proof spike (live GKE, RF=3 StatefulSet, force-killed pods). The spike surfaced 3 findings; this PR fixes the 2 real bugs and corrects a stale design-doc claim for the 3rd.

1. **Fresh-node formation race (real bug).** A fleet node that isn't one of the 3 placement ordinals could lose a startup race and silently never start its replica of a brand-new stream's cluster: `start_or_join_replicated/3` blindly trusted `:ra.start_cluster/2`'s reply even when its `NotStarted` list was non-empty (`:ra`'s own docs say `NotStarted` members "need to be retried periodically" — the old code just dropped that on the floor). Fixed two ways: `Riptide.Application.start/2` now starts every node's local `:ra` system unconditionally at boot (closing the race at its root), and `start_or_join_replicated/3` now checks real liveness for any `NotStarted` member and returns a retriable error instead of silently accepting partial replication — routing through `Riptide.Stream.Placement`'s existing bounded retry loop.

2. **`riptide-0` addressing SPOF (real bug).** `Riptide.Placement.assign/2,3`/`lookup/1,2` hardcoded addressing the metadata cluster via only `riptide-0`, with no fallback — a de-facto single point of failure for the entire placement layer on every restart of that one pod, even though the underlying 3-member Raft cluster stayed healthy via its other members the whole time. Fixed: both now try each placement ordinal in turn.

3. **Not a bug — doc correction.** Confirmed (live + reproduced via a controlled multi-node test + direct `:ra` source reading) that the placement cluster's own membership self-heals automatically after genuine quorum loss, with zero data loss — contradicting the 3c-i design spec's "not automatically reconciled" claim, which is corrected here. This holds structurally as long as the placement cluster never snapshots (`PlacementMachine.apply/3` never emits `release_cursor`); a new tripwire regression test guards against that assumption silently breaking later.

## Test plan

- [x] `mix test` — 113 tests, 0 failures (was 110; +3 new regression tests), run 3x to check for multi-node test flakiness
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] New test `test/riptide/ra_cluster_replicated_formation_test.exs` reproduces finding 1 directly (RF=3, kills the exact NotStarted race) and proves the fix
- [x] New test in `test/riptide/placement_cluster_test.exs` reproduces finding 2 (kills riptide-0's peer, confirms fallback)
- [x] New test `test/riptide/placement_snapshot_recovery_test.exs` reproduces the finding-3 self-heal scenario as a permanent tripwire

🤖 Generated with [Claude Code](https://claude.com/claude-code)