### PR TITLE
Fix: reject tokens with explicit null exp/iss/aud

### DIFF
--- a/lib/riptide/auth/token_config.ex
+++ b/lib/riptide/auth/token_config.ex
@@ -28,9 +28,20 @@ defmodule Riptide.Auth.TokenConfig do
   claim key show up in the token at all. Left alone, this means a validly
   signed token that simply omits `exp`, `iss`, or `aud` would skip that
   claim's check entirely and be accepted. `verify_and_validate_required_claims/1`
-  closes that gap by requiring all three to be present, on top of whatever
-  `verify_and_validate/1` (Joken.Config's own generated function) already
-  checks for claims that are present.
+  closes that gap by requiring all three to be present *and non-null*, on
+  top of whatever `verify_and_validate/1` (Joken.Config's own generated
+  function) already checks for claims that are present.
+
+  The non-null part matters on its own: a token with an explicit `"exp":
+  null` (present, not omitted) still passes Joken's own default `exp`
+  validator (`&(&1 > current_time())`) — `nil > <integer>` evaluates `true`
+  under Erlang/Elixir term ordering (atoms sort above numbers), so a null
+  `exp` reads as "never expires" instead of failing outright. `iss`/`aud`'s
+  own validators here are equality/membership checks, so a null value
+  already fails those correctly (`nil == "some-issuer"` is `false`) — `exp`
+  is the only one of the three with this specific gap, but the presence
+  check below treats all three claims uniformly (require present and
+  non-null) rather than special-casing just `exp`.
   """
   use Joken.Config
 
@@ -46,9 +57,10 @@ defmodule Riptide.Auth.TokenConfig do
   end
 
   @doc """
-  Same as the generated `verify_and_validate/1`, plus an explicit presence
-  check for `exp`/`iss`/`aud` — see the "Required claims" section above for
-  why that check can't just live inside `token_config/0`'s claim validators.
+  Same as the generated `verify_and_validate/1`, plus an explicit
+  present-and-non-null check for `exp`/`iss`/`aud` — see the "Required
+  claims" section above for why that check can't just live inside
+  `token_config/0`'s claim validators.
   """
   @spec verify_and_validate_required_claims(Joken.bearer_token()) ::
           {:ok, Joken.claims()} | {:error, Joken.error_reason()}
@@ -59,7 +71,7 @@ defmodule Riptide.Auth.TokenConfig do
   end
 
   defp require_claims(claims) do
-    case Enum.filter(@required_claims, &(not Map.has_key?(claims, &1))) do
+    case Enum.filter(@required_claims, &is_nil(Map.get(claims, &1))) do
       [] -> {:ok, claims}
       missing -> {:error, {:missing_claims, missing}}
     end

--- a/test/riptide/auth/verifier/oidc_test.exs
+++ b/test/riptide/auth/verifier/oidc_test.exs
@@ -131,4 +131,16 @@ defmodule Riptide.Auth.Verifier.OIDCTest do
   test "rejects a validly-signed token that omits aud entirely", %{signer: signer} do
     assert {:error, _reason} = Verifier.OIDC.verify(token_missing("aud", signer))
   end
+
+  # Regression test: `"exp": null` (present, not omitted) previously passed
+  # Joken's default `exp` validator (`&(&1 > current_time())`) because
+  # `nil > <integer>` evaluates `true` under Erlang/Elixir term ordering,
+  # and the presence check added for the "omits entirely" cases above only
+  # checked `Map.has_key?/2`, which is also `true` for a key present with a
+  # `nil` value.
+  test "rejects a token with an explicit null exp instead of treating it as never-expiring", %{
+    signer: signer
+  } do
+    assert {:error, _reason} = Verifier.OIDC.verify(token(%{"exp" => nil}, signer))
+  end
 end


### PR DESCRIPTION
## Summary
- Closes a residual finding parked during Phase 4b's final review (PR #25): a validly-signed token with an explicit `"exp": null` (present, not omitted) was accepted as never-expiring, because `nil > <integer>` evaluates `true` under Erlang/Elixir term ordering, and the required-claims presence check used `Map.has_key?/2`, which is also `true` for a null-valued key.
- Fix: `require_claims/1` now checks `is_nil(Map.get(claims, key))`, treating "missing" and "present-but-null" the same way for all three required claims (`exp`/`iss`/`aud`).

## Test plan
- [x] New regression test: a token with an explicit `"exp": null` is rejected (confirmed it fails without the fix, passes with it)
- [x] Full suite: 175 tests, 0 failures
- [x] `mix credo --strict` / `mix format --check-formatted`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)