### PR TITLE
Phase 3d-ii: automatic stream replica healing

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Riptide — Production Readiness Roadmap
 
-**Last updated:** 2026-08-24
+**Last updated:** 2026-08-25
 
 This tracks Riptide's path from "working reference implementation" (shipped: see
 [PR #1](https://github.com/OpenFASTER-Standard/riptide/pull/1)) to "production-grade centerpiece
@@ -264,9 +264,20 @@ sub-projects 1 and 2 did internally):
        (`PlacementMachine.apply/3` never emits `release_cursor`); a tripwire regression test
        (`test/riptide/placement_snapshot_recovery_test.exs`) guards against that assumption
        silently breaking in the future.
+  - **3d-ii — Automatic stream replica healing.** A stream with exactly one dead replica (of
+    RF=3) is now detected and repaired automatically, with zero operator action — see
+    `docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md`. **Shipped
+    2026-08-25.** `Riptide.Stream.ReplicaHealer` sweeps every known stream on a timer, gated to
+    only the placement cluster's current Raft leader (reusing its existing leader election for
+    single-writer safety, no new coordination mechanism), and on finding a dead member: joins a
+    live replacement into the stream's real `:ra` cluster (`RaCluster.replace_member/5`),
+    updates the durable placement assignment, and broadcasts a PubSub invalidation so no node's
+    cache keeps routing to the dead replica. Live-proved against a real 5-pod GKE StatefulSet
+    (RF=3): a killed replica pod was automatically replaced with no operator action and no data
+    loss.
 
 **Status**: Phases 3a-3b shipped. Phase 3c (3c-i/3c-ii/3c-iii) fully shipped. Phase 3d-i (HA
-proof spike + fixes) shipped 2026-08-25. Phase 3d-ii (operator tooling) not yet designed.
+proof spike + fixes) shipped 2026-08-25. Phase 3d-ii (automatic stream replica healing) shipped 2026-08-25.
 
 ## 4-5. Not yet started
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -232,8 +232,16 @@ sub-projects 1 and 2 did internally):
     stream's 3 replicas correctly served both a request that resolved the existing
     assignment and a real cross-pod read.
 - **Phase 3d — HA proof + operator tooling.** Actually kill a node and prove streams keep
-  working; manual grow/shrink tooling matching RabbitMQ's own manual-first precedent, deliberately
-  deferring sophisticated auto-rebalancing.
+  working. **Scope correction (2026-08-25, ahead of 3d-ii design):** the placement cluster's own
+  membership is a solved problem (see 3d-i finding 3) — this phase's remaining, still-fully-open
+  job is repairing a *stream's own* replica set after a member's node identity drifts. That drift
+  isn't a rare failure mode: every pod restart (routine deploy included) gets a fresh IP-based
+  `node()` identity (Phase 3b), so it's the normal steady state of running this fleet, not an
+  edge case. Manual/on-demand operator tooling for something this frequent doesn't scale — 3d-ii
+  is scoped as a **fully automatic background self-healing process** (detect drift, pick a
+  replacement, repair — zero operator/human involvement in the steady-state case), not a
+  RabbitMQ-style manual-first CLI tool as originally sketched. This is a deliberate reversal of
+  the sub-project's earlier "manual grow/shrink first" framing for this specific piece.
   - **3d-i — HA proof spike.** Live GKE spike (5-pod StatefulSet, RF=3): force-killed placement-
     cluster pods and a stream replica pod to observe real failure/recovery behavior. **Investigated
     and fixed 2026-08-25.** Found and fixed 2 real bugs, corrected a stale design-doc claim:

--- a/docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md
+++ b/docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md
@@ -1014,13 +1014,18 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
 
     assert Enum.any?(results, &(&1 == :ok))
 
-    for {_pid, node, _ordinal} <- peers do
-      {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
-    end
-
+    # PubSub before Placement — Task 5's `Riptide.Stream.Placement.init/1`
+    # now subscribes to a PubSub topic on start (tolerating a not-yet-started
+    # `Riptide.PubSub` via a scoped rescue, but there's no reason to rely on
+    # that here when starting it first is just as easy and matches real
+    # `Riptide.Application.start/2`'s own ordering).
     for {_pid, node, _ordinal} <- peers do
       {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
       {:ok, _} = start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
     end
 
     stream_id = "healer-cluster-" <> Uniq.UUID.uuid4()

--- a/docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md
+++ b/docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md
@@ -230,18 +230,11 @@ git commit -m "Add Riptide.Placement.list_all/1 and replace_member/4"
 
 - [ ] **Step 1: Write the failing test for `placement_leader?/0`**
 
-Add to `test/riptide/ra_cluster_test.exs`, in a new `describe` block after the existing `describe "attempt_start_placement_cluster/1"` block:
+Add to `test/riptide/ra_cluster_test.exs`, in a new `describe` block after the existing `describe "attempt_start_placement_cluster/1"` block. Note: `test_helper.exs` always bootstraps a real, running (single-node-collapsed) placement cluster on the test-runner's own node before any test file runs, so there is no honest way to observe a "not running locally" state from within this async suite — only the positive case is tested here; the collapsed cluster's sole member is trivially always its own leader:
 
 ```elixir
   describe "placement_leader?/0" do
-    test "returns false when the placement cluster isn't running locally" do
-      refute RaCluster.placement_leader?()
-    end
-
-    test "returns true once this node forms/joins the placement cluster and becomes its leader" do
-      resolve_fun = fn _ordinal -> node() end
-      :ok = RaCluster.attempt_start_placement_cluster(resolve_fun)
-
+    test "returns true for this node's own already-running (collapsed) placement cluster" do
       assert RaCluster.placement_leader?()
     end
   end
@@ -1050,10 +1043,16 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
     # Kill node_c for real — the replica being replaced.
     stop_peer_for(peers, node_c)
 
-    # Run the sweep directly from node_a (a placement ordinal) rather than
-    # waiting on the real 30s timer — node_a is also guaranteed to be the
-    # placement cluster's actual leader often enough in a 3-member cluster
-    # that a short retry loop below tolerates the case where it isn't yet.
+    # Run the sweep directly from node_a rather than waiting on the real
+    # 30s timer. `ReplicaHealer.sweep/0` itself performs no leader check —
+    # only the timer-driven `handle_info(:sweep, state)` gates on
+    # `RaCluster.placement_leader?/0` before calling `sweep/0` — so calling
+    # `sweep/0` directly here always attempts the repair regardless of
+    # node_a's actual leadership status; this is a deliberate test-only
+    # bypass of the production gating path, not a claim about node_a being
+    # the leader. The retry loop below exists for a different reason: the
+    # kill in the previous step needs a moment to actually disconnect
+    # before `RaCluster.member_alive?/1` reliably observes it as dead.
     assert eventually(fn ->
              :erpc.call(node_a, Riptide.Stream.ReplicaHealer, :sweep, []) == :ok and
                Enum.sort(:erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])) !=

--- a/docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md
+++ b/docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md
@@ -1,0 +1,1271 @@
+# Phase 3d-ii: Automatic Stream Replica Healing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect a stream with exactly one dead replica and automatically replace it with a live fleet node — no operator action required — closing the gap where a stream's frozen `node()`-based replica assignment never re-resolves after a pod restart (unlike the placement cluster, which self-heals for free per Phase 3d-i).
+
+**Architecture:** A new `Riptide.Stream.ReplicaHealer` `GenServer`, started only on the 3 placement ordinals (same gating as `ensure_placement_cluster_started/0`), ticks on a timer and — only when this node is the placement cluster's current Raft leader — lists every known stream (`Riptide.Placement.list_all/1`, new), checks each replica's real liveness, and for any stream with exactly one dead member, picks a live replacement and repairs it: joins the replacement into the stream's own `:ra` cluster (`RaCluster.replace_member/5`, new — verified against the pinned `:ra` source's real `add_member`/`start_server`/`remove_member` sequence), updates the durable placement assignment (`PlacementMachine`'s new `{:replace_member, ...}` command), and broadcasts a `Phoenix.PubSub` invalidation so any node's stale in-memory cache of that stream's server ids gets corrected.
+
+**Tech Stack:** Elixir/OTP, `:ra` (Erlang Raft, pinned `2.15.4`), `Phoenix.PubSub`, ExUnit, OTP 25's `:peer` module for real multi-node integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md`
+
+## Global Constraints
+
+- Only streams with exactly one dead member (of RF=3) are auto-repaired. A stream with 2+ dead members has already lost quorum — `:ra`'s own membership-change primitives require consensus to commit, so they fail/timeout harmlessly against such a cluster rather than making anything worse. This is never special-cased in code; it falls out of the underlying primitives.
+- No deliberate replication-factor changes (this only replaces a dead member 1-for-1) and no proactive node decommissioning/evacuation — both explicitly out of scope (spec §3).
+- No new locking/coordination primitive — single-writer safety across the 3 ordinals comes from the placement cluster's own existing Raft leader election.
+- No explicit flapping/debounce state — a node that reconnects before the next sweep is simply observed alive again next tick and left untouched.
+- `RaCluster` remains the sole module that calls `:ra` directly (standing invariant since Phase 3c-i) — `Riptide.Stream.ReplicaHealer` never calls `:ra` itself, only `RaCluster`/`Placement` functions.
+
+---
+
+### Task 1: `PlacementMachine`'s `list/1` query + `{:replace_member, ...}` command
+
+**Files:**
+- Modify: `lib/riptide/placement/placement_machine.ex`
+- Test: `test/riptide/placement/placement_machine_test.exs`
+
+**Interfaces:**
+- Consumes: nothing new — pure state-machine logic on the existing `state()` type (`%{String.t() => [node()]}`).
+- Produces: `PlacementMachine.list/1` (`state() -> state()`, i.e. returns the full map) and the new `{:replace_member, stream_id, dead_node, new_node}` command handled by `apply/3`. Task 2 wraps both in `Riptide.Placement`'s client API.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/riptide/placement/placement_machine_test.exs`, after the existing `get/2` tests:
+
+```elixir
+  test "list/1 returns the full stream_id => nodes map" do
+    state = %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}
+    assert PlacementMachine.list(state) == state
+  end
+
+  test "list/1 returns an empty map when nothing is assigned yet" do
+    assert PlacementMachine.list(PlacementMachine.init(%{})) == %{}
+  end
+
+  test "apply/3 {:replace_member, ...} swaps a dead node for a new one in an existing assignment" do
+    state = %{"s1" => [:a, :b, :c]}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1}, {:replace_member, "s1", :b, :z}, state)
+
+    assert new_state == %{"s1" => [:a, :z, :c]}
+    assert reply == [:a, :z, :c]
+    assert effects == []
+  end
+
+  test "apply/3 {:replace_member, ...} is a no-op if the named dead node is no longer present" do
+    state = %{"s1" => [:a, :z, :c]}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 2}, {:replace_member, "s1", :b, :y}, state)
+
+    assert new_state == %{"s1" => [:a, :z, :c]}
+    assert reply == [:a, :z, :c]
+    assert effects == []
+  end
+
+  test "apply/3 {:replace_member, ...} is a no-op for an unknown stream_id" do
+    state = %{}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1}, {:replace_member, "unknown", :a, :b}, state)
+
+    assert new_state == %{}
+    assert reply == nil
+    assert effects == []
+  end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mix test test/riptide/placement/placement_machine_test.exs --trace`
+Expected: FAIL — `PlacementMachine.list/1` is undefined, and `apply/3` has no clause matching `{:replace_member, ...}`.
+
+- [ ] **Step 3: Implement `list/1` and the `{:replace_member, ...}` command**
+
+Modify `lib/riptide/placement/placement_machine.ex` — add after the existing `{:assign, ...}` clause of `apply/3`:
+
+```elixir
+  # Idempotent the same way {:assign, ...} is: if `dead_node` is no longer
+  # part of `stream_id`'s stored assignment (e.g. a different placement-
+  # cluster leader, from a prior Raft term, already won this exact repair),
+  # this is a no-op that returns the current assignment unchanged rather
+  # than erroring — safe to call redundantly from a racing leader.
+  @impl :ra_machine
+  def apply(_meta, {:replace_member, stream_id, dead_node, new_node}, state) do
+    case Map.fetch(state, stream_id) do
+      {:ok, nodes} ->
+        if dead_node in nodes do
+          new_nodes = Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
+          new_state = Map.put(state, stream_id, new_nodes)
+          {new_state, new_nodes, []}
+        else
+          {state, nodes, []}
+        end
+
+      :error ->
+        {state, nil, []}
+    end
+  end
+
+  @spec list(state()) :: state()
+  def list(state), do: state
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mix test test/riptide/placement/placement_machine_test.exs --trace`
+Expected: PASS, all tests including the pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/riptide/placement/placement_machine.ex test/riptide/placement/placement_machine_test.exs
+git commit -m "Add PlacementMachine.list/1 and {:replace_member, ...} command"
+```
+
+---
+
+### Task 2: `Riptide.Placement.list_all/1` and `replace_member/3` client functions
+
+**Files:**
+- Modify: `lib/riptide/placement.ex`
+- Test: `test/riptide/placement_test.exs`
+
+**Interfaces:**
+- Consumes: `PlacementMachine.list/1`, the `{:replace_member, ...}` command (Task 1); the existing private `with_ordinal_fallback/2` helper (Phase 3d-i fix 2) for ordinal-fallback addressing.
+- Produces: `Placement.list_all/1` (`(String.t() -> node()) -> %{String.t() => [node()]}`) and `Placement.replace_member/4` (`(stream_id, dead_node, new_node, resolve_fun) -> [node()] | nil`). Both consumed by Task 6's healer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/riptide/placement_test.exs`, inside the existing `describe "assign/2 and lookup/2 against the real metadata cluster"` block:
+
+```elixir
+    test "list_all/1 includes every real assignment made so far" do
+      stream_id = "placement-list-all-" <> Uniq.UUID.uuid4()
+      Placement.assign(stream_id, [node()])
+
+      assert Placement.list_all()[stream_id] == [node()]
+    end
+
+    test "replace_member/3 swaps a dead node for a new one in a real assignment" do
+      stream_id = "placement-replace-member-" <> Uniq.UUID.uuid4()
+      fake_dead_node = :"fake-dead@nowhere"
+      Placement.assign(stream_id, [node(), fake_dead_node])
+
+      replaced = Placement.replace_member(stream_id, fake_dead_node, :"fake-new@nowhere")
+
+      assert Enum.sort(replaced) == Enum.sort([node(), :"fake-new@nowhere"])
+      assert Enum.sort(Placement.lookup(stream_id)) == Enum.sort([node(), :"fake-new@nowhere"])
+    end
+
+    test "replace_member/3 is a no-op if the dead node named is no longer part of the assignment" do
+      stream_id = "placement-replace-member-noop-" <> Uniq.UUID.uuid4()
+      Placement.assign(stream_id, [node()])
+
+      result = Placement.replace_member(stream_id, :"never-was-here@nowhere", :"new@nowhere")
+
+      assert result == [node()]
+      assert Placement.lookup(stream_id) == [node()]
+    end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mix test test/riptide/placement_test.exs --trace`
+Expected: FAIL — `Placement.list_all/1` and `Placement.replace_member/4` are undefined.
+
+- [ ] **Step 3: Implement `list_all/1` and `replace_member/4`**
+
+Modify `lib/riptide/placement.ex` — add after the existing `lookup/2` function, before `defp placement_server_id/1`:
+
+```elixir
+  @spec list_all((String.t() -> node())) :: %{String.t() => [node()]}
+  def list_all(resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.consistent_query(server_id, &PlacementMachine.list/1)
+    end)
+  end
+
+  @spec replace_member(String.t(), node(), node(), (String.t() -> node())) :: [node()] | nil
+  def replace_member(
+        stream_id,
+        dead_node,
+        new_node,
+        resolve_fun \\ &RaCluster.default_ordinal_resolver/1
+      ) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(server_id, {:replace_member, stream_id, dead_node, new_node})
+    end)
+  end
+```
+
+Note: `with_ordinal_fallback/2` is renamed from its current 2-arity private form only if needed — check the existing signature at `lib/riptide/placement.ex` (added in Phase 3d-i fix 2) before adding these; it already takes `(resolve_fun, fun)` and works unchanged for both new functions.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mix test test/riptide/placement_test.exs --trace`
+Expected: PASS, all tests including the pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/riptide/placement.ex test/riptide/placement_test.exs
+git commit -m "Add Riptide.Placement.list_all/1 and replace_member/4"
+```
+
+---
+
+### Task 3: `RaCluster.member_alive?/1` made public + `RaCluster.placement_leader?/0`
+
+**Files:**
+- Modify: `lib/riptide/ra_cluster.ex`
+- Test: `test/riptide/ra_cluster_test.exs`
+
+**Interfaces:**
+- Consumes: the existing private `member_alive?/1` (Phase 3d-i fix 1, currently `defp` at `lib/riptide/ra_cluster.ex:313`) and the existing `@placement_cluster_name` module attribute.
+- Produces: `RaCluster.member_alive?/1` (now public — `(:ra.server_id()) -> boolean()`) and `RaCluster.placement_leader?/0` (`() -> boolean()`). Both consumed by Task 6's healer.
+
+- [ ] **Step 1: Write the failing test for `placement_leader?/0`**
+
+Add to `test/riptide/ra_cluster_test.exs`, in a new `describe` block after the existing `describe "attempt_start_placement_cluster/1"` block:
+
+```elixir
+  describe "placement_leader?/0" do
+    test "returns false when the placement cluster isn't running locally" do
+      refute RaCluster.placement_leader?()
+    end
+
+    test "returns true once this node forms/joins the placement cluster and becomes its leader" do
+      resolve_fun = fn _ordinal -> node() end
+      :ok = RaCluster.attempt_start_placement_cluster(resolve_fun)
+
+      assert RaCluster.placement_leader?()
+    end
+  end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mix test test/riptide/ra_cluster_test.exs --trace`
+Expected: FAIL — `RaCluster.placement_leader?/0` is undefined. (The first test, checking the not-yet-formed case, may pass vacuously depending on test order since `test_helper.exs` already bootstraps a shared placement cluster at suite boot — this is expected and fine; the second test is the real proof.)
+
+- [ ] **Step 3: Make `member_alive?/1` public and add `placement_leader?/0`**
+
+Modify `lib/riptide/ra_cluster.ex`:
+
+Change the two `member_alive?/1` clauses (currently around line 313) from `defp` to `def`, keeping their bodies and the comment above them unchanged:
+
+```elixir
+  # Public (not `defp`) so callers beyond this module — e.g.
+  # `Riptide.Stream.ReplicaHealer` (Phase 3d-ii) — can check a specific
+  # stream replica's real liveness, local or remote, the same way this
+  # module already does internally for `start_or_join_replicated/3`'s own
+  # `NotStarted` handling.
+  @spec member_alive?(:ra.server_id()) :: boolean()
+  def member_alive?({name, node}) when node == node() do
+    server_alive?(name)
+  end
+
+  def member_alive?({name, node}) do
+    case :erpc.call(node, __MODULE__, :server_alive?, [name], 5_000) do
+      true -> true
+      false -> false
+    end
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+```
+
+Add `placement_leader?/0` after `placement_server_id/2` (around line 45, right before the `default_ordinal_resolver/1` comment block):
+
+```elixir
+  # Whether THIS node is currently the placement cluster's Raft leader —
+  # used by `Riptide.Stream.ReplicaHealer` (Phase 3d-ii) to gate stream
+  # replica repair so only one of the 3 placement ordinals ever acts on a
+  # given sweep, reusing the placement cluster's own existing leader
+  # election rather than a new coordination mechanism. Queries the LOCAL
+  # member directly (`{@placement_cluster_name, node()}`) rather than going
+  # through `placement_server_id/2`'s ordinal/DNS resolution, since this is
+  # only ever meaningful to call from a node that's itself a placement
+  # ordinal already running its own local member.
+  @spec placement_leader?() :: boolean()
+  def placement_leader? do
+    case :ra.members({@placement_cluster_name, node()}) do
+      {:ok, _members, {@placement_cluster_name, leader_node}} -> leader_node == node()
+      _ -> false
+    end
+  end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mix test test/riptide/ra_cluster_test.exs --trace`
+Expected: PASS, all tests including the pre-existing ones.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `mix test`
+Expected: PASS, 0 failures — `member_alive?/1` becoming public doesn't change any existing caller's behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/riptide/ra_cluster.ex test/riptide/ra_cluster_test.exs
+git commit -m "Expose RaCluster.member_alive?/1 publicly, add placement_leader?/0"
+```
+
+---
+
+### Task 4: `RaCluster.replace_member/5` — the real `:ra` join-and-evict primitive
+
+**Files:**
+- Modify: `lib/riptide/ra_cluster.ex`
+- Test: `test/riptide/ra_cluster_test.exs` (collapsed-node case), `test/riptide/ra_cluster_replace_member_test.exs` (new — real multi-node `:peer` proof)
+
+**Interfaces:**
+- Consumes: `ensure_system_started/0`, `uid_for/1`, `member_alive?/1` (Task 3), the module's own `@system` attribute.
+- Produces: `RaCluster.replace_member/5` (`(uid, survivor_nodes, dead_node, new_node, machine) -> :ok | {:error, term()}`). Consumed by Task 6's healer.
+
+This is verified against the pinned `:ra` source (`deps/ra/src/ra.erl`) and its own README
+(`deps/ra/README.md`, "Dynamically Changing Cluster Membership" section): growing a running
+cluster is `:ra.add_member(existing_member_id_or_ids, new_member_id)` **first** (tells the
+existing cluster about the new member), **then** `:ra.start_server/5` on the new member (config's
+`initial_members` set to just the existing survivor(s), not a fresh `initial_members` list) so it
+starts as a joining follower and catches up via ordinary log replication — the reverse order of
+`start_or_join_replicated/3`'s fresh-cluster-formation case. `:ra.start_server/2,5` internally
+RPCs to whichever node the target server id names (confirmed in
+`deps/ra/src/ra_server_sup_sup.erl:41-48`), so this can be called from any connected node, not
+just the joining node itself — consistent with every other `RaCluster` primitive's
+location-transparent style.
+
+- [ ] **Step 1: Write the failing collapsed-node test**
+
+Add to `test/riptide/ra_cluster_test.exs`, in a new `describe` block after `describe "start_or_join_replicated/3"`:
+
+```elixir
+  describe "replace_member/5" do
+    test "replaces a member with a fresh one, collapsed onto a single real node" do
+      uid = "replace-member-" <> Uniq.UUID.uuid4()
+      name = String.to_atom(uid)
+      machine = {:module, EchoMachine, %{}}
+      on_exit(fn -> :ra.force_delete_server(:default, {name, node()}) end)
+
+      assert {:ok, _server_ids} =
+               RaCluster.start_or_join_replicated(uid, [node()], machine)
+
+      # A single real node standing in for both "the dead node" and "the
+      # replacement" is nonsensical for a real repair, but proves the
+      # function's own call sequence (add_member, start_server, remove_member)
+      # doesn't blow up against a real, already-running single-member
+      # cluster — real distinctness is proven separately by Step 5's
+      # `:peer`-based test.
+      assert RaCluster.replace_member(uid, [node()], :"dead@nowhere", node(), machine) ==
+               {:error, :already_member}
+    end
+  end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mix test test/riptide/ra_cluster_test.exs --trace`
+Expected: FAIL — `RaCluster.replace_member/5` is undefined.
+
+- [ ] **Step 3: Implement `replace_member/5`**
+
+Modify `lib/riptide/ra_cluster.ex` — add after `start_or_join_replicated/3` (end of the module, before the final `end`):
+
+```elixir
+  # Grows a stream's already-running `:ra` cluster by one member (`new_node`)
+  # and evicts a dead one (`dead_node`) — the real repair primitive behind
+  # Phase 3d-ii's automatic replica healing. `survivor_nodes` must be at
+  # least one currently-alive member of the cluster (never `dead_node`
+  # itself); passing every survivor (not just one) lets `:ra` itself pick a
+  # reachable one to route the membership-change commands through, the same
+  # `ra_server_id() | [ra_server_id()]` flexibility `:ra.add_member/2` and
+  # `:ra.remove_member/2` already support directly.
+  #
+  # Order matters and is NOT `start_or_join_replicated/3`'s "form a fresh
+  # cluster" order — verified against `:ra`'s own growing-a-cluster
+  # documentation (`deps/ra/README.md`, "Dynamically Changing Cluster
+  # Membership"): add the member to the existing cluster's configuration
+  # FIRST, then start the joining server itself with `initial_members` set
+  # to just the survivor(s) — reversed, a freshly-started server with no
+  # cluster membership entry yet has nothing to catch up from.
+  @spec replace_member(String.t(), [node()], node(), node(), :ra_machine.machine()) ::
+          :ok | {:error, term()}
+  def replace_member(uid, survivor_nodes, dead_node, new_node, machine) do
+    ensure_system_started()
+    name = String.to_atom(uid)
+    survivor_ids = Enum.map(survivor_nodes, &{name, &1})
+    dead_id = {name, dead_node}
+    new_id = {name, new_node}
+    cluster_name = uid <> "_cluster"
+
+    with {:ok, _reply, _leader} <- :ra.add_member(survivor_ids, new_id),
+         :ok <- :ra.start_server(@system, cluster_name, new_id, machine, survivor_ids),
+         {:ok, _reply, _leader} <- :ra.remove_member(survivor_ids, dead_id) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      {:timeout, _} -> {:error, :timeout}
+    end
+  end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mix test test/riptide/ra_cluster_test.exs --trace`
+Expected: PASS, all tests including the pre-existing ones. The collapsed-node test expects `{:error, :already_member}` because `node()` is already a member of its own single-node cluster — this is expected and correct; it proves the call sequence executes against real `:ra` without crashing, not a successful 3-node repair (that's Step 5).
+
+- [ ] **Step 5: Write the real multi-node proof**
+
+Create `test/riptide/ra_cluster_replace_member_test.exs`:
+
+```elixir
+defmodule Riptide.RaClusterReplaceMemberTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  alias Riptide.Test.EchoMachine
+
+  @peers [
+    {:repl_a, "repl-a", ~c"127.0.0.40"},
+    {:repl_b, "repl-b", ~c"127.0.0.41"},
+    {:repl_c, "repl-c", ~c"127.0.0.42"}
+  ]
+
+  @replacement {:repl_d, "repl-d", ~c"127.0.0.43"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"ra_cluster_replace_member_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "replace_member/5 evicts a dead real member and joins a fresh real replacement, preserving data" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    all_specs = @peers ++ [@replacement]
+
+    peers =
+      for {alive_name, ordinal, host} <- all_specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"ra_cluster_replace_member_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, node_d, _}] = peers
+    original_nodes = [node_a, node_b, node_c]
+
+    uid = "replace-member-real-" <> Uniq.UUID.uuid4()
+    machine = {:module, EchoMachine, %{}}
+
+    assert {:ok, _server_ids} =
+             :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+               uid,
+               original_nodes,
+               machine
+             ])
+
+    name = String.to_atom(uid)
+
+    # Write real data before the repair, to prove it survives.
+    :erpc.call(node_a, Riptide.RaCluster, :process_command, [{name, node_a}, {:add, "a"}])
+
+    # Kill node_c for real — the member being replaced.
+    stop_peer_for(peers, node_c)
+
+    survivor_nodes = [node_a, node_b]
+
+    assert :ok =
+             :erpc.call(node_a, Riptide.RaCluster, :replace_member, [
+               uid,
+               survivor_nodes,
+               node_c,
+               node_d,
+               machine
+             ])
+
+    assert eventually(fn ->
+             case :erpc.call(node_a, :ra, :members, [{name, node_a}]) do
+               {:ok, members, _leader} ->
+                 member_nodes = Enum.map(members, fn {_name, n} -> n end)
+                 Enum.sort(member_nodes) == Enum.sort([node_a, node_b, node_d])
+
+               _ ->
+                 false
+             end
+           end)
+
+    assert :erpc.call(node_d, Riptide.RaCluster, :server_alive?, [name])
+    refute :erpc.call(node_a, Riptide.RaCluster, :member_alive?, [{name, node_c}])
+
+    # No data loss: the write made before the repair is still there,
+    # readable through the NEW member.
+    assert :erpc.call(node_d, Riptide.RaCluster, :local_query, [{name, node_d}, & &1]) == ["a"]
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} = Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    try do
+      :peer.stop(pid)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true ->
+        Process.sleep(100)
+        eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end
+```
+
+- [ ] **Step 6: Run it**
+
+Run: `mix test test/riptide/ra_cluster_replace_member_test.exs --trace`
+Expected: PASS. Run it 3 times in a row to confirm no flakiness and clean cleanup (no leftover `repl-*` directories in the repo root after each run).
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `mix test`
+Expected: PASS, 0 failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/riptide/ra_cluster.ex test/riptide/ra_cluster_test.exs test/riptide/ra_cluster_replace_member_test.exs
+git commit -m "Add RaCluster.replace_member/5: real Ra membership-change repair primitive"
+```
+
+---
+
+### Task 5: `Riptide.Stream.Placement` cache invalidation via PubSub
+
+**Files:**
+- Modify: `lib/riptide/stream/placement.ex`
+- Test: `test/riptide/stream/placement_test.exs`
+
+**Interfaces:**
+- Consumes: `Phoenix.PubSub` (already started before this `GenServer` in `Riptide.Application`'s children list), `RaCluster.uid_for/1`.
+- Produces: a `{:stream_placement_changed, stream_id, new_nodes}` message contract on the `"stream_placement_changed"` PubSub topic. Task 6's healer broadcasts this after every successful repair.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/riptide/stream/stream_supervisor_test.exs` a new test (this module already has the right aliases and `on_exit`/cleanup pattern):
+
+```elixir
+  test "the local cache is corrected when a stream_placement_changed PubSub message arrives" do
+    stream_id = "stream-#{System.unique_integer([:positive])}"
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+    assert StreamSupervisor.ensure_ready(stream_id) == :ok
+    uid = Riptide.RaCluster.uid_for(stream_id)
+    original_server_ids = Riptide.Stream.Placement.server_ids!(stream_id)
+    assert original_server_ids == [{String.to_atom(uid), node()}]
+
+    fake_new_node = :"fake-replacement@nowhere"
+
+    Phoenix.PubSub.broadcast(
+      Riptide.PubSub,
+      "stream_placement_changed",
+      {:stream_placement_changed, stream_id, [fake_new_node]}
+    )
+
+    # PubSub delivery is async even within one BEAM — poll briefly rather
+    # than asserting immediately.
+    assert Enum.any?(1..20, fn _ ->
+             Process.sleep(10)
+             Riptide.Stream.Placement.server_ids!(stream_id) == [{String.to_atom(uid), fake_new_node}]
+           end)
+  end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mix test test/riptide/stream/stream_supervisor_test.exs --trace`
+Expected: FAIL — the cache never updates because `Riptide.Stream.Placement` isn't subscribed to the topic yet, so the poll loop times out without ever seeing the fake node.
+
+- [ ] **Step 3: Subscribe and handle the invalidation message**
+
+Modify `lib/riptide/stream/placement.ex`:
+
+Change `init/1`:
+
+```elixir
+  @impl GenServer
+  def init(:ok) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    Phoenix.PubSub.subscribe(Riptide.PubSub, "stream_placement_changed")
+    {:ok, %{}}
+  end
+```
+
+Add a new `handle_info/2` clause, placed after `init/1` and before the module's existing `@doc` for `ensure_started/4`:
+
+```elixir
+  # Corrects this node's cached server ids the moment `Riptide.Stream.ReplicaHealer`
+  # (Phase 3d-ii) repairs a stream elsewhere in the fleet — without this, a
+  # node that already cached the old (now partially dead) server ids would
+  # keep them until it happened to restart, per this module's own
+  # cache-forever design (see moduledoc). Overwrites directly rather than
+  # evicting, since the correct value is already known from the broadcast —
+  # no need to force a re-resolution round-trip through the placement
+  # cluster.
+  @impl GenServer
+  def handle_info({:stream_placement_changed, stream_id, new_nodes}, state) do
+    uid = RaCluster.uid_for(stream_id)
+    server_ids = Enum.map(new_nodes, &{String.to_atom(uid), &1})
+    :ets.insert(@table, {stream_id, server_ids})
+    {:noreply, state}
+  end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `mix test test/riptide/stream/stream_supervisor_test.exs --trace`
+Expected: PASS, all tests including the pre-existing ones.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `mix test`
+Expected: PASS, 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/riptide/stream/placement.ex test/riptide/stream/stream_supervisor_test.exs
+git commit -m "Riptide.Stream.Placement: invalidate cached server ids via PubSub broadcast"
+```
+
+---
+
+### Task 6: `Riptide.Stream.ReplicaHealer` — the sweep loop, wired into `Riptide.Application`
+
+**Files:**
+- Create: `lib/riptide/stream/replica_healer.ex`
+- Modify: `lib/riptide/application.ex`
+- Test: `test/riptide/stream/replica_healer_test.exs`
+
+**Interfaces:**
+- Consumes: `Riptide.Placement.list_all/1`, `replace_member/4` (Task 2); `RaCluster.member_alive?/1`, `placement_leader?/0`, `replace_member/5`, `uid_for/1` (Tasks 3-4); `Riptide.Placement.select_nodes/2` (existing, Phase 3c-i).
+- Produces: `ReplicaHealer.pick_replacement/2` (`([node()], [node()]) -> node() | nil`) and `ReplicaHealer.sweep/0` (`() -> :ok`), both public for direct testing without waiting on the timer. Consumed by Task 7's integration test.
+
+- [ ] **Step 1: Write the failing unit tests for `pick_replacement/2`**
+
+Create `test/riptide/stream/replica_healer_test.exs`:
+
+```elixir
+defmodule Riptide.Stream.ReplicaHealerTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Stream.ReplicaHealer
+
+  describe "pick_replacement/2" do
+    test "picks a live node not already among the current members" do
+      result = ReplicaHealer.pick_replacement([:a, :b], [:a, :b, :c, :d])
+      assert result in [:c, :d]
+    end
+
+    test "returns nil when every live node is already a current member" do
+      assert ReplicaHealer.pick_replacement([:a, :b, :c], [:a, :b, :c]) == nil
+    end
+
+    test "returns nil when there are no live candidate nodes at all" do
+      assert ReplicaHealer.pick_replacement([:a, :b], []) == nil
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `mix test test/riptide/stream/replica_healer_test.exs --trace`
+Expected: FAIL — `Riptide.Stream.ReplicaHealer` doesn't exist yet.
+
+- [ ] **Step 3: Create the `ReplicaHealer` module**
+
+Create `lib/riptide/stream/replica_healer.ex`:
+
+```elixir
+defmodule Riptide.Stream.ReplicaHealer do
+  @moduledoc """
+  Fully automatic background repair for a stream's replica set — see Phase
+  3d-ii design spec for the full motivation. Runs only on the 3 placement
+  ordinals (wired in `Riptide.Application`, same gating as
+  `Riptide.RaCluster.ensure_placement_cluster_started/0`), and only the
+  placement cluster's current Raft leader ever acts on a given sweep
+  (`RaCluster.placement_leader?/0`) — reusing that cluster's own existing
+  leader election as single-writer safety, rather than a new coordination
+  mechanism. No operator action is required in the steady-state case.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Riptide.Placement
+  alias Riptide.RaCluster
+  alias Riptide.Stream.RaMachine
+
+  @sweep_interval_ms 30_000
+  @stream_machine {:module, RaMachine, %{retention: :infinity}}
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(:ok) do
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state) do
+    if RaCluster.placement_leader?() do
+      sweep()
+    end
+
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep do
+    interval = Application.get_env(:riptide, :replica_healer_sweep_interval_ms, @sweep_interval_ms)
+    Process.send_after(self(), :sweep, interval)
+  end
+
+  @doc """
+  One full pass over every known stream: find any with exactly one dead
+  member and repair it. Public (not just reachable via the timer) so tests
+  can invoke it directly rather than waiting on a real interval.
+  """
+  @spec sweep() :: :ok
+  def sweep do
+    Placement.list_all()
+    |> Enum.each(&maybe_repair/1)
+  end
+
+  defp maybe_repair({stream_id, nodes}) do
+    uid = RaCluster.uid_for(stream_id)
+    name = String.to_atom(uid)
+    dead_nodes = Enum.reject(nodes, &RaCluster.member_alive?({name, &1}))
+
+    case dead_nodes do
+      [dead_node] -> repair(stream_id, uid, nodes, dead_node)
+      _ -> :ok
+    end
+  end
+
+  defp repair(stream_id, uid, nodes, dead_node) do
+    survivor_nodes = nodes -- [dead_node]
+
+    case pick_replacement(nodes) do
+      nil ->
+        :ok
+
+      new_node ->
+        case RaCluster.replace_member(uid, survivor_nodes, dead_node, new_node, @stream_machine) do
+          :ok ->
+            new_nodes = Placement.replace_member(stream_id, dead_node, new_node)
+
+            Phoenix.PubSub.broadcast(
+              Riptide.PubSub,
+              "stream_placement_changed",
+              {:stream_placement_changed, stream_id, new_nodes}
+            )
+
+            Logger.info(
+              "ReplicaHealer repaired #{stream_id}: replaced #{inspect(dead_node)} with #{inspect(new_node)}"
+            )
+
+          {:error, reason} ->
+            Logger.warning(
+              "ReplicaHealer failed to repair #{stream_id} (dead: #{inspect(dead_node)}): #{inspect(reason)}"
+            )
+        end
+    end
+  end
+
+  @doc """
+  Picks a live fleet node to replace a dead member with — a candidate not
+  already among `current_nodes`, chosen the same random-selection way
+  `Riptide.Placement.propose_nodes/2` already picks a new stream's initial
+  replicas. `live_nodes` defaults to `Node.list()` but is overridable for
+  tests, mirroring `propose_nodes/2`'s own `peers \\\\ Node.list()` pattern.
+  """
+  @spec pick_replacement([node()], [node()]) :: node() | nil
+  def pick_replacement(current_nodes, live_nodes \\ Node.list()) do
+    case Placement.select_nodes(live_nodes -- current_nodes, 1) do
+      [node] -> node
+      [] -> nil
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `mix test test/riptide/stream/replica_healer_test.exs --trace`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `ReplicaHealer` into `Riptide.Application`**
+
+Modify `lib/riptide/application.ex` — change `placement_bootstrap_children/0`:
+
+```elixir
+  defp placement_bootstrap_children do
+    if System.get_env("HOSTNAME") in Riptide.RaCluster.placement_ordinals() do
+      [
+        {Task, &Riptide.RaCluster.ensure_placement_cluster_started/0},
+        Riptide.Stream.ReplicaHealer
+      ]
+    else
+      []
+    end
+  end
+```
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `mix test`
+Expected: PASS, 0 failures. `Riptide.Stream.ReplicaHealer` now starts as part of the application in every test run (since `test_helper.exs` runs on a single collapsed node that's always a placement ordinal — see its own comments) but its sweep only ever runs on its own 30s timer, which no test waits for; nothing in the existing suite should be affected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/riptide/stream/replica_healer.ex lib/riptide/application.ex test/riptide/stream/replica_healer_test.exs
+git commit -m "Add Riptide.Stream.ReplicaHealer: automatic stream replica repair sweep"
+```
+
+---
+
+### Task 7: Real multi-node proof — end-to-end automatic repair
+
+**Files:**
+- Create: `test/riptide/stream/replica_healer_cluster_test.exs`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6 — `Riptide.Stream.StreamServer.start_link/1`/`append/2`/`get_since/2` (existing), `Riptide.Stream.ReplicaHealer.sweep/0` (Task 6), `Riptide.Placement.lookup/1` (existing).
+- Produces: nothing further downstream — this is the real proof the whole chain works together against genuinely distinct nodes, extending the established `:peer`-based recipe (`test/riptide/stream/stream_placement_cluster_test.exs`) with a real kill + real automatic repair in the middle.
+
+- [ ] **Step 1: Write the test**
+
+Create `test/riptide/stream/replica_healer_cluster_test.exs`:
+
+```elixir
+defmodule Riptide.Stream.ReplicaHealerClusterTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  @peers [
+    {:healer_a, "riptide-0", ~c"127.0.0.50"},
+    {:healer_b, "riptide-1", ~c"127.0.0.51"},
+    {:healer_c, "riptide-2", ~c"127.0.0.52"}
+  ]
+
+  @replacement {:healer_d, "healer-d", ~c"127.0.0.53"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"replica_healer_cluster_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "a stream's dead replica is automatically detected and repaired, with no data loss" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    all_specs = @peers ++ [@replacement]
+
+    peers =
+      for {alive_name, ordinal, host} <- all_specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"replica_healer_cluster_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+    ordinal_to_node = Map.new(peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
+    resolve_fun = fn ordinal -> Map.fetch!(ordinal_to_node, ordinal) end
+
+    for {_pid, node, _ordinal} <- peers do
+      :erpc.call(node, Application, :put_env, [:riptide, :ordinal_resolver, resolve_fun])
+    end
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, _node_d, _}] = peers
+    placement_peers = Enum.take(peers, 3)
+
+    results =
+      Enum.map(placement_peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
+      end)
+
+    assert Enum.any?(results, &(&1 == :ok))
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+      {:ok, _} = start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+    end
+
+    stream_id = "healer-cluster-" <> Uniq.UUID.uuid4()
+
+    # Explicitly assign the stream to exactly the 3 placement-ordinal nodes
+    # (not left to propose_nodes/2's own randomness) so we know precisely
+    # which peer to kill and which stays as the extra fleet node available
+    # as a replacement candidate for pick_replacement/2.
+    original_nodes = [node_a, node_b, node_c]
+    assert Enum.sort(:erpc.call(node_a, Riptide.Placement, :assign, [stream_id, original_nodes])) ==
+             Enum.sort(original_nodes)
+
+    assert :ok = :erpc.call(node_a, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+
+    graph = :erpc.call(node_a, RDF.Graph, :new, [])
+    event = :erpc.call(node_a, Riptide.Event, :new, [stream_id, :replace, graph])
+    stamped = :erpc.call(node_a, Riptide.Stream.StreamServer, :append, [stream_id, event])
+    assert stamped.sequence == 1
+
+    # Kill node_c for real — the replica being replaced.
+    stop_peer_for(peers, node_c)
+
+    # Run the sweep directly from node_a (a placement ordinal) rather than
+    # waiting on the real 30s timer — node_a is also guaranteed to be the
+    # placement cluster's actual leader often enough in a 3-member cluster
+    # that a short retry loop below tolerates the case where it isn't yet.
+    assert eventually(fn ->
+             :erpc.call(node_a, Riptide.Stream.ReplicaHealer, :sweep, []) == :ok and
+               Enum.sort(:erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])) !=
+                 Enum.sort(original_nodes)
+           end)
+
+    repaired_nodes = :erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])
+    assert length(repaired_nodes) == 3
+    refute node_c in repaired_nodes
+    assert node_a in repaired_nodes
+    assert node_b in repaired_nodes
+
+    [new_node] = repaired_nodes -- [node_a, node_b]
+
+    # No data loss: the write made before the repair is still there,
+    # readable through the fresh replacement.
+    assert :ok = :erpc.call(new_node, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+    {:ok, read_back} = :erpc.call(new_node, Riptide.Stream.StreamServer, :get_since, [stream_id, 0])
+    assert [%{sequence: 1}] = read_back
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    try do
+      :peer.stop(pid)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+
+    spawn(node, fn ->
+      result = apply(mod, fun, args)
+      send(parent, {:start_unlinked_result, result})
+      Process.sleep(:infinity)
+    end)
+
+    receive do
+      {:start_unlinked_result, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true ->
+        Process.sleep(200)
+        eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `mix test test/riptide/stream/replica_healer_cluster_test.exs --trace`
+Expected: PASS. Run it 3 times in a row to confirm no flakiness and clean cleanup (no leftover `riptide-*`/`healer-d` directories in the repo root after each run).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `mix test`
+Expected: PASS, 0 failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/riptide/stream/replica_healer_cluster_test.exs
+git commit -m "Add real multi-node proof: automatic stream replica repair end-to-end"
+```
+
+---
+
+### Task 8: Live proof against a real GKE StatefulSet
+
+**Files:**
+- No new files — this task operates against a disposable deployment using the existing `k8s/` manifests.
+
+**Interfaces:**
+- Consumes: the already-deployed `k8s/*.yaml` manifests, a built Docker image including this plan's Tasks 1-7.
+- Produces: a written verification record (this task's own report) — no code.
+
+**Note before starting:** deploying this live requires the operator's explicit go-ahead — ask before creating any real cluster resources, following the same convention as every prior live-proof task this sub-project has done.
+
+- [ ] **Step 1: Build and push a fresh throwaway-tagged image, deploy to a disposable namespace with 5 replicas**
+
+```bash
+kubectl create namespace riptide-phase-3d-ii-proof
+kubectl config set-context --current --namespace=riptide-phase-3d-ii-proof
+```
+
+```bash
+sed -e 's|ghcr.io/openfaster-standard/riptide:latest|ghcr.io/openfaster-standard/riptide:phase-3d-ii-proof|' \
+    -e 's|replicas: 3|replicas: 5|' \
+    k8s/statefulset.yaml | kubectl apply -f -
+```
+
+If ghcr.io pull fails with `401 Unauthorized`, fix it the same way as every prior live proof this sub-project has hit:
+
+```bash
+kubectl create secret docker-registry ghcr-pull-secret \
+  --docker-server=ghcr.io \
+  --docker-username=<your github username> \
+  --docker-password="$(gh auth token)"
+kubectl patch statefulset riptide --type='json' \
+  -p='[{"op":"add","path":"/spec/template/spec/imagePullSecrets","value":[{"name":"ghcr-pull-secret"}]}]'
+kubectl delete pod riptide-0 riptide-1 riptide-2 riptide-3 riptide-4 --wait=false
+```
+
+Run: `kubectl rollout status statefulset/riptide --timeout=180s`
+Expected: all 5 pods reach `Ready`.
+
+- [ ] **Step 2: Create a stream assigned to a real pod, then kill that pod**
+
+```bash
+kubectl exec riptide-0 -- bin/riptide rpc "IO.inspect(Riptide.Stream.StreamSupervisor.ensure_ready(\"live-heal-proof-stream\")); IO.inspect(Riptide.Stream.Placement.server_ids!(\"live-heal-proof-stream\"))"
+```
+
+Expected: `:ok`, then a 3-element `{name, node}` list. Note the 3 assigned pods from the node atoms' IPs (`kubectl get pods -o wide`). Write one real event, then force-kill one of the 3 assigned pods (not `riptide-0`, to keep issuing commands from a live pod):
+
+```bash
+kubectl exec riptide-0 -- bin/riptide rpc "IO.inspect(Riptide.Stream.StreamServer.append(\"live-heal-proof-stream\", Riptide.Event.new(\"live-heal-proof-stream\", :replace, RDF.Graph.new())))"
+kubectl delete pod <one-of-the-3-assigned-pods> --grace-period=0 --force
+kubectl rollout status statefulset/riptide --timeout=180s
+```
+
+- [ ] **Step 3: Wait for automatic repair and verify no data loss**
+
+Wait up to the sweep interval (default 30s) plus rollout time, then:
+
+```bash
+kubectl exec riptide-0 -- bin/riptide rpc "IO.inspect(Riptide.Placement.lookup(\"live-heal-proof-stream\"))"
+```
+
+Expected: a 3-element node list that no longer includes the killed pod's original identity, and does include a live pod not in the original assignment (the fleet's spare capacity, since RF=3 with 5 real pods leaves 2 spares) — with **no operator action taken to produce this**, only waiting. Confirm no data loss by reading back through the new member:
+
+```bash
+kubectl exec <the-new-member-pod> -- bin/riptide rpc "IO.inspect(Riptide.Stream.StreamServer.get_since(\"live-heal-proof-stream\", 0))"
+```
+
+Expected: `{:ok, [%Riptide.Event{sequence: 1, ...}]}`.
+
+- [ ] **Step 4: Tear down**
+
+```bash
+kubectl delete namespace riptide-phase-3d-ii-proof
+kubectl config set-context --current --namespace=default
+```
+
+Poll `kubectl get namespace riptide-phase-3d-ii-proof` until `NotFound`. Delete the throwaway image tag from ghcr.io and the local docker image. Leave nothing behind.
+
+- [ ] **Step 5: Record the results**
+
+Write a short summary (for Task 9's `PROGRESS.md` update and the PR description) of what was directly observed at Steps 2-3 — the actual command output, not a paraphrased summary.
+
+---
+
+### Task 9: Full verification + `PROGRESS.md` + wrap-up
+
+**Files:**
+- Modify: `PROGRESS.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-8, including Task 8's recorded live-proof results.
+- Produces: nothing further downstream — terminal task.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `mix test`
+Expected: PASS, 0 failures — including every test added in Tasks 1-7 and every pre-existing test unaffected.
+
+- [ ] **Step 2: Run Credo and formatter checks**
+
+Run: `mix credo --strict && mix format --check-formatted`
+Expected: both clean. Fix anything flagged and re-run.
+
+- [ ] **Step 3: Update `PROGRESS.md`**
+
+In the `## 3. Clustering / horizontal scale / HA` section, replace the current 3d-ii placeholder text (the scope-correction paragraph added when the design spec was written) with:
+
+```markdown
+  - **3d-ii — Automatic stream replica healing.** A stream with exactly one dead replica (of
+    RF=3) is now detected and repaired automatically, with zero operator action — see
+    `docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md`. **Shipped
+    2026-08-25.** `Riptide.Stream.ReplicaHealer` sweeps every known stream on a timer, gated to
+    only the placement cluster's current Raft leader (reusing its existing leader election for
+    single-writer safety, no new coordination mechanism), and on finding a dead member: joins a
+    live replacement into the stream's real `:ra` cluster (`RaCluster.replace_member/5`),
+    updates the durable placement assignment, and broadcasts a PubSub invalidation so no node's
+    cache keeps routing to the dead replica. Live-proved against a real 5-pod GKE StatefulSet
+    (RF=3): a killed replica pod was automatically replaced with no operator action and no data
+    loss.
+```
+
+Change the `**Status**:` line to reflect Phase 3d-ii shipped alongside 3d-i.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add PROGRESS.md
+git commit -m "Mark Phase 3d-ii shipped in PROGRESS.md"
+```

--- a/docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md
+++ b/docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md
@@ -121,12 +121,15 @@ just "nothing to do yet."
 Given a stream with dead member `D` and chosen replacement `R`, addressed against the stream's
 own `:ra` cluster (a surviving member's server id, entirely separate from the placement cluster):
 
-1. `:ra.start_server/2` on `R`'s node, using the same config shape
+1. `:ra.add_member(survivor_id, new_id)` — registers `R` as a cluster member FIRST, before its
+   local server exists. Verified against `:ra`'s own growing-a-cluster documentation (`ra`'s
+   README, "Dynamically Changing Cluster Membership"): a freshly-started server with no cluster
+   membership entry yet has nothing to catch up from, so the membership entry must exist before
+   step 2 brings the server itself up.
+2. `:ra.start_server/2` on `R`'s node, using the same config shape
    `RaCluster.start_or_join_replicated/3` already builds (`uid`, `cluster_name`,
    `log_init_args`) — but as a server *joining* an existing cluster, not forming a fresh one.
-   Brings up `R`'s local Ra server so it's ready to receive the cluster's replicated log.
-2. `:ra.add_member(survivor_id, new_id)` — registers `R` as a cluster member; it begins catching
-   up via ordinary Raft log replication.
+   Brings up `R`'s local Ra server so it can start catching up via ordinary Raft log replication.
 3. `:ra.remove_member(survivor_id, dead_id)` — evicts `D` from the cluster's membership.
 4. `Riptide.Placement.replace_member(stream_id, D, R)` — updates the durable metadata so future
    lookups (and any node's future cache population) return the corrected node list.

--- a/docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md
+++ b/docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md
@@ -1,0 +1,179 @@
+# Phase 3d-ii — Automatic Stream Replica Healing — Design
+
+**Status:** Approved 2026-08-25.
+
+Sub-project 3 (Clustering / horizontal scale / HA) phasing and prior context:
+`docs/superpowers/specs/2026-08-25-phase-3c-i-placement-metadata-design.md`,
+`docs/superpowers/specs/2026-08-25-phase-3c-ii-multi-member-ra-clusters-design.md`,
+`docs/superpowers/specs/2026-08-25-phase-3c-iii-request-routing-design.md`. This phase follows
+directly from the Phase 3d-i HA-proof spike (documented in the 3c-i design spec's §5 correction
+and `PROGRESS.md`).
+
+## 1. Context & motivation
+
+Phase 3d-i's live GKE spike investigated what happens when nodes are force-killed. One of its
+three findings — the placement metadata cluster's own membership self-healing automatically
+after quorum loss — turned out to be a solved problem, not something this phase needs to build.
+But investigating it surfaced a sharper, still-fully-open gap: **a stream's own replica set has
+no equivalent self-healing, and no tooling exists to repair it either.**
+
+The placement cluster self-heals because its 3 members are addressed by re-resolvable ordinal
+names (`"riptide-0"` → whatever node currently answers to that hostname) — a restarted pod's
+fresh identity is picked up automatically the next time cluster formation is attempted. A
+stream's replica assignment (`Riptide.Placement.lookup/1`) is different: it's a **frozen list of
+specific `node()` atoms**, fixed permanently at assignment time (Phase 3c-i's own
+permanent-once-assigned invariant). There is no ordinal-style re-resolution for it. Worse, stream
+cluster formation is purely *reactive* — triggered only when a client request for that specific
+stream lands on `Riptide.Stream.StreamSupervisor.ensure_ready/1` — and `resolve_nodes/1` checks
+`node() in nodes` against that frozen list, so a freshly-restarted node's new identity will never
+match anything in it. The system doesn't just fail to repair the drift; it never even recognizes
+that the restarted node *should* be considered for reclaiming that slot.
+
+This isn't a rare failure mode. `node()` identity is IP-based (Phase 3b design), and pod IPs are
+not stable across any restart — routine rolling deploys included, not just crashes. Every restart
+of every pod hosting a stream replica is, structurally, identity drift. Manual/on-demand operator
+tooling for something this frequent doesn't scale operationally — an operator or script would
+need to babysit every single pod restart across the fleet. This phase is scoped instead as a
+**fully automatic background self-healing process**: detect a stream with a dead replica, pick a
+live replacement, repair it — zero operator or human involvement in the steady-state case. This
+is a deliberate reversal of the sub-project's earlier "manual grow/shrink first" framing
+(originally modeled on RabbitMQ's manual-first precedent) for this specific piece; that framing
+fit the placement cluster's own membership question, which turned out not to need tooling at all,
+better than it fits a problem this operationally frequent.
+
+## 2. Scope
+
+- Detecting a stream with exactly one dead replica (of its fixed RF=3 members) and automatically
+  replacing it with a live fleet node — no operator action required in the steady-state case.
+- The full repair chain: joining the replacement into the stream's real `:ra` cluster, evicting
+  the dead member, updating the stream's durable placement assignment, and invalidating any
+  node's stale in-memory cache of that assignment.
+- Single-writer safety across the 3 placement ordinals (which run this process) via the placement
+  cluster's own existing Raft leader election — no new locking/coordination mechanism.
+
+## 3. Out of scope
+
+- **Multi-member (quorum-loss) stream recovery** — a stream with 2-of-3 members dead has already
+  lost quorum; `:ra.add_member`/`:ra.remove_member` require consensus to commit, so they simply
+  fail/timeout harmlessly against such a cluster rather than making things worse. This is
+  self-limiting by the underlying primitives, not special-cased logic here. Genuine multi-member
+  loss stays separate, rarer, manual disaster-recovery territory — not designed in this phase.
+- **Deliberate replication-factor changes** (e.g. RF 3 → 5) — this design only replaces a dead
+  member 1-for-1; it never changes how many replicas a stream has.
+- **Proactive node decommissioning/evacuation** (moving replicas off a node ahead of a planned
+  removal) — this design is reactive (repairs after a node is already gone), not predictive.
+- Any change to the placement cluster's own membership handling — solved in 3d-i.
+
+## 4. Architecture
+
+A new `Riptide.Stream.ReplicaHealer` `GenServer`, added to `Riptide.Application`'s existing
+`placement_bootstrap_children/0` list alongside `ensure_placement_cluster_started/0` — so it only
+runs on the 3 fixed placement ordinals, reusing the existing gating mechanism rather than
+inventing a new "which nodes run this" decision.
+
+On a `:timer.send_interval/2` tick (default 30s, configurable via application env), it:
+
+1. Checks whether `node()` is the placement cluster's *current* Raft leader (via
+   `:ra.members/1` against `RaCluster.placement_server_id/1,2` — the reply already includes the
+   current leader). If not, no-ops until the next tick.
+2. If leader: calls `Riptide.Placement.list_all/1` (new — see §5) to enumerate every known
+   stream's assignment, and checks each member's real liveness (§6).
+3. For any stream with exactly one dead member, performs the repair (§7).
+
+Only the leadership check plus one cheap read runs on all 3 ordinals every tick; only the actual
+leader ever executes a repair, so at most one repair attempt per stream happens fleet-wide at a
+time — for free, from Raft's own leader election, no new coordination primitive needed.
+
+## 5. Placement metadata additions
+
+Two additions to `Riptide.Placement`/`Riptide.Placement.PlacementMachine`, both following the
+existing idempotent-by-construction pattern `:assign` already uses (Phase 3c-i §4):
+
+- **`PlacementMachine.list/1`** (a query function, like the existing `get/2`) returns the full
+  `%{stream_id() => [node()]}` state so the healer can enumerate every stream without needing a
+  stream_id in hand first. Exposed as `Riptide.Placement.list_all/1`, using the same
+  ordinal-fallback addressing `assign/2,3` and `lookup/1,2` already use (Phase 3d-i fix 2).
+- **New command `{:replace_member, stream_id, dead_node, new_node}`**, handled by
+  `PlacementMachine.apply/3`: if `stream_id`'s stored nodes still contain `dead_node`, replace it
+  with `new_node` and return the updated list; if `dead_node` is no longer present (e.g. a
+  different placement-cluster leader, from a prior Raft term, already won this exact repair),
+  it's a no-op that returns the current list unchanged — the same idempotent race-safety shape
+  `:assign` already has for concurrent-proposal races. Exposed as
+  `Riptide.Placement.replace_member/3`.
+
+## 6. Detecting a dead replica
+
+For each `{stream_id, nodes}` from `list_all/1`, the healer computes that stream's server ids
+(`RaCluster.uid_for(stream_id)` combined with each node) and checks liveness the same way Phase
+3d-i's fix 1 already does for `RaCluster.start_or_join_replicated/3`'s own `NotStarted` handling:
+a local `Process.whereis/1` check for `node() == node()`, an `:erpc.call/4` to the remote node's
+own `RaCluster.server_alive?/1` otherwise. An unreachable node is always treated as not-alive,
+never assumed fine — the same conservative default already established there.
+
+Replacement selection reuses `Riptide.Placement.propose_nodes/2`'s existing logic: candidates are
+live fleet nodes (`Node.list()`) not already among the stream's surviving members, one chosen at
+random via the existing `select_nodes/2`. If no live candidate exists (a saturated or emptied
+fleet), the repair is skipped this tick and re-attempted next tick — not treated as an error,
+just "nothing to do yet."
+
+## 7. Repair execution
+
+Given a stream with dead member `D` and chosen replacement `R`, addressed against the stream's
+own `:ra` cluster (a surviving member's server id, entirely separate from the placement cluster):
+
+1. `:ra.start_server/2` on `R`'s node, using the same config shape
+   `RaCluster.start_or_join_replicated/3` already builds (`uid`, `cluster_name`,
+   `log_init_args`) — but as a server *joining* an existing cluster, not forming a fresh one.
+   Brings up `R`'s local Ra server so it's ready to receive the cluster's replicated log.
+2. `:ra.add_member(survivor_id, new_id)` — registers `R` as a cluster member; it begins catching
+   up via ordinary Raft log replication.
+3. `:ra.remove_member(survivor_id, dead_id)` — evicts `D` from the cluster's membership.
+4. `Riptide.Placement.replace_member(stream_id, D, R)` — updates the durable metadata so future
+   lookups (and any node's future cache population) return the corrected node list.
+5. `Phoenix.PubSub.broadcast(Riptide.PubSub, "stream_placement_changed", {stream_id, new_nodes})`
+   — `Riptide.Stream.Placement`'s `GenServer` subscribes to this topic on init and evicts (or
+   overwrites) that `stream_id`'s ETS cache entry on receipt, so no node keeps routing to `D`
+   indefinitely. This is a new responsibility for that module; its own permanent-once-assigned
+   caching invariant (Phase 3c-ii's moduledoc) is superseded by this phase for the specific case
+   of an operator-invisible automatic repair — the *value* still only ever changes via this one
+   controlled path, never arbitrarily.
+
+The exact `:ra` call shapes for steps 1-2 (join-an-existing-cluster, as opposed to
+`start_or_join_replicated/3`'s form-a-fresh-cluster case) get verified against the pinned `:ra`
+source during implementation planning, the same way every other `RaCluster` primitive in this
+project has been.
+
+## 8. Safety & error handling
+
+- **Only single-dead-member streams are auto-repaired** (§3) — self-limiting via the underlying
+  `:ra` consensus requirement, not special-cased logic.
+- **No explicit flapping/debounce protection beyond the sweep interval itself.** A node that
+  reconnects before the next tick is simply observed as alive again and never touched. Simpler
+  than tracking "seen dead N times" state; revisit only if real flapping churn shows up in
+  practice.
+- **Partial-failure recovery is "try again next tick."** If a repair fails partway (e.g.
+  `add_member` succeeds but the metadata update doesn't land), the underlying `:ra` state hasn't
+  reached the fully-repaired end state, so the next sweep re-detects the same dead member and
+  retries the whole sequence — no separate retry/rollback logic inside the healer.
+- **A lost PubSub invalidation degrades, not breaks.** A node that misses the broadcast keeps a
+  stale cache entry with 2 correct members and 1 dead one; `:ra` operations still succeed via the
+  live members (a single reachable member plus leader-redirect is enough), just with one extra
+  doomed RPC attempt possible until that node's cache is otherwise refreshed.
+- **Every repair action is logged** (stream_id, dead node, chosen replacement) — the point is
+  that an operator doesn't need to *act*, but they should still be able to see what happened
+  after the fact.
+
+## 9. Testing
+
+- **Unit tests** for `PlacementMachine`'s new `list/1` query and `{:replace_member, ...}` command
+  (pure state-machine logic, no real `:ra`), mirroring the existing `:assign` tests.
+- **Unit tests** for replacement-node selection, parallel to `propose_nodes/2`'s own tests.
+- **Real multi-node integration test**, using the established `:peer`-based pattern from
+  3c-ii/3c-iii/3d-i: form a real 3-node stream cluster, kill one member for real, invoke the
+  healer's sweep logic directly (not waiting on the timer), and confirm the dead member is
+  evicted, a live replacement joins, `Riptide.Placement.lookup/1` reflects the new node set, and
+  the stream's data is still fully readable/writable afterward with no loss.
+- **Leadership-gating test** confirming only the placement cluster's actual current leader
+  performs a repair when multiple ordinals tick concurrently, mirroring the existing
+  redundant-call self-correction tests for `attempt_start_placement_cluster/1`/
+  `start_or_join_replicated/3`.

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -48,7 +48,10 @@ defmodule Riptide.Application do
   # of the application (Phoenix Endpoint, etc.) from booting normally.
   defp placement_bootstrap_children do
     if System.get_env("HOSTNAME") in Riptide.RaCluster.placement_ordinals() do
-      [{Task, &Riptide.RaCluster.ensure_placement_cluster_started/0}]
+      [
+        {Task, &Riptide.RaCluster.ensure_placement_cluster_started/0},
+        Riptide.Stream.ReplicaHealer
+      ]
     else
       []
     end

--- a/lib/riptide/placement.ex
+++ b/lib/riptide/placement.ex
@@ -53,6 +53,25 @@ defmodule Riptide.Placement do
     end)
   end
 
+  @spec list_all((String.t() -> node())) :: %{String.t() => [node()]}
+  def list_all(resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.consistent_query(server_id, &PlacementMachine.list/1)
+    end)
+  end
+
+  @spec replace_member(String.t(), node(), node(), (String.t() -> node())) :: [node()] | nil
+  def replace_member(
+        stream_id,
+        dead_node,
+        new_node,
+        resolve_fun \\ &RaCluster.default_ordinal_resolver/1
+      ) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(server_id, {:replace_member, stream_id, dead_node, new_node})
+    end)
+  end
+
   # Tries each placement ordinal, in `RaCluster.placement_ordinals/0`'s own
   # fixed order, until one of them answers — `RaCluster.process_command/2`
   # and `consistent_query/2` both raise on failure/timeout (see their own

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -42,7 +42,7 @@ defmodule Riptide.Placement.PlacementMachine do
     case Map.fetch(state, stream_id) do
       {:ok, nodes} ->
         if dead_node in nodes do
-          new_nodes = Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
+          new_nodes = replace_in_list(nodes, dead_node, new_node)
           new_state = Map.put(state, stream_id, new_nodes)
           {new_state, new_nodes, []}
         else
@@ -52,6 +52,10 @@ defmodule Riptide.Placement.PlacementMachine do
       :error ->
         {state, nil, []}
     end
+  end
+
+  defp replace_in_list(nodes, dead_node, new_node) do
+    Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
   end
 
   @spec get(state(), String.t()) :: [node()] | nil

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -32,8 +32,33 @@ defmodule Riptide.Placement.PlacementMachine do
     end
   end
 
+  # Idempotent the same way {:assign, ...} is: if `dead_node` is no longer
+  # part of `stream_id`'s stored assignment (e.g. a different placement-
+  # cluster leader, from a prior Raft term, already won this exact repair),
+  # this is a no-op that returns the current assignment unchanged rather
+  # than erroring — safe to call redundantly from a racing leader.
+  @impl :ra_machine
+  def apply(_meta, {:replace_member, stream_id, dead_node, new_node}, state) do
+    case Map.fetch(state, stream_id) do
+      {:ok, nodes} ->
+        if dead_node in nodes do
+          new_nodes = Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
+          new_state = Map.put(state, stream_id, new_nodes)
+          {new_state, new_nodes, []}
+        else
+          {state, nodes, []}
+        end
+
+      :error ->
+        {state, nil, []}
+    end
+  end
+
   @spec get(state(), String.t()) :: [node()] | nil
   def get(state, stream_id) do
     Map.get(state, stream_id)
   end
+
+  @spec list(state()) :: state()
+  def list(state), do: state
 end

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -42,12 +42,26 @@ defmodule Riptide.RaCluster do
   # through `placement_server_id/2`'s ordinal/DNS resolution, since this is
   # only ever meaningful to call from a node that's itself a placement
   # ordinal already running its own local member.
+  # Wrapped in `try/catch :exit` because `:ra.members/1` doesn't always turn
+  # a bad outcome into an `{:error, _}` tuple: `ra_server_proc`'s own
+  # `gen_statem_safe_call/3` only converts `timeout`/`noproc`/`nodedown`/
+  # `shutdown` exits into a return value — any OTHER exit (e.g. the local
+  # member process crashing for an unrelated reason while this exact call is
+  # in flight) propagates straight out of `gen_statem:call/3` as a genuine
+  # `exit`, which a plain `case` can't catch. `Riptide.Stream.ReplicaHealer`
+  # (Phase 3d-ii) is the first caller to invoke this from a periodic
+  # boot-time timer rather than a one-off request path, so a rare exit here
+  # would otherwise crash that GenServer outright instead of just skipping a
+  # sweep. Any exit is treated as "not the leader" — the same conservative
+  # default this function already returns for a plain `{:error, _}`.
   @spec placement_leader?() :: boolean()
   def placement_leader? do
     case :ra.members({@placement_cluster_name, node()}) do
       {:ok, _members, {@placement_cluster_name, leader_node}} -> leader_node == node()
       _ -> false
     end
+  catch
+    :exit, _ -> false
   end
 
   # Resolves a StatefulSet ordinal to its *current* Erlang node identity.
@@ -548,15 +562,69 @@ defmodule Riptide.RaCluster do
     new_id = {name, new_node}
     cluster_name = uid <> "_cluster"
 
-    with {:ok, _reply, _leader} <-
-           retry_cluster_change(fn -> :ra.add_member(survivor_ids, new_id) end),
-         :ok <- :ra.start_server(@system, cluster_name, new_id, machine, survivor_ids),
+    with :ok <- add_member(survivor_ids, new_id),
+         :ok <- start_joining_server(cluster_name, new_id, machine, survivor_ids),
          {:ok, _reply, _leader} <-
            retry_cluster_change(fn -> :ra.remove_member(survivor_ids, dead_id) end) do
       :ok
     else
       {:error, reason} -> {:error, reason}
       {:timeout, _} -> {:error, :timeout}
+    end
+  end
+
+  # Self-corrects the exact same "redundant retry after a partial prior
+  # success" shape `start_new_cluster/4` and `attempt_start_placement_cluster/1`
+  # already handle for their own `:ra` calls (see their own docs): if a
+  # previous `replace_member/5` attempt's `add_member` step already landed
+  # (e.g. this node crashed before reaching `remove_member`), `:ra.add_member/2`
+  # now genuinely returns `{:error, :already_member}` for `new_id` — a real,
+  # non-transient error `retry_cluster_change/2` deliberately does NOT retry
+  # (see its own doc). Without this, that error would fail the whole repair
+  # attempt outright on every retry, leaving the stream permanently stuck
+  # (finding 3, Phase 3d-ii final review) instead of proceeding on to
+  # (re-)ensure the joining server itself is started.
+  @spec add_member([:ra.server_id()], :ra.server_id()) ::
+          :ok | {:error, term()} | {:timeout, term()}
+  defp add_member(survivor_ids, new_id) do
+    case retry_cluster_change(fn -> :ra.add_member(survivor_ids, new_id) end) do
+      {:ok, _reply, _leader} -> :ok
+      {:error, :already_member} -> :ok
+      {:error, reason} -> {:error, reason}
+      {:timeout, _} = timeout -> timeout
+    end
+  end
+
+  # Same self-correction idiom as `start_new_cluster/4`'s own "recheck
+  # liveness after an error, in case someone else already won" pattern — but
+  # checking `member_alive?/1` (local-or-remote, since `new_id`'s node is
+  # often a genuinely different physical node than whichever node is running
+  # this repair) rather than pattern-matching a specific error shape like
+  # `{:error, {:already_started, _pid}}`. Confirmed necessary, not just
+  # defensive: `:ra.start_server/5`'s underlying supervisor child-start
+  # failure for an id that's already running can come back wrapped as
+  # `{:error, {:shutdown, {:failed_to_start_child, ChildId, {:already_started,
+  # pid}}}}` rather than the bare tuple (observed via this module's own
+  # collapsed-node test, where `new_node` coincides with an already-running
+  # survivor) — matching only the unwrapped shape silently let that case fall
+  # through as a genuine failure. Checking real liveness instead is robust to
+  # whatever exact wrapping `:ra`/its supervisor happens to produce for "this
+  # id is already running," the same reasoning `start_new_cluster/4` already
+  # established for its own redundant-start races.
+  @spec start_joining_server(String.t(), :ra.server_id(), :ra_machine.machine(), [
+          :ra.server_id()
+        ]) :: :ok | {:error, term()}
+  defp start_joining_server(cluster_name, new_id, machine, survivor_ids) do
+    case :ra.start_server(@system, cluster_name, new_id, machine, survivor_ids) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        if member_alive?(new_id) do
+          :ok
+        else
+          {:error, reason}
+        end
     end
   end
 

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -521,4 +521,83 @@ defmodule Riptide.RaCluster do
         end
     end
   end
+
+  # Grows a stream's already-running `:ra` cluster by one member (`new_node`)
+  # and evicts a dead one (`dead_node`) — the real repair primitive behind
+  # Phase 3d-ii's automatic replica healing. `survivor_nodes` must be at
+  # least one currently-alive member of the cluster (never `dead_node`
+  # itself); passing every survivor (not just one) lets `:ra` itself pick a
+  # reachable one to route the membership-change commands through, the same
+  # `ra_server_id() | [ra_server_id()]` flexibility `:ra.add_member/2` and
+  # `:ra.remove_member/2` already support directly.
+  #
+  # Order matters and is NOT `start_or_join_replicated/3`'s "form a fresh
+  # cluster" order — verified against `:ra`'s own growing-a-cluster
+  # documentation (`deps/ra/README.md`, "Dynamically Changing Cluster
+  # Membership"): add the member to the existing cluster's configuration
+  # FIRST, then start the joining server itself with `initial_members` set
+  # to just the survivor(s) — reversed, a freshly-started server with no
+  # cluster membership entry yet has nothing to catch up from.
+  @spec replace_member(String.t(), [node()], node(), node(), :ra_machine.machine()) ::
+          :ok | {:error, term()}
+  def replace_member(uid, survivor_nodes, dead_node, new_node, machine) do
+    ensure_system_started()
+    name = String.to_atom(uid)
+    survivor_ids = Enum.map(survivor_nodes, &{name, &1})
+    dead_id = {name, dead_node}
+    new_id = {name, new_node}
+    cluster_name = uid <> "_cluster"
+
+    with {:ok, _reply, _leader} <-
+           retry_cluster_change(fn -> :ra.add_member(survivor_ids, new_id) end),
+         :ok <- :ra.start_server(@system, cluster_name, new_id, machine, survivor_ids),
+         {:ok, _reply, _leader} <-
+           retry_cluster_change(fn -> :ra.remove_member(survivor_ids, dead_id) end) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      {:timeout, _} -> {:error, :timeout}
+    end
+  end
+
+  # `:ra.add_member/2` and `:ra.remove_member/2` both return as soon as their
+  # membership-change command is APPENDED to the leader's log
+  # (`after_log_append` reply mode — confirmed directly against
+  # `deps/ra/src/ra.erl`'s `add_member/3`/`remove_member/3`), not once it's
+  # been committed and applied. And `:ra` only permits ONE cluster
+  # membership change in flight at a time: "concurrent changes will be
+  # rejected by design" (`deps/ra/README.md`, "Dynamically Changing Cluster
+  # Membership"). That combination makes `{:error, :cluster_change_not_permitted}`
+  # a genuinely transient condition `replace_member/5` can hit back-to-back
+  # in two different spots, both confirmed empirically against a real
+  # multi-node `:ra` cluster (see `ra_cluster_replace_member_test.exs`):
+  #
+  #   1. `add_member` itself, when `survivor_nodes` was elected leader only
+  #      moments ago (e.g. right after `start_or_join_replicated/3`, or
+  #      right after failing over from a just-killed `dead_node`) — every
+  #      new leader must commit a no-op entry for its own current term
+  #      before ANY membership change is permitted (see the collapsed-node
+  #      test in `ra_cluster_test.exs`).
+  #   2. `remove_member`, racing ahead of THIS SAME CALL's own `add_member`
+  #      change, which hasn't committed+applied yet.
+  #
+  # Retrying the SAME `:ra` call (never the whole `with` chain, and never
+  # more than this one specific error atom) is safe here specifically
+  # because `cluster_change_not_permitted` means the change was REJECTED
+  # outright — nothing was appended, so nothing can be double-applied by
+  # trying again. Any other error (notably a genuine `{:error, :already_member}`
+  # for a `new_node` that's already a distinct, non-transient member — see
+  # the collapsed-node test's own assertion) is NOT retried and propagates
+  # immediately, unchanged.
+  @spec retry_cluster_change((-> term()), pos_integer()) :: term()
+  defp retry_cluster_change(fun, attempts_left \\ 50) do
+    case fun.() do
+      {:error, :cluster_change_not_permitted} when attempts_left > 1 ->
+        Process.sleep(100)
+        retry_cluster_change(fun, attempts_left - 1)
+
+      other ->
+        other
+    end
+  end
 end

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -33,6 +33,23 @@ defmodule Riptide.RaCluster do
     {@placement_cluster_name, resolve_fun.(ordinal)}
   end
 
+  # Whether THIS node is currently the placement cluster's Raft leader —
+  # used by `Riptide.Stream.ReplicaHealer` (Phase 3d-ii) to gate stream
+  # replica repair so only one of the 3 placement ordinals ever acts on a
+  # given sweep, reusing the placement cluster's own existing leader
+  # election rather than a new coordination mechanism. Queries the LOCAL
+  # member directly (`{@placement_cluster_name, node()}`) rather than going
+  # through `placement_server_id/2`'s ordinal/DNS resolution, since this is
+  # only ever meaningful to call from a node that's itself a placement
+  # ordinal already running its own local member.
+  @spec placement_leader?() :: boolean()
+  def placement_leader? do
+    case :ra.members({@placement_cluster_name, node()}) do
+      {:ok, _members, {@placement_cluster_name, leader_node}} -> leader_node == node()
+      _ -> false
+    end
+  end
+
   # Resolves a StatefulSet ordinal to its *current* Erlang node identity.
   # In production this is always the real DNS-based resolution below
   # (mirroring exactly how `Cluster.Strategy.Kubernetes.DNS` resolves peers
@@ -301,20 +318,17 @@ defmodule Riptide.RaCluster do
     end
   end
 
-  # Local-or-remote liveness check for a single Ra server id — used to
-  # distinguish, member by member, "genuinely never started" from "already
-  # running, just not *newly* started by this particular
-  # `:ra.start_cluster/2` call" (see `start_or_join_replicated/3`'s
-  # `NotStarted` handling below). A member unreachable over `:erpc` (network
-  # blip, node still booting) is conservatively treated as not-alive, which
-  # only ever causes a spurious retry of an already-fine formation — never a
-  # silently-accepted broken one.
+  # Public (not `defp`) so callers beyond this module — e.g.
+  # `Riptide.Stream.ReplicaHealer` (Phase 3d-ii) — can check a specific
+  # stream replica's real liveness, local or remote, the same way this
+  # module already does internally for `start_or_join_replicated/3`'s own
+  # `NotStarted` handling.
   @spec member_alive?(:ra.server_id()) :: boolean()
-  defp member_alive?({name, node}) when node == node() do
+  def member_alive?({name, node}) when node == node() do
     server_alive?(name)
   end
 
-  defp member_alive?({name, node}) do
+  def member_alive?({name, node}) do
     case :erpc.call(node, __MODULE__, :server_alive?, [name], 5_000) do
       true -> true
       false -> false

--- a/lib/riptide/stream/placement.ex
+++ b/lib/riptide/stream/placement.ex
@@ -32,15 +32,7 @@ defmodule Riptide.Stream.Placement do
   @impl GenServer
   def init(:ok) do
     :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
-
-    # Subscribe to cache invalidation broadcasts, but gracefully handle isolated
-    # test environments where PubSub might not be started.
-    try do
-      Phoenix.PubSub.subscribe(Riptide.PubSub, "stream_placement_changed")
-    rescue
-      ArgumentError -> :ok
-    end
-
+    Phoenix.PubSub.subscribe(Riptide.PubSub, "stream_placement_changed")
     {:ok, %{}}
   end
 

--- a/lib/riptide/stream/placement.ex
+++ b/lib/riptide/stream/placement.ex
@@ -15,6 +15,7 @@ defmodule Riptide.Stream.Placement do
   """
 
   use GenServer
+  require Logger
 
   alias Riptide.Placement
   alias Riptide.RaCluster
@@ -45,10 +46,26 @@ defmodule Riptide.Stream.Placement do
   # no need to force a re-resolution round-trip through the placement
   # cluster.
   @impl GenServer
-  def handle_info({:stream_placement_changed, stream_id, new_nodes}, state) do
+  def handle_info({:stream_placement_changed, stream_id, new_nodes}, state)
+      when is_list(new_nodes) do
     uid = RaCluster.uid_for(stream_id)
     server_ids = Enum.map(new_nodes, &{String.to_atom(uid), &1})
     :ets.insert(@table, {stream_id, server_ids})
+    {:noreply, state}
+  end
+
+  # `Placement.replace_member/3` (the only producer of this broadcast) can
+  # theoretically return `nil` — if `stream_id` is no longer present in the
+  # placement store at all (e.g. a future stream-delete path; currently
+  # unreachable since no delete command exists yet). Skipping instead of
+  # crashing is cheap insurance against a high-blast-radius crash of this
+  # shared, fleet-wide cache subscriber.
+  def handle_info({:stream_placement_changed, stream_id, new_nodes}, state) do
+    Logger.warning(
+      "Riptide.Stream.Placement got a non-list stream_placement_changed broadcast for " <>
+        "#{inspect(stream_id)} (#{inspect(new_nodes)}); skipping cache update"
+    )
+
     {:noreply, state}
   end
 

--- a/lib/riptide/stream/placement.ex
+++ b/lib/riptide/stream/placement.ex
@@ -32,7 +32,32 @@ defmodule Riptide.Stream.Placement do
   @impl GenServer
   def init(:ok) do
     :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+
+    # Subscribe to cache invalidation broadcasts, but gracefully handle isolated
+    # test environments where PubSub might not be started.
+    try do
+      Phoenix.PubSub.subscribe(Riptide.PubSub, "stream_placement_changed")
+    rescue
+      ArgumentError -> :ok
+    end
+
     {:ok, %{}}
+  end
+
+  # Corrects this node's cached server ids the moment `Riptide.Stream.ReplicaHealer`
+  # (Phase 3d-ii) repairs a stream elsewhere in the fleet — without this, a
+  # node that already cached the old (now partially dead) server ids would
+  # keep them until it happened to restart, per this module's own
+  # cache-forever design (see moduledoc). Overwrites directly rather than
+  # evicting, since the correct value is already known from the broadcast —
+  # no need to force a re-resolution round-trip through the placement
+  # cluster.
+  @impl GenServer
+  def handle_info({:stream_placement_changed, stream_id, new_nodes}, state) do
+    uid = RaCluster.uid_for(stream_id)
+    server_ids = Enum.map(new_nodes, &{String.to_atom(uid), &1})
+    :ets.insert(@table, {stream_id, server_ids})
+    {:noreply, state}
   end
 
   @doc """

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -119,18 +119,33 @@ defmodule Riptide.Stream.ReplicaHealer do
   already among `current_nodes`. Deterministic (sorted, first candidate)
   rather than random, unlike `Riptide.Placement.propose_nodes/2`'s own
   selection for a brand-new stream: two concurrent or retried repair
-  attempts for the very same `{stream_id, dead_node}` pair always compute
-  the same `current_nodes`/`live_nodes` inputs, so picking deterministically
-  means they always converge on the same replacement node too — turning a
-  redundant second attempt (e.g. after a partial failure, or a leadership
-  handoff mid-sweep — see finding 3, Phase 3d-ii final review) into a safe
-  retry of the same repair instead of a competing one that could leave the
-  stream over-replicated. `live_nodes` defaults to `Node.list()` but is
-  overridable for tests, mirroring `propose_nodes/2`'s own
-  `peers \\ Node.list()` pattern.
+  attempts for the very same `{stream_id, dead_node}` pair need to always
+  compute the same `current_nodes`/`live_nodes` inputs, so that picking
+  deterministically means they always converge on the same replacement node
+  too — turning a redundant second attempt (e.g. after a partial failure, or
+  a leadership handoff mid-sweep — see finding 3, Phase 3d-ii final review)
+  into a safe retry of the same repair instead of a competing one that could
+  leave the stream over-replicated.
+
+  `live_nodes` defaults to `[node() | Node.list()]`, NOT bare `Node.list()`
+  — this matters because `Node.list()` never includes the calling node
+  itself, so two different callers (e.g. two different placement ordinals,
+  racing across that same leadership handoff) each get a DIFFERENT raw
+  `Node.list()`: one that excludes only itself. If the sorted-first pick
+  happened to land on one of those excluded callers — a real possibility,
+  since a placement ordinal is just as valid a replacement candidate as any
+  other fleet node, especially in a small cluster where the fleet is
+  essentially just the 3 placement ordinals — the two callers would compute
+  DIFFERENT replacements, defeating the determinism this function exists to
+  guarantee. Prepending `node()` closes that asymmetry: as long as the
+  cluster is fully connected (the normal case), every caller's
+  `[node() | Node.list()]` resolves to the exact same full fleet, just in a
+  different order — and `pick_replacement/2`'s own sort makes it
+  order-independent. Overridable for tests, mirroring `propose_nodes/2`'s
+  own `peers \\ Node.list()` pattern.
   """
   @spec pick_replacement([node()], [node()]) :: node() | nil
-  def pick_replacement(current_nodes, live_nodes \\ Node.list()) do
+  def pick_replacement(current_nodes, live_nodes \\ [node() | Node.list()]) do
     case (live_nodes -- current_nodes) |> Enum.uniq() |> Enum.sort() do
       [] -> nil
       [node | _rest] -> node
@@ -144,6 +159,17 @@ defmodule Riptide.Stream.ReplicaHealer do
   # `with_ordinal_fallback/2` "try the next one on failure" shape) since any
   # single survivor being briefly unreachable shouldn't block discovering a
   # value every survivor's machine state agrees on.
+  #
+  # Also catches `:exit`, not just `rescue`s: `RaCluster.consistent_query/2`
+  # (and the underlying `:ra.consistent_query/2` it wraps) can genuinely
+  # *exit* rather than raise or return an `{:error, _}`/`{:timeout, _}` in
+  # some failure modes — the same class of failure `RaCluster.placement_leader?/0`
+  # already guards against with its own `catch :exit` (see finding 5, Phase
+  # 3d-ii final review). A `rescue` clause alone does not catch an `exit`, so
+  # without this a survivor dying exactly during this query would crash this
+  # GenServer's synchronous sweep outright instead of just moving on to the
+  # next survivor — the same "briefly unreachable shouldn't block discovery"
+  # rationale this function already follows for raised errors.
   @spec discover_retention(String.t(), [node()]) :: {:ok, term()} | :error
   defp discover_retention(uid, survivor_nodes) do
     name = String.to_atom(uid)
@@ -153,6 +179,8 @@ defmodule Riptide.Stream.ReplicaHealer do
         {:ok, RaCluster.consistent_query({name, node}, &Map.get(&1, :retention))}
       rescue
         _ -> nil
+      catch
+        :exit, _ -> nil
       end
     end)
   end

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -42,7 +42,9 @@ defmodule Riptide.Stream.ReplicaHealer do
   end
 
   defp schedule_sweep do
-    interval = Application.get_env(:riptide, :replica_healer_sweep_interval_ms, @sweep_interval_ms)
+    interval =
+      Application.get_env(:riptide, :replica_healer_sweep_interval_ms, @sweep_interval_ms)
+
     Process.send_after(self(), :sweep, interval)
   end
 

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -18,7 +18,6 @@ defmodule Riptide.Stream.ReplicaHealer do
   alias Riptide.Stream.RaMachine
 
   @sweep_interval_ms 30_000
-  @stream_machine {:module, RaMachine, %{retention: :infinity}}
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
@@ -78,40 +77,83 @@ defmodule Riptide.Stream.ReplicaHealer do
         :ok
 
       new_node ->
-        case RaCluster.replace_member(uid, survivor_nodes, dead_node, new_node, @stream_machine) do
-          :ok ->
-            new_nodes = Placement.replace_member(stream_id, dead_node, new_node)
+        case discover_retention(uid, survivor_nodes) do
+          {:ok, retention} ->
+            do_repair(stream_id, uid, survivor_nodes, dead_node, new_node, retention)
 
-            Phoenix.PubSub.broadcast(
-              Riptide.PubSub,
-              "stream_placement_changed",
-              {:stream_placement_changed, stream_id, new_nodes}
-            )
-
-            Logger.info(
-              "ReplicaHealer repaired #{stream_id}: replaced #{inspect(dead_node)} with #{inspect(new_node)}"
-            )
-
-          {:error, reason} ->
+          :error ->
             Logger.warning(
-              "ReplicaHealer failed to repair #{stream_id} (dead: #{inspect(dead_node)}): #{inspect(reason)}"
+              "ReplicaHealer could not discover #{stream_id}'s current retention from any " <>
+                "survivor (#{inspect(survivor_nodes)}); skipping repair this tick"
             )
         end
     end
   end
 
+  defp do_repair(stream_id, uid, survivor_nodes, dead_node, new_node, retention) do
+    machine = {:module, RaMachine, %{retention: retention}}
+
+    case RaCluster.replace_member(uid, survivor_nodes, dead_node, new_node, machine) do
+      :ok ->
+        new_nodes = Placement.replace_member(stream_id, dead_node, new_node)
+
+        Phoenix.PubSub.broadcast(
+          Riptide.PubSub,
+          "stream_placement_changed",
+          {:stream_placement_changed, stream_id, new_nodes}
+        )
+
+        Logger.info(
+          "ReplicaHealer repaired #{stream_id}: replaced #{inspect(dead_node)} with #{inspect(new_node)}"
+        )
+
+      {:error, reason} ->
+        Logger.warning(
+          "ReplicaHealer failed to repair #{stream_id} (dead: #{inspect(dead_node)}): #{inspect(reason)}"
+        )
+    end
+  end
+
   @doc """
   Picks a live fleet node to replace a dead member with — a candidate not
-  already among `current_nodes`, chosen the same random-selection way
-  `Riptide.Placement.propose_nodes/2` already picks a new stream's initial
-  replicas. `live_nodes` defaults to `Node.list()` but is overridable for
-  tests, mirroring `propose_nodes/2`'s own `peers \\ Node.list()` pattern.
+  already among `current_nodes`. Deterministic (sorted, first candidate)
+  rather than random, unlike `Riptide.Placement.propose_nodes/2`'s own
+  selection for a brand-new stream: two concurrent or retried repair
+  attempts for the very same `{stream_id, dead_node}` pair always compute
+  the same `current_nodes`/`live_nodes` inputs, so picking deterministically
+  means they always converge on the same replacement node too — turning a
+  redundant second attempt (e.g. after a partial failure, or a leadership
+  handoff mid-sweep — see finding 3, Phase 3d-ii final review) into a safe
+  retry of the same repair instead of a competing one that could leave the
+  stream over-replicated. `live_nodes` defaults to `Node.list()` but is
+  overridable for tests, mirroring `propose_nodes/2`'s own
+  `peers \\ Node.list()` pattern.
   """
   @spec pick_replacement([node()], [node()]) :: node() | nil
   def pick_replacement(current_nodes, live_nodes \\ Node.list()) do
-    case Placement.select_nodes(live_nodes -- current_nodes, 1) do
-      [node] -> node
+    case (live_nodes -- current_nodes) |> Enum.uniq() |> Enum.sort() do
       [] -> nil
+      [node | _rest] -> node
     end
+  end
+
+  # `RaCluster` is the sole module allowed to call `:ra` directly (see its
+  # own moduledoc) — this goes through `RaCluster.consistent_query/2`, the
+  # existing linearizable-read primitive, rather than reaching into `:ra`
+  # itself. Tries every survivor in turn (mirroring `Riptide.Placement`'s own
+  # `with_ordinal_fallback/2` "try the next one on failure" shape) since any
+  # single survivor being briefly unreachable shouldn't block discovering a
+  # value every survivor's machine state agrees on.
+  @spec discover_retention(String.t(), [node()]) :: {:ok, term()} | :error
+  defp discover_retention(uid, survivor_nodes) do
+    name = String.to_atom(uid)
+
+    Enum.find_value(survivor_nodes, :error, fn node ->
+      try do
+        {:ok, RaCluster.consistent_query({name, node}, &Map.get(&1, :retention))}
+      rescue
+        _ -> nil
+      end
+    end)
   end
 end

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -1,0 +1,115 @@
+defmodule Riptide.Stream.ReplicaHealer do
+  @moduledoc """
+  Fully automatic background repair for a stream's replica set — see Phase
+  3d-ii design spec for the full motivation. Runs only on the 3 placement
+  ordinals (wired in `Riptide.Application`, same gating as
+  `Riptide.RaCluster.ensure_placement_cluster_started/0`), and only the
+  placement cluster's current Raft leader ever acts on a given sweep
+  (`RaCluster.placement_leader?/0`) — reusing that cluster's own existing
+  leader election as single-writer safety, rather than a new coordination
+  mechanism. No operator action is required in the steady-state case.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Riptide.Placement
+  alias Riptide.RaCluster
+  alias Riptide.Stream.RaMachine
+
+  @sweep_interval_ms 30_000
+  @stream_machine {:module, RaMachine, %{retention: :infinity}}
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(:ok) do
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state) do
+    if RaCluster.placement_leader?() do
+      sweep()
+    end
+
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp schedule_sweep do
+    interval = Application.get_env(:riptide, :replica_healer_sweep_interval_ms, @sweep_interval_ms)
+    Process.send_after(self(), :sweep, interval)
+  end
+
+  @doc """
+  One full pass over every known stream: find any with exactly one dead
+  member and repair it. Public (not just reachable via the timer) so tests
+  can invoke it directly rather than waiting on a real interval.
+  """
+  @spec sweep() :: :ok
+  def sweep do
+    Placement.list_all()
+    |> Enum.each(&maybe_repair/1)
+  end
+
+  defp maybe_repair({stream_id, nodes}) do
+    uid = RaCluster.uid_for(stream_id)
+    name = String.to_atom(uid)
+    dead_nodes = Enum.reject(nodes, &RaCluster.member_alive?({name, &1}))
+
+    case dead_nodes do
+      [dead_node] -> repair(stream_id, uid, nodes, dead_node)
+      _ -> :ok
+    end
+  end
+
+  defp repair(stream_id, uid, nodes, dead_node) do
+    survivor_nodes = nodes -- [dead_node]
+
+    case pick_replacement(nodes) do
+      nil ->
+        :ok
+
+      new_node ->
+        case RaCluster.replace_member(uid, survivor_nodes, dead_node, new_node, @stream_machine) do
+          :ok ->
+            new_nodes = Placement.replace_member(stream_id, dead_node, new_node)
+
+            Phoenix.PubSub.broadcast(
+              Riptide.PubSub,
+              "stream_placement_changed",
+              {:stream_placement_changed, stream_id, new_nodes}
+            )
+
+            Logger.info(
+              "ReplicaHealer repaired #{stream_id}: replaced #{inspect(dead_node)} with #{inspect(new_node)}"
+            )
+
+          {:error, reason} ->
+            Logger.warning(
+              "ReplicaHealer failed to repair #{stream_id} (dead: #{inspect(dead_node)}): #{inspect(reason)}"
+            )
+        end
+    end
+  end
+
+  @doc """
+  Picks a live fleet node to replace a dead member with — a candidate not
+  already among `current_nodes`, chosen the same random-selection way
+  `Riptide.Placement.propose_nodes/2` already picks a new stream's initial
+  replicas. `live_nodes` defaults to `Node.list()` but is overridable for
+  tests, mirroring `propose_nodes/2`'s own `peers \\ Node.list()` pattern.
+  """
+  @spec pick_replacement([node()], [node()]) :: node() | nil
+  def pick_replacement(current_nodes, live_nodes \\ Node.list()) do
+    case Placement.select_nodes(live_nodes -- current_nodes, 1) do
+      [node] -> node
+      [] -> nil
+    end
+  end
+end

--- a/test/riptide/placement/placement_machine_test.exs
+++ b/test/riptide/placement/placement_machine_test.exs
@@ -45,4 +45,46 @@ defmodule Riptide.Placement.PlacementMachineTest do
   test "get/2 returns nil for an unknown stream" do
     assert PlacementMachine.get(%{}, "unknown") == nil
   end
+
+  test "list/1 returns the full stream_id => nodes map" do
+    state = %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}
+    assert PlacementMachine.list(state) == state
+  end
+
+  test "list/1 returns an empty map when nothing is assigned yet" do
+    assert PlacementMachine.list(PlacementMachine.init(%{})) == %{}
+  end
+
+  test "apply/3 {:replace_member, ...} swaps a dead node for a new one in an existing assignment" do
+    state = %{"s1" => [:a, :b, :c]}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1}, {:replace_member, "s1", :b, :z}, state)
+
+    assert new_state == %{"s1" => [:a, :z, :c]}
+    assert reply == [:a, :z, :c]
+    assert effects == []
+  end
+
+  test "apply/3 {:replace_member, ...} is a no-op if the named dead node is no longer present" do
+    state = %{"s1" => [:a, :z, :c]}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 2}, {:replace_member, "s1", :b, :y}, state)
+
+    assert new_state == %{"s1" => [:a, :z, :c]}
+    assert reply == [:a, :z, :c]
+    assert effects == []
+  end
+
+  test "apply/3 {:replace_member, ...} is a no-op for an unknown stream_id" do
+    state = %{}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1}, {:replace_member, "unknown", :a, :b}, state)
+
+    assert new_state == %{}
+    assert reply == nil
+    assert effects == []
+  end
 end

--- a/test/riptide/placement_test.exs
+++ b/test/riptide/placement_test.exs
@@ -84,7 +84,7 @@ defmodule Riptide.PlacementTest do
       stream_id = "placement-replace-member-noop-" <> Uniq.UUID.uuid4()
       Placement.assign(stream_id, [node()])
 
-      result = Placement.replace_member(stream_id, :"never-was-here@nowhere", :"new@nowhere")
+      result = Placement.replace_member(stream_id, :"never-was-here@nowhere", :new@nowhere)
 
       assert result == [node()]
       assert Placement.lookup(stream_id) == [node()]

--- a/test/riptide/placement_test.exs
+++ b/test/riptide/placement_test.exs
@@ -61,5 +61,33 @@ defmodule Riptide.PlacementTest do
       assert assigned == [node()]
       assert Placement.lookup(stream_id) == [node()]
     end
+
+    test "list_all/1 includes every real assignment made so far" do
+      stream_id = "placement-list-all-" <> Uniq.UUID.uuid4()
+      Placement.assign(stream_id, [node()])
+
+      assert Placement.list_all()[stream_id] == [node()]
+    end
+
+    test "replace_member/3 swaps a dead node for a new one in a real assignment" do
+      stream_id = "placement-replace-member-" <> Uniq.UUID.uuid4()
+      fake_dead_node = :"fake-dead@nowhere"
+      Placement.assign(stream_id, [node(), fake_dead_node])
+
+      replaced = Placement.replace_member(stream_id, fake_dead_node, :"fake-new@nowhere")
+
+      assert Enum.sort(replaced) == Enum.sort([node(), :"fake-new@nowhere"])
+      assert Enum.sort(Placement.lookup(stream_id)) == Enum.sort([node(), :"fake-new@nowhere"])
+    end
+
+    test "replace_member/3 is a no-op if the dead node named is no longer part of the assignment" do
+      stream_id = "placement-replace-member-noop-" <> Uniq.UUID.uuid4()
+      Placement.assign(stream_id, [node()])
+
+      result = Placement.replace_member(stream_id, :"never-was-here@nowhere", :"new@nowhere")
+
+      assert result == [node()]
+      assert Placement.lookup(stream_id) == [node()]
+    end
   end
 end

--- a/test/riptide/ra_cluster_replace_member_test.exs
+++ b/test/riptide/ra_cluster_replace_member_test.exs
@@ -157,7 +157,8 @@ defmodule Riptide.RaClusterReplaceMemberTest do
   end
 
   defp stop_peer_for(peers, target_node) do
-    {pid, ^target_node, _ordinal} = Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+    {pid, ^target_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
 
     try do
       :peer.stop(pid)
@@ -168,8 +169,12 @@ defmodule Riptide.RaClusterReplaceMemberTest do
 
   defp eventually(fun, attempts_left \\ 50) do
     cond do
-      fun.() -> true
-      attempts_left <= 1 -> false
+      fun.() ->
+        true
+
+      attempts_left <= 1 ->
+        false
+
       true ->
         Process.sleep(100)
         eventually(fun, attempts_left - 1)

--- a/test/riptide/ra_cluster_replace_member_test.exs
+++ b/test/riptide/ra_cluster_replace_member_test.exs
@@ -13,6 +13,14 @@ defmodule Riptide.RaClusterReplaceMemberTest do
 
   @replacement {:repl_d, "repl-d", ~c"127.0.0.43"}
 
+  @peers2 [
+    {:repl2_a, "repl2-a", ~c"127.0.0.44"},
+    {:repl2_b, "repl2-b", ~c"127.0.0.45"},
+    {:repl2_c, "repl2-c", ~c"127.0.0.46"}
+  ]
+
+  @replacement2 {:repl2_d, "repl2-d", ~c"127.0.0.47"}
+
   setup_all do
     unless Node.alive?() do
       {:ok, _pid} = Node.start(:"ra_cluster_replace_member_origin@127.0.0.1", :longnames)
@@ -22,82 +30,7 @@ defmodule Riptide.RaClusterReplaceMemberTest do
   end
 
   test "replace_member/5 evicts a dead real member and joins a fresh real replacement, preserving data" do
-    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
-    all_specs = @peers ++ [@replacement]
-
-    peers =
-      for {alive_name, ordinal, host} <- all_specs do
-        {:ok, pid, node} =
-          :peer.start_link(%{
-            name: alive_name,
-            host: host,
-            longnames: true,
-            args: pa_args,
-            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
-          })
-
-        {pid, node, ordinal}
-      end
-
-    on_exit(fn ->
-      Enum.each(peers, fn {pid, _node, _ordinal} ->
-        if Process.alive?(pid) do
-          try do
-            :peer.stop(pid)
-          catch
-            :exit, _ -> :ok
-          end
-        end
-      end)
-
-      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
-        File.rm_rf!(Path.join(File.cwd!(), ordinal))
-      end)
-    end)
-
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
-
-    for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
-               :erpc.call(node, :code, :load_binary, [
-                 module,
-                 ~c"ra_cluster_replace_member_test.ex",
-                 bytecode
-               ])
-    end
-
-    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
-
-    for {n1, n2} <- unique_pairs(nodes) do
-      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
-    end
-
-    for {_pid, node, _ordinal} <- peers do
-      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
-    end
-
-    # Every peer's own local `:default` Ra system must be started BEFORE any
-    # of them attempts to form or grow a cluster — `start_or_join_replicated/3`
-    # and `replace_member/5` both call `:ra.start_cluster/2`/`:ra.start_server/5`,
-    # which reach out over RPC to start (or add) servers on the OTHER member
-    # nodes too, not just the local one. `start_or_join_replicated/3`'s own
-    # `ensure_system_started/0` call only starts the system on whichever node
-    # the erpc call itself lands on (node_a below) — it has no way to reach
-    # the other peers' local systems. Matches the exact same prerequisite this
-    # codebase's other real multi-node tests already establish (see
-    # `ra_cluster_replicated_formation_test.exs` and
-    # `placement_cluster_test.exs`'s `bootstrap_ra_on_peers/1`); without this,
-    # every remote member's start fails with `{:error, :system_not_started}`.
-    for {_pid, node, _ordinal} <- peers do
-      case :erpc.call(node, :ra_system, :start, [
-             :erpc.call(node, Riptide.RaCluster, :system_config, [])
-           ]) do
-        {:ok, _pid} -> :ok
-        {:ok, _pid, _info} -> :ok
-        {:error, {:already_started, _pid}} -> :ok
-      end
-    end
-
+    peers = bootstrap_peers(@peers ++ [@replacement])
     [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, node_d, _}] = peers
     original_nodes = [node_a, node_b, node_c]
 
@@ -156,14 +89,189 @@ defmodule Riptide.RaClusterReplaceMemberTest do
     assert :erpc.call(node_d, Riptide.RaCluster, :local_query, [{name, node_d}, & &1]) == ["a"]
   end
 
+  test "replace_member/5 self-corrects when a prior attempt already added and started the replacement" do
+    # Reproduces finding 3(b) from the Phase 3d-ii final review: a repair
+    # attempt can crash after `add_member` and `start_server` both succeed
+    # but before `remove_member` runs (e.g. the node running the repair
+    # crashes right there). The very next `replace_member/5` retry must
+    # still converge on a fully repaired cluster instead of failing outright
+    # on `:ra.add_member/2`'s now-genuine `{:error, :already_member}` (and
+    # `:ra.start_server/5`'s equivalent "already there") for a `new_node`
+    # that's already fully joined.
+    peers = bootstrap_peers(@peers2 ++ [@replacement2])
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, node_d, _}] = peers
+    original_nodes = [node_a, node_b, node_c]
+
+    uid = "replace-member-self-correct-" <> Uniq.UUID.uuid4()
+    machine = {:module, EchoMachine, %{}}
+
+    assert {:ok, _server_ids} =
+             :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+               uid,
+               original_nodes,
+               machine
+             ])
+
+    name = String.to_atom(uid)
+    :erpc.call(node_a, Riptide.RaCluster, :process_command, [{name, node_a}, {:add, "a"}])
+
+    stop_peer_for(peers, node_c)
+    survivor_ids = [{name, node_a}, {name, node_b}]
+    cluster_name = uid <> "_cluster"
+
+    # Simulate a prior attempt that got all the way through `add_member` and
+    # `start_server` — exactly what `replace_member/5` itself does for these
+    # same two steps — but crashed before ever calling `remove_member`.
+    # Retries past `:cluster_change_not_permitted` the same way
+    # `replace_member/5`'s own `retry_cluster_change/2` does (node_c dying
+    # may force a fresh leader election among the 2 survivors first).
+    assert eventually(fn ->
+             match?(
+               {:ok, _reply, _leader},
+               :erpc.call(node_a, :ra, :add_member, [survivor_ids, {name, node_d}])
+             )
+           end)
+
+    assert :ok =
+             :erpc.call(node_d, :ra, :start_server, [
+               :default,
+               cluster_name,
+               {name, node_d},
+               machine,
+               survivor_ids
+             ])
+
+    # Wait for node_d to be fully caught up and voting before treating the
+    # "prior attempt" as done — otherwise the repair below would have to
+    # commit `remove_member` with only 2 of the (still 4-member, since
+    # node_c hasn't been evicted yet) config's members able to ack, which
+    # can't reach quorum until node_d's freshly-started server finishes
+    # catching up and becomes a real voter.
+    assert eventually(fn ->
+             :erpc.call(node_d, Riptide.RaCluster, :server_alive?, [name]) and
+               :erpc.call(node_d, Riptide.RaCluster, :local_query, [{name, node_d}, & &1]) ==
+                 ["a"]
+           end)
+
+    # The real repair call, run as if for the first time — its own internal
+    # `add_member`/`start_server` now both hit "already there" outcomes and
+    # must self-correct past them rather than failing the whole call, then
+    # succeed at `remove_member` (node_d is already a caught-up voter, so
+    # this commits fast).
+    assert :ok =
+             :erpc.call(node_a, Riptide.RaCluster, :replace_member, [
+               uid,
+               [node_a, node_b],
+               node_c,
+               node_d,
+               machine
+             ])
+
+    assert eventually(fn ->
+             case :erpc.call(node_a, :ra, :members, [{name, node_a}]) do
+               {:ok, members, _leader} ->
+                 member_nodes = Enum.map(members, fn {_name, n} -> n end)
+                 Enum.sort(member_nodes) == Enum.sort([node_a, node_b, node_d])
+
+               _ ->
+                 false
+             end
+           end)
+
+    assert :erpc.call(node_d, Riptide.RaCluster, :server_alive?, [name])
+    refute :erpc.call(node_a, Riptide.RaCluster, :member_alive?, [{name, node_c}])
+    assert :erpc.call(node_d, Riptide.RaCluster, :local_query, [{name, node_d}, & &1]) == ["a"]
+  end
+
+  # Shared bootstrap for both tests above: spins up real `:peer` nodes for
+  # `specs`, connects them, starts `:ra` and its `:default` system on each,
+  # and registers cleanup — everything short of forming any particular
+  # cluster, which each test does itself against its own uid.
+  defp bootstrap_peers(specs) do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    peers =
+      for {alive_name, ordinal, host} <- specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, &stop_peer/1)
+
+      Enum.each(specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"ra_cluster_replace_member_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    # Every peer's own local `:default` Ra system must be started BEFORE any
+    # of them attempts to form or grow a cluster — `start_or_join_replicated/3`
+    # and `replace_member/5` both call `:ra.start_cluster/2`/`:ra.start_server/5`,
+    # which reach out over RPC to start (or add) servers on the OTHER member
+    # nodes too, not just the local one. `start_or_join_replicated/3`'s own
+    # `ensure_system_started/0` call only starts the system on whichever node
+    # the erpc call itself lands on (node_a below) — it has no way to reach
+    # the other peers' local systems. Matches the exact same prerequisite this
+    # codebase's other real multi-node tests already establish (see
+    # `ra_cluster_replicated_formation_test.exs` and
+    # `placement_cluster_test.exs`'s `bootstrap_ra_on_peers/1`); without this,
+    # every remote member's start fails with `{:error, :system_not_started}`.
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    peers
+  end
+
   defp stop_peer_for(peers, target_node) do
     {pid, ^target_node, _ordinal} =
       Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
 
-    try do
-      :peer.stop(pid)
-    catch
-      :exit, _ -> :ok
+    stop_peer({pid, target_node, nil})
+  end
+
+  defp stop_peer({pid, _node, _ordinal}) do
+    if Process.alive?(pid) do
+      try do
+        :peer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
     end
   end
 

--- a/test/riptide/ra_cluster_replace_member_test.exs
+++ b/test/riptide/ra_cluster_replace_member_test.exs
@@ -1,0 +1,185 @@
+defmodule Riptide.RaClusterReplaceMemberTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  alias Riptide.Test.EchoMachine
+
+  @peers [
+    {:repl_a, "repl-a", ~c"127.0.0.40"},
+    {:repl_b, "repl-b", ~c"127.0.0.41"},
+    {:repl_c, "repl-c", ~c"127.0.0.42"}
+  ]
+
+  @replacement {:repl_d, "repl-d", ~c"127.0.0.43"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"ra_cluster_replace_member_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "replace_member/5 evicts a dead real member and joins a fresh real replacement, preserving data" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    all_specs = @peers ++ [@replacement]
+
+    peers =
+      for {alive_name, ordinal, host} <- all_specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"ra_cluster_replace_member_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    # Every peer's own local `:default` Ra system must be started BEFORE any
+    # of them attempts to form or grow a cluster — `start_or_join_replicated/3`
+    # and `replace_member/5` both call `:ra.start_cluster/2`/`:ra.start_server/5`,
+    # which reach out over RPC to start (or add) servers on the OTHER member
+    # nodes too, not just the local one. `start_or_join_replicated/3`'s own
+    # `ensure_system_started/0` call only starts the system on whichever node
+    # the erpc call itself lands on (node_a below) — it has no way to reach
+    # the other peers' local systems. Matches the exact same prerequisite this
+    # codebase's other real multi-node tests already establish (see
+    # `ra_cluster_replicated_formation_test.exs` and
+    # `placement_cluster_test.exs`'s `bootstrap_ra_on_peers/1`); without this,
+    # every remote member's start fails with `{:error, :system_not_started}`.
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, node_d, _}] = peers
+    original_nodes = [node_a, node_b, node_c]
+
+    uid = "replace-member-real-" <> Uniq.UUID.uuid4()
+    machine = {:module, EchoMachine, %{}}
+
+    assert {:ok, _server_ids} =
+             :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+               uid,
+               original_nodes,
+               machine
+             ])
+
+    name = String.to_atom(uid)
+
+    # Write real data before the repair, to prove it survives.
+    :erpc.call(node_a, Riptide.RaCluster, :process_command, [{name, node_a}, {:add, "a"}])
+
+    # Kill node_c for real — the member being replaced.
+    stop_peer_for(peers, node_c)
+
+    survivor_nodes = [node_a, node_b]
+
+    # If node_c happened to be the leader, the survivors must elect a new one
+    # before any membership change is possible; and even once a leader is
+    # settled, `replace_member/5`'s own `remove_member` call can briefly race
+    # its own preceding `add_member` change. Both are real, transient `:ra`
+    # conditions (`replace_member/5` retries internally — see its own
+    # `retry_cluster_change/2` for the full explanation), not something this
+    # test needs to work around itself.
+    assert :ok =
+             :erpc.call(node_a, Riptide.RaCluster, :replace_member, [
+               uid,
+               survivor_nodes,
+               node_c,
+               node_d,
+               machine
+             ])
+
+    assert eventually(fn ->
+             case :erpc.call(node_a, :ra, :members, [{name, node_a}]) do
+               {:ok, members, _leader} ->
+                 member_nodes = Enum.map(members, fn {_name, n} -> n end)
+                 Enum.sort(member_nodes) == Enum.sort([node_a, node_b, node_d])
+
+               _ ->
+                 false
+             end
+           end)
+
+    assert :erpc.call(node_d, Riptide.RaCluster, :server_alive?, [name])
+    refute :erpc.call(node_a, Riptide.RaCluster, :member_alive?, [{name, node_c}])
+
+    # No data loss: the write made before the repair is still there,
+    # readable through the NEW member.
+    assert :erpc.call(node_d, Riptide.RaCluster, :local_query, [{name, node_d}, & &1]) == ["a"]
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} = Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    try do
+      :peer.stop(pid)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true ->
+        Process.sleep(100)
+        eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end

--- a/test/riptide/ra_cluster_test.exs
+++ b/test/riptide/ra_cluster_test.exs
@@ -302,4 +302,25 @@ defmodule Riptide.RaClusterTest do
                {:error, :cluster_not_formed}
     end
   end
+
+  describe "replace_member/5" do
+    test "replaces a member with a fresh one, collapsed onto a single real node" do
+      uid = "replace-member-" <> Uniq.UUID.uuid4()
+      name = String.to_atom(uid)
+      machine = {:module, EchoMachine, %{}}
+      on_exit(fn -> :ra.force_delete_server(:default, {name, node()}) end)
+
+      assert {:ok, _server_ids} =
+               RaCluster.start_or_join_replicated(uid, [node()], machine)
+
+      # A single real node standing in for both "the dead node" and "the
+      # replacement" is nonsensical for a real repair, but proves the
+      # function's own call sequence (add_member, start_server, remove_member)
+      # doesn't blow up against a real, already-running single-member
+      # cluster — real distinctness is proven separately by Step 5's
+      # `:peer`-based test.
+      assert RaCluster.replace_member(uid, [node()], :"dead@nowhere", node(), machine) ==
+               {:error, :already_member}
+    end
+  end
 end

--- a/test/riptide/ra_cluster_test.exs
+++ b/test/riptide/ra_cluster_test.exs
@@ -150,6 +150,12 @@ defmodule Riptide.RaClusterTest do
     end
   end
 
+  describe "placement_leader?/0" do
+    test "returns true for this node's own already-running (collapsed) placement cluster" do
+      assert RaCluster.placement_leader?()
+    end
+  end
+
   describe "attempt_start_placement_cluster/1" do
     test "a resolver that raises (e.g. default_ordinal_resolver/1 on an unresolvable DNS name) yields a retriable error instead of an uncaught exception" do
       # Mirrors exactly how `default_ordinal_resolver/1` fails for real: a

--- a/test/riptide/ra_cluster_test.exs
+++ b/test/riptide/ra_cluster_test.exs
@@ -319,7 +319,7 @@ defmodule Riptide.RaClusterTest do
       # doesn't blow up against a real, already-running single-member
       # cluster — real distinctness is proven separately by Step 5's
       # `:peer`-based test.
-      assert RaCluster.replace_member(uid, [node()], :"dead@nowhere", node(), machine) ==
+      assert RaCluster.replace_member(uid, [node()], :dead@nowhere, node(), machine) ==
                {:error, :already_member}
     end
   end

--- a/test/riptide/ra_cluster_test.exs
+++ b/test/riptide/ra_cluster_test.exs
@@ -319,8 +319,16 @@ defmodule Riptide.RaClusterTest do
       # doesn't blow up against a real, already-running single-member
       # cluster — real distinctness is proven separately by Step 5's
       # `:peer`-based test.
+      #
+      # `node()` is already a member here, so `add_member`/`start_server` both
+      # self-correct on their own respective "already there" outcomes (finding
+      # 3, Phase 3d-ii final review — see `RaCluster.add_member/2` and
+      # `start_joining_server/4`'s own docs) and the call proceeds all the way
+      # to `remove_member`, which is where this contrived scenario's real
+      # error surfaces: `:dead@nowhere` was never actually a member of this
+      # single-member cluster to begin with.
       assert RaCluster.replace_member(uid, [node()], :dead@nowhere, node(), machine) ==
-               {:error, :already_member}
+               {:error, :not_member}
     end
   end
 end

--- a/test/riptide/stream/placement_test.exs
+++ b/test/riptide/stream/placement_test.exs
@@ -133,6 +133,28 @@ defmodule Riptide.Stream.PlacementTest do
     end
   end
 
+  describe "handle_info/2 - {:stream_placement_changed, ...}" do
+    test "a non-list new_nodes (e.g. a future stream-delete path returning nil) is ignored instead of crashing the shared cache subscriber" do
+      stream_id = "stream-placement-cache-guard-" <> Uniq.UUID.uuid4()
+      on_exit(fn -> RaCluster.force_delete(stream_id) end)
+      machine = {:module, EchoMachine, %{}}
+
+      {:ok, server_ids} = StreamPlacement.ensure_started(stream_id, machine)
+
+      pid = Process.whereis(StreamPlacement)
+      send(pid, {:stream_placement_changed, stream_id, nil})
+
+      # Synchronize: `:sys.get_state/1` blocks until every message enqueued
+      # ahead of it — including the one just sent above — has actually been
+      # handled, so this deterministically observes the post-handling state
+      # rather than racing the GenServer's own mailbox.
+      :sys.get_state(pid)
+
+      assert Process.alive?(pid)
+      assert StreamPlacement.server_ids!(stream_id) == server_ids
+    end
+  end
+
   describe "server_ids!/1" do
     test "raises if ensure_started/2 has never run for this stream on this node" do
       stream_id = "stream-placement-unstarted-" <> Uniq.UUID.uuid4()

--- a/test/riptide/stream/replica_healer_cluster_test.exs
+++ b/test/riptide/stream/replica_healer_cluster_test.exs
@@ -1,0 +1,211 @@
+defmodule Riptide.Stream.ReplicaHealerClusterTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  @peers [
+    {:healer_a, "riptide-0", ~c"127.0.0.50"},
+    {:healer_b, "riptide-1", ~c"127.0.0.51"},
+    {:healer_c, "riptide-2", ~c"127.0.0.52"}
+  ]
+
+  @replacement {:healer_d, "healer-d", ~c"127.0.0.53"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"replica_healer_cluster_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "a stream's dead replica is automatically detected and repaired, with no data loss" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    all_specs = @peers ++ [@replacement]
+
+    peers =
+      for {alive_name, ordinal, host} <- all_specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"replica_healer_cluster_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+    ordinal_to_node = Map.new(peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
+    resolve_fun = fn ordinal -> Map.fetch!(ordinal_to_node, ordinal) end
+
+    for {_pid, node, _ordinal} <- peers do
+      :erpc.call(node, Application, :put_env, [:riptide, :ordinal_resolver, resolve_fun])
+    end
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, _node_d, _}] = peers
+    placement_peers = Enum.take(peers, 3)
+
+    results =
+      Enum.map(placement_peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
+      end)
+
+    assert Enum.any?(results, &(&1 == :ok))
+
+    # PubSub before Placement — Task 5's `Riptide.Stream.Placement.init/1`
+    # now subscribes to a PubSub topic on start (tolerating a not-yet-started
+    # `Riptide.PubSub` via a scoped rescue, but there's no reason to rely on
+    # that here when starting it first is just as easy and matches real
+    # `Riptide.Application.start/2`'s own ordering).
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+      {:ok, _} = start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+    end
+
+    stream_id = "healer-cluster-" <> Uniq.UUID.uuid4()
+
+    # Explicitly assign the stream to exactly the 3 placement-ordinal nodes
+    # (not left to propose_nodes/2's own randomness) so we know precisely
+    # which peer to kill and which stays as the extra fleet node available
+    # as a replacement candidate for pick_replacement/2.
+    original_nodes = [node_a, node_b, node_c]
+    assert Enum.sort(:erpc.call(node_a, Riptide.Placement, :assign, [stream_id, original_nodes])) ==
+             Enum.sort(original_nodes)
+
+    assert :ok = :erpc.call(node_a, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+
+    graph = :erpc.call(node_a, RDF.Graph, :new, [])
+    event = :erpc.call(node_a, Riptide.Event, :new, [stream_id, :replace, graph])
+    stamped = :erpc.call(node_a, Riptide.Stream.StreamServer, :append, [stream_id, event])
+    assert stamped.sequence == 1
+
+    # Kill node_c for real — the replica being replaced.
+    stop_peer_for(peers, node_c)
+
+    # Run the sweep directly from node_a rather than waiting on the real
+    # 30s timer. `ReplicaHealer.sweep/0` itself performs no leader check —
+    # only the timer-driven `handle_info(:sweep, state)` gates on
+    # `RaCluster.placement_leader?/0` before calling `sweep/0` — so calling
+    # `sweep/0` directly here always attempts the repair regardless of
+    # node_a's actual leadership status; this is a deliberate test-only
+    # bypass of the production gating path, not a claim about node_a being
+    # the leader. The retry loop below exists for a different reason: the
+    # kill in the previous step needs a moment to actually disconnect
+    # before `RaCluster.member_alive?/1` reliably observes it as dead.
+    assert eventually(fn ->
+             :erpc.call(node_a, Riptide.Stream.ReplicaHealer, :sweep, []) == :ok and
+               Enum.sort(:erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])) !=
+                 Enum.sort(original_nodes)
+           end)
+
+    repaired_nodes = :erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])
+    assert length(repaired_nodes) == 3
+    refute node_c in repaired_nodes
+    assert node_a in repaired_nodes
+    assert node_b in repaired_nodes
+
+    [new_node] = repaired_nodes -- [node_a, node_b]
+
+    # No data loss: the write made before the repair is still there,
+    # readable through the fresh replacement.
+    assert :ok = :erpc.call(new_node, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+    {:ok, read_back} = :erpc.call(new_node, Riptide.Stream.StreamServer, :get_since, [stream_id, 0])
+    assert [%{sequence: 1}] = read_back
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    try do
+      :peer.stop(pid)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+
+    :erlang.spawn(node, fn ->
+      result = apply(mod, fun, args)
+      send(parent, {:start_unlinked_result, result})
+      Process.sleep(:infinity)
+    end)
+
+    receive do
+      {:start_unlinked_result, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true ->
+        Process.sleep(200)
+        eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end

--- a/test/riptide/stream/replica_healer_cluster_test.exs
+++ b/test/riptide/stream/replica_healer_cluster_test.exs
@@ -107,7 +107,9 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
     # `Riptide.Application.start/2`'s own ordering).
     for {_pid, node, _ordinal} <- peers do
       {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
-      {:ok, _} = start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+
+      {:ok, _} =
+        start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
     end
 
     for {_pid, node, _ordinal} <- peers do
@@ -121,6 +123,7 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
     # which peer to kill and which stays as the extra fleet node available
     # as a replacement candidate for pick_replacement/2.
     original_nodes = [node_a, node_b, node_c]
+
     assert Enum.sort(:erpc.call(node_a, Riptide.Placement, :assign, [stream_id, original_nodes])) ==
              Enum.sort(original_nodes)
 
@@ -161,7 +164,10 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
     # No data loss: the write made before the repair is still there,
     # readable through the fresh replacement.
     assert :ok = :erpc.call(new_node, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
-    {:ok, read_back} = :erpc.call(new_node, Riptide.Stream.StreamServer, :get_since, [stream_id, 0])
+
+    {:ok, read_back} =
+      :erpc.call(new_node, Riptide.Stream.StreamServer, :get_since, [stream_id, 0])
+
     assert [%{sequence: 1}] = read_back
   end
 
@@ -194,8 +200,12 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
 
   defp eventually(fun, attempts_left \\ 50) do
     cond do
-      fun.() -> true
-      attempts_left <= 1 -> false
+      fun.() ->
+        true
+
+      attempts_left <= 1 ->
+        false
+
       true ->
         Process.sleep(200)
         eventually(fun, attempts_left - 1)

--- a/test/riptide/stream/replica_healer_leadership_gate_test.exs
+++ b/test/riptide/stream/replica_healer_leadership_gate_test.exs
@@ -1,0 +1,257 @@
+defmodule Riptide.Stream.ReplicaHealerLeadershipGateTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  # Design spec §9's own testing requirement, never previously implemented
+  # (Phase 3d-ii final review, finding 2): a real multi-node test proving
+  # only the placement cluster's actual current leader ever performs a
+  # repair. `Riptide.Stream.ReplicaHealer.sweep/0` itself has no leader
+  # check — the gate lives entirely in `handle_info(:sweep, state)` — so
+  # this exercises that REAL production message-handling path (sending
+  # `:sweep` to each node's own registered `ReplicaHealer` process), unlike
+  # `replica_healer_cluster_test.exs`'s existing test, which deliberately
+  # calls `sweep/0` directly and bypasses the gate entirely.
+  @peers [
+    {:gate_a, "riptide-0", ~c"127.0.0.70"},
+    {:gate_b, "riptide-1", ~c"127.0.0.71"},
+    {:gate_c, "riptide-2", ~c"127.0.0.72"}
+  ]
+
+  @replacement {:gate_d, "healer-gate-d", ~c"127.0.0.73"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"replica_healer_leadership_gate_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "only the placement cluster's actual leader repairs a dead replica when :sweep is sent to every ordinal" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    all_specs = @peers ++ [@replacement]
+
+    peers =
+      for {alive_name, ordinal, host} <- all_specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"replica_healer_leadership_gate_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+    ordinal_to_node = Map.new(peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
+    resolve_fun = fn ordinal -> Map.fetch!(ordinal_to_node, ordinal) end
+
+    for {_pid, node, _ordinal} <- peers do
+      :erpc.call(node, Application, :put_env, [:riptide, :ordinal_resolver, resolve_fun])
+
+      # Prevent each node's own real 30s sweep timer from firing mid-test and
+      # confusing which send/handle_info actually caused a given repair —
+      # this test drives every sweep explicitly.
+      :erpc.call(node, Application, :put_env, [
+        :riptide,
+        :replica_healer_sweep_interval_ms,
+        3_600_000
+      ])
+    end
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, _node_d, _}] = peers
+    placement_peers = Enum.take(peers, 3)
+
+    results =
+      Enum.map(placement_peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
+      end)
+
+    assert Enum.any?(results, &(&1 == :ok))
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+
+      {:ok, _} =
+        start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+    end
+
+    stream_id = "healer-gate-" <> Uniq.UUID.uuid4()
+    original_nodes = [node_a, node_b, node_c]
+
+    assert Enum.sort(:erpc.call(node_a, Riptide.Placement, :assign, [stream_id, original_nodes])) ==
+             Enum.sort(original_nodes)
+
+    assert :ok = :erpc.call(node_a, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+
+    graph = :erpc.call(node_a, RDF.Graph, :new, [])
+    event = :erpc.call(node_a, Riptide.Event, :new, [stream_id, :replace, graph])
+    stamped = :erpc.call(node_a, Riptide.Stream.StreamServer, :append, [stream_id, event])
+    assert stamped.sequence == 1
+
+    # Kill node_c for real — the replica being replaced AND one of the 3
+    # placement ordinals. The 2 survivors still hold quorum (2 of 3) for the
+    # placement cluster itself.
+    stop_peer_for(peers, node_c)
+
+    survivors = [node_a, node_b]
+
+    # Find which of the 2 survivors is the placement cluster's actual
+    # current Raft leader — may take a moment to settle if node_c happened
+    # to be the leader itself.
+    leader_node =
+      eventually_find(survivors, fn node ->
+        :erpc.call(node, Riptide.RaCluster, :placement_leader?, [])
+      end)
+
+    assert leader_node != nil, "no survivor became the placement leader in time"
+    [non_leader_node] = survivors -- [leader_node]
+
+    for node <- survivors do
+      {:ok, _} = start_unlinked(node, Riptide.Stream.ReplicaHealer, :start_link, [[]])
+    end
+
+    # Send :sweep to the NON-leader's real, registered ReplicaHealer process
+    # first — exercising the exact production `handle_info(:sweep, state)`
+    # path, including its `RaCluster.placement_leader?/0` gate. Synchronize
+    # with `:sys.get_state/2` (blocks until every message queued ahead of it,
+    # including this :sweep, has been handled) before checking anything, so
+    # this is a deterministic observation, not a timing guess.
+    :erpc.call(non_leader_node, :erlang, :send, [Riptide.Stream.ReplicaHealer, :sweep])
+    :erpc.call(non_leader_node, :sys, :get_state, [Riptide.Stream.ReplicaHealer, 30_000])
+
+    assert Enum.sort(:erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])) ==
+             Enum.sort(original_nodes),
+           "the non-leader's ReplicaHealer must not have repaired anything"
+
+    # Now send :sweep to the ACTUAL leader's ReplicaHealer — this one must
+    # perform the real repair, synchronously (the whole add_member/
+    # start_server/remove_member sequence runs inside handle_info/2 before
+    # it replies), so the sync call above already means the repair is done
+    # by the time this call returns too.
+    :erpc.call(leader_node, :erlang, :send, [Riptide.Stream.ReplicaHealer, :sweep])
+    :erpc.call(leader_node, :sys, :get_state, [Riptide.Stream.ReplicaHealer, 30_000])
+
+    repaired_nodes = :erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])
+    assert length(repaired_nodes) == 3
+    refute node_c in repaired_nodes
+    assert node_a in repaired_nodes
+    assert node_b in repaired_nodes
+
+    [new_node] = repaired_nodes -- [node_a, node_b]
+
+    # No data loss, and no over-replication: exactly one real repair
+    # happened, driven only by the leader.
+    assert :erpc.call(new_node, Riptide.RaCluster, :server_alive?, [
+             String.to_atom(:erpc.call(node_a, Riptide.RaCluster, :uid_for, [stream_id]))
+           ])
+
+    assert :ok = :erpc.call(new_node, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+
+    {:ok, read_back} =
+      :erpc.call(new_node, Riptide.Stream.StreamServer, :get_since, [stream_id, 0])
+
+    assert [%{sequence: 1}] = read_back
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    try do
+      :peer.stop(pid)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+
+    :erlang.spawn(node, fn ->
+      result = apply(mod, fun, args)
+      send(parent, {:start_unlinked_result, result})
+      Process.sleep(:infinity)
+    end)
+
+    receive do
+      {:start_unlinked_result, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  # Like `eventually/2` but returns whichever candidate first satisfies
+  # `pred`, or `nil` if none does within the retry budget — used here to
+  # find the placement cluster's actual leader among the 2 survivors.
+  defp eventually_find(candidates, pred, attempts_left \\ 50) do
+    case Enum.find(candidates, pred) do
+      nil when attempts_left > 1 ->
+        Process.sleep(200)
+        eventually_find(candidates, pred, attempts_left - 1)
+
+      found ->
+        found
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end

--- a/test/riptide/stream/replica_healer_retention_test.exs
+++ b/test/riptide/stream/replica_healer_retention_test.exs
@@ -1,0 +1,229 @@
+defmodule Riptide.Stream.ReplicaHealerRetentionTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 60_000
+
+  # Reproduces finding 1 from the Phase 3d-ii final review: `ReplicaHealer`
+  # used to hardcode `retention: :infinity` for the JOINING replacement
+  # member's machine config, regardless of the stream's actual retention —
+  # silently diverging a repaired replica from its peers for any
+  # finite-retention stream with too few events to have snapshotted yet
+  # (`RaMachine`'s own `min_snapshot_interval` default is 4096 entries). This
+  # test forms a real finite-retention stream cluster directly via
+  # `RaCluster.start_or_join_replicated/3` (bypassing
+  # `Riptide.Stream.StreamSupervisor.ensure_ready/1`, which today always
+  # hardcodes `:infinity` itself — a separate, pre-existing limitation the
+  # finding notes is why this exact gap isn't yet reachable in production;
+  # see that finding's own text), kills a replica, runs the healer's real
+  # repair, and asserts the joined replacement's local machine state carries
+  # the *real* retention, not `:infinity`.
+  @peers [
+    {:ret_a, "riptide-0", ~c"127.0.0.60"},
+    {:ret_b, "riptide-1", ~c"127.0.0.61"},
+    {:ret_c, "riptide-2", ~c"127.0.0.62"}
+  ]
+
+  @replacement {:ret_d, "healer-retention-d", ~c"127.0.0.63"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"replica_healer_retention_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "a repaired replica of a finite-retention stream is joined with its stream's real retention, not :infinity" do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+    all_specs = @peers ++ [@replacement]
+
+    peers =
+      for {alive_name, ordinal, host} <- all_specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, fn {pid, _node, _ordinal} ->
+        if Process.alive?(pid) do
+          try do
+            :peer.stop(pid)
+          catch
+            :exit, _ -> :ok
+          end
+        end
+      end)
+
+      Enum.each(all_specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"replica_healer_retention_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+    ordinal_to_node = Map.new(peers, fn {_pid, node, ordinal} -> {ordinal, node} end)
+    resolve_fun = fn ordinal -> Map.fetch!(ordinal_to_node, ordinal) end
+
+    for {_pid, node, _ordinal} <- peers do
+      :erpc.call(node, Application, :put_env, [:riptide, :ordinal_resolver, resolve_fun])
+    end
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}, {_pid_d, _node_d, _}] = peers
+    placement_peers = Enum.take(peers, 3)
+
+    results =
+      Enum.map(placement_peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :attempt_start_placement_cluster, [resolve_fun])
+      end)
+
+    assert Enum.any?(results, &(&1 == :ok))
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+
+      {:ok, _} =
+        start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+    end
+
+    stream_id = "healer-retention-" <> Uniq.UUID.uuid4()
+    original_nodes = [node_a, node_b, node_c]
+
+    assert Enum.sort(:erpc.call(node_a, Riptide.Placement, :assign, [stream_id, original_nodes])) ==
+             Enum.sort(original_nodes)
+
+    uid = :erpc.call(node_a, Riptide.RaCluster, :uid_for, [stream_id])
+    # A real, finite retention — deliberately NOT :infinity, and small enough
+    # that no snapshot will ever fire (RaMachine's min_snapshot_interval
+    # default is 4096 entries), so a repaired replica can only recover the
+    # right retention by discovering it live, never by inheriting it from a
+    # snapshot.
+    machine = {:module, Riptide.Stream.RaMachine, %{retention: 3}}
+
+    assert {:ok, _server_ids} =
+             :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+               uid,
+               original_nodes,
+               machine
+             ])
+
+    name = String.to_atom(uid)
+
+    # Kill node_c for real — the replica being replaced.
+    stop_peer_for(peers, node_c)
+
+    assert eventually(fn ->
+             :erpc.call(node_a, Riptide.Stream.ReplicaHealer, :sweep, []) == :ok and
+               Enum.sort(:erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])) !=
+                 Enum.sort(original_nodes)
+           end)
+
+    repaired_nodes = :erpc.call(node_a, Riptide.Placement, :lookup, [stream_id])
+    [new_node] = repaired_nodes -- [node_a, node_b]
+
+    assert :erpc.call(new_node, Riptide.RaCluster, :server_alive?, [name])
+
+    # The real assertion for finding 1: the joined replacement's own LOCAL
+    # machine state carries the stream's REAL retention (3), not the
+    # previously-hardcoded :infinity. Deliberately `local_query/2`, not
+    # `consistent_query/2` — `consistent_query/2` always answers via
+    # whichever node is the current Raft LEADER (per its own moduledoc),
+    # so it can't observe a divergence in one specific follower's own local
+    # state; `local_query/2` reads that exact node's possibly-stale/diverged
+    # state directly, which is the whole point of this test.
+    retention =
+      :erpc.call(new_node, Riptide.RaCluster, :local_query, [
+        {name, new_node},
+        &Map.get(&1, :retention)
+      ])
+
+    assert retention == 3
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    try do
+      :peer.stop(pid)
+    catch
+      :exit, _ -> :ok
+    end
+  end
+
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+
+    :erlang.spawn(node, fn ->
+      result = apply(mod, fun, args)
+      send(parent, {:start_unlinked_result, result})
+      Process.sleep(:infinity)
+    end)
+
+    receive do
+      {:start_unlinked_result, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() ->
+        true
+
+      attempts_left <= 1 ->
+        false
+
+      true ->
+        Process.sleep(200)
+        eventually(fun, attempts_left - 1)
+    end
+  end
+
+  defp unique_pairs(list) do
+    for {a, i} <- Enum.with_index(list),
+        {b, j} <- Enum.with_index(list),
+        i < j,
+        do: {a, b}
+  end
+end

--- a/test/riptide/stream/replica_healer_test.exs
+++ b/test/riptide/stream/replica_healer_test.exs
@@ -16,5 +16,45 @@ defmodule Riptide.Stream.ReplicaHealerTest do
     test "returns nil when there are no live candidate nodes at all" do
       assert ReplicaHealer.pick_replacement([:a, :b], []) == nil
     end
+
+    test "two different racing callers converge on the same pick once each includes its own identity" do
+      # Simulates the actual race this function exists to close: two DIFFERENT
+      # placement ordinals (e.g. :c and :d) retry the very same repair across
+      # a leadership handoff (finding 3). Each one's raw `Node.list()` excludes
+      # only ITSELF, so caller :c's raw view is `full_fleet -- [:c]` and caller
+      # :d's raw view is `full_fleet -- [:d]` -- two DIFFERENT sets ({a,b,d} vs
+      # {a,b,c}), which is exactly the asymmetry that broke determinism. The
+      # fix is prepending each caller's own identity back on
+      # (`[node() | Node.list()]`), simulated explicitly here as
+      # `[caller | full_fleet -- [caller]]`: once BOTH callers do that, both
+      # end up looking at the identical full fleet (just reordered), so
+      # `pick_replacement/2`'s existing sort-then-take-first logic is
+      # guaranteed to compute the same candidate for either one.
+      current_nodes = [:a, :b]
+      full_fleet = [:a, :b, :c, :d]
+
+      caller_c_view = [:c | full_fleet -- [:c]]
+      caller_d_view = [:d | full_fleet -- [:d]]
+
+      assert Enum.sort(caller_c_view) == Enum.sort(full_fleet)
+      assert Enum.sort(caller_d_view) == Enum.sort(full_fleet)
+
+      assert ReplicaHealer.pick_replacement(current_nodes, caller_c_view) ==
+               ReplicaHealer.pick_replacement(current_nodes, caller_d_view)
+    end
+
+    test "default live_nodes includes this node's own identity, not just Node.list()" do
+      # `Node.list()` never includes the calling node itself, so setting
+      # `current_nodes` to exactly what THIS node currently sees as its live
+      # peers means node() is, by construction, the one candidate a correct
+      # default must still find -- it can only come from the default itself
+      # adding the caller's own identity back in (`[node() | Node.list()]`),
+      # not from `live_nodes` alone. Before the fix (bare `Node.list()` as
+      # the default), `live_nodes` would equal `current_nodes` exactly here,
+      # so the candidate set would be empty and this would return `nil`
+      # instead of `node()`.
+      current_nodes = Node.list()
+      assert ReplicaHealer.pick_replacement(current_nodes) == node()
+    end
   end
 end

--- a/test/riptide/stream/replica_healer_test.exs
+++ b/test/riptide/stream/replica_healer_test.exs
@@ -1,0 +1,20 @@
+defmodule Riptide.Stream.ReplicaHealerTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Stream.ReplicaHealer
+
+  describe "pick_replacement/2" do
+    test "picks a live node not already among the current members" do
+      result = ReplicaHealer.pick_replacement([:a, :b], [:a, :b, :c, :d])
+      assert result in [:c, :d]
+    end
+
+    test "returns nil when every live node is already a current member" do
+      assert ReplicaHealer.pick_replacement([:a, :b, :c], [:a, :b, :c]) == nil
+    end
+
+    test "returns nil when there are no live candidate nodes at all" do
+      assert ReplicaHealer.pick_replacement([:a, :b], []) == nil
+    end
+  end
+end

--- a/test/riptide/stream/stream_placement_cluster_test.exs
+++ b/test/riptide/stream/stream_placement_cluster_test.exs
@@ -132,8 +132,8 @@ defmodule Riptide.Stream.StreamPlacementClusterTest do
     start_ra_application(peers)
     start_ra_systems(peers)
     bootstrap_placement_cluster(peers, resolve_fun)
-    start_placement_server(peers)
     start_pubsub(peers)
+    start_placement_server(peers)
 
     {peers, nodes, resolve_fun}
   end

--- a/test/riptide/stream/stream_supervisor_test.exs
+++ b/test/riptide/stream/stream_supervisor_test.exs
@@ -35,4 +35,29 @@ defmodule Riptide.Stream.StreamSupervisorTest do
     {:ok, events_b} = StreamServer.get_since(stream_b, 0)
     assert events_b == []
   end
+
+  test "the local cache is corrected when a stream_placement_changed PubSub message arrives" do
+    stream_id = "stream-#{System.unique_integer([:positive])}"
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+    assert StreamSupervisor.ensure_ready(stream_id) == :ok
+    uid = Riptide.RaCluster.uid_for(stream_id)
+    original_server_ids = Riptide.Stream.Placement.server_ids!(stream_id)
+    assert original_server_ids == [{String.to_atom(uid), node()}]
+
+    fake_new_node = :"fake-replacement@nowhere"
+
+    Phoenix.PubSub.broadcast(
+      Riptide.PubSub,
+      "stream_placement_changed",
+      {:stream_placement_changed, stream_id, [fake_new_node]}
+    )
+
+    # PubSub delivery is async even within one BEAM — poll briefly rather
+    # than asserting immediately.
+    assert Enum.any?(1..20, fn _ ->
+             Process.sleep(10)
+             Riptide.Stream.Placement.server_ids!(stream_id) == [{String.to_atom(uid), fake_new_node}]
+           end)
+  end
 end

--- a/test/riptide/stream/stream_supervisor_test.exs
+++ b/test/riptide/stream/stream_supervisor_test.exs
@@ -2,7 +2,7 @@ defmodule Riptide.Stream.StreamSupervisorTest do
   use ExUnit.Case, async: true
 
   alias Riptide.Event
-  alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias Riptide.Stream.{Placement, StreamServer, StreamSupervisor}
 
   test "ensure_ready/1 returns :ok for an unseen stream id" do
     stream_id = "stream-#{System.unique_integer([:positive])}"
@@ -42,7 +42,7 @@ defmodule Riptide.Stream.StreamSupervisorTest do
 
     assert StreamSupervisor.ensure_ready(stream_id) == :ok
     uid = Riptide.RaCluster.uid_for(stream_id)
-    original_server_ids = Riptide.Stream.Placement.server_ids!(stream_id)
+    original_server_ids = Placement.server_ids!(stream_id)
     assert original_server_ids == [{String.to_atom(uid), node()}]
 
     fake_new_node = :"fake-replacement@nowhere"
@@ -57,7 +57,10 @@ defmodule Riptide.Stream.StreamSupervisorTest do
     # than asserting immediately.
     assert Enum.any?(1..20, fn _ ->
              Process.sleep(10)
-             Riptide.Stream.Placement.server_ids!(stream_id) == [{String.to_atom(uid), fake_new_node}]
+
+             Placement.server_ids!(stream_id) == [
+               {String.to_atom(uid), fake_new_node}
+             ]
            end)
   end
 end

--- a/test/riptide_web/routing_cluster_test.exs
+++ b/test/riptide_web/routing_cluster_test.exs
@@ -110,14 +110,14 @@ defmodule RiptideWeb.RoutingClusterTest do
     assert Enum.any?(results, &(&1 == :ok))
 
     for {_pid, node, _ordinal} <- peers do
-      {:ok, _pid} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
-    end
-
-    for {_pid, node, _ordinal} <- peers do
       {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
 
       {:ok, _pid} =
         start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _pid} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
     end
 
     {_pid, entry_node, _ordinal} = hd(peers)


### PR DESCRIPTION
## Summary

Implements Phase 3d-ii: fully automatic, zero-operator-action repair of a stream's replica set after a member's node identity drifts (every pod restart in this fleet gets a fresh IP-based `node()` identity, so this is the normal steady state, not a rare failure).

- New `Riptide.Stream.ReplicaHealer` GenServer, running only on the 3 placement ordinals, ticks on a 30s timer. Only the placement cluster's current Raft leader acts (reusing its existing leader election — no new coordination primitive), listing every known stream and checking real replica liveness.
- For a stream with exactly one dead member: discovers its real current retention from a live survivor, picks a deterministic replacement, joins it into the stream's real `:ra` cluster (`RaCluster.replace_member/5`), evicts the dead member, updates the durable placement record, and broadcasts a PubSub invalidation so no node's cache keeps routing to the dead replica.
- `RaCluster.replace_member/5` self-corrects on partial-failure retries (mirrors this codebase's existing "self-correct on redundant call" idiom), so a crash mid-repair converges cleanly on the next sweep instead of getting stuck or over-replicating.
- Live-proved against a real 5-pod GKE StatefulSet (RF=3): a force-killed replica pod was automatically replaced with zero operator action and zero data loss.

Full design: `docs/superpowers/specs/2026-08-25-phase-3d-ii-replica-healing-design.md`. Full plan: `docs/superpowers/plans/2026-08-25-phase-3d-ii-replica-healing.md`.

Built via subagent-driven development (9 tasks, each with its own implementer + independent task review), followed by a final whole-branch review that caught a real Critical bug (retention hardcoded to `:infinity`, which would have silently diverged a finite-retention stream's replicas — not reachable today since an earlier phase already hardcodes the same value on the only production call path, but fixed properly), a genuinely missing spec-mandated test (leadership-gating), and a subtle cross-node determinism bug in the replacement-selection logic (fixed in a follow-up round, independently re-verified).

## Test plan

- [x] `mix test` — 135 tests, 0 failures
- [x] `mix credo --strict` clean
- [x] `mix format --check-formatted` clean
- [x] Real multi-node `:peer`-based tests: replica replacement primitive, self-correction on partial failure, leadership-gating, end-to-end automatic repair
- [x] Live proof against a real 5-pod GKE StatefulSet (RF=3): killed a replica pod, confirmed automatic repair with no operator action and no data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)