### PR TITLE
Phase 4c: Authorization (ACP-inspired subset)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -327,10 +327,25 @@ sub-project 3 was decomposed into phases 3a-3d.
   since Phoenix deliberately doesn't expose the raw `Authorization` header to `Socket.connect/3`.
   Live-proved end-to-end against a real, disposable `oidc-provider`-based OIDC issuer. No
   authorization/enforcement yet — that's Phase 4c.
-- **Phase 4c — Authorization (ACP).** Not yet designed.
+- **Phase 4c — Authorization (ACP).** **Shipped 2026-08-26** — see
+  `docs/superpowers/specs/2026-08-26-phase-4c-authorization-design.md`. An ACP-inspired policy
+  model (`Riptide.Authz.Policy`: `effect: :allow | :deny`, `modes: [:read | :write]`, `matcher:
+  :public | :authenticated | {:agent, subject}`), evaluated with container-level inheritance and
+  deny-overrides-allow, enforced across all 3 transports (a new `RiptideWeb.Plugs.Authorize` for
+  LDP HTTP; direct `Riptide.Authz.evaluate/4` calls from SSE and the WebSocket channel after
+  recovering tenant/path from an opaque `stream_id` via a new `parse_stream_id/1`). Default-deny,
+  with an implicit bootstrap: the first authenticated write to a policy-less tenant atomically
+  claims tenant-root ownership (`Riptide.Authz.Store.claim_tenant_if_unclaimed/2`), so no separate
+  tenant registry is needed. Policies persist via the *existing* shared placement Ra cluster
+  (`Riptide.Placement.PlacementMachine` gained `policies` state alongside its original `streams`
+  state) rather than a second Ra cluster to operate. A minimal, tenant-root-only policy management
+  API (`POST`/`GET /tenants/:tenant_id/policies`) lets an owner grant other agents access. Not
+  full Solid ACP compliance — no Access Control Resources as discoverable resources, no
+  client/VC/issuer matchers, no `Control` mode, no policy revocation yet; see the design spec §3
+  for the complete list of deliberate omissions.
 - **Phase 4d — TLS.** Not yet designed.
 
-**Status**: Phases 4a-4b shipped 2026-08-26. Phases 4c-4d not yet designed.
+**Status**: Phases 4a-4c shipped 2026-08-26. Phase 4d not yet designed.
 
 ## 5. Not yet started
 

--- a/lib/riptide/authz.ex
+++ b/lib/riptide/authz.ex
@@ -1,0 +1,47 @@
+defmodule Riptide.Authz do
+  @moduledoc """
+  Transport-agnostic authorization decision point — called identically from
+  `RiptideWeb.Plugs.Authorize` (LDP HTTP), `RiptideWeb.Realtime.SseController`,
+  and `RiptideWeb.Realtime.ReplicationChannel` (Tasks 4, 7, 8), the same way
+  `Riptide.Auth.Verifier`'s `verify/1` is called identically from
+  `RiptideWeb.Plugs.Authenticate` and `RiptideWeb.Realtime.Socket.connect/3`
+  (Phase 4b). See the Phase 4c design spec §5 for the algorithm this
+  implements.
+  """
+
+  alias Riptide.Authz.Policy
+
+  @spec evaluate(String.t(), [String.t()], map() | nil, Policy.mode()) :: :allow | :deny
+  def evaluate(tenant_id, path_segments, current_subject, mode) do
+    store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
+
+    matching_policies =
+      path_segments
+      |> prefixes()
+      |> Enum.flat_map(&store.list_policies(tenant_id, &1))
+      |> Enum.filter(&applies?(&1, current_subject, mode))
+
+    cond do
+      Enum.any?(matching_policies, &(&1.effect == :deny)) -> :deny
+      Enum.any?(matching_policies, &(&1.effect == :allow)) -> :allow
+      true -> :deny
+    end
+  end
+
+  # Every prefix of path_segments, including the empty one (the tenant
+  # root): for ["docs", "sub"] this is [[], ["docs"], ["docs", "sub"]] — an
+  # ancestor container's policies apply to everything under it.
+  defp prefixes(path_segments) do
+    Enum.map(0..length(path_segments), &Enum.take(path_segments, &1))
+  end
+
+  defp applies?(%Policy{matcher: matcher, modes: modes}, current_subject, mode) do
+    mode in modes and matches?(matcher, current_subject)
+  end
+
+  defp matches?(:public, _current_subject), do: true
+  defp matches?(:authenticated, current_subject), do: not is_nil(current_subject)
+
+  defp matches?({:agent, subject}, current_subject),
+    do: not is_nil(current_subject) and current_subject["sub"] == subject
+end

--- a/lib/riptide/authz/policy.ex
+++ b/lib/riptide/authz/policy.ex
@@ -1,0 +1,18 @@
+defmodule Riptide.Authz.Policy do
+  @moduledoc """
+  One ACP-inspired access policy: grants (`effect: :allow`) or denies
+  (`effect: :deny`) some set of `modes` to whoever `matcher` matches. See
+  `Riptide.Authz.evaluate/4` for how a set of policies attached to a
+  resource's ancestor path prefixes is combined into a single allow/deny
+  decision (deny always overrides allow).
+  """
+
+  @type effect :: :allow | :deny
+  @type mode :: :read | :write
+  @type matcher :: :public | :authenticated | {:agent, String.t()}
+
+  @type t :: %__MODULE__{effect: effect(), modes: [mode()], matcher: matcher()}
+
+  @enforce_keys [:effect, :modes, :matcher]
+  defstruct [:effect, :modes, :matcher]
+end

--- a/lib/riptide/authz/store.ex
+++ b/lib/riptide/authz/store.ex
@@ -1,0 +1,16 @@
+defmodule Riptide.Authz.Store do
+  @moduledoc """
+  Behaviour for where `Riptide.Authz.Policy` structs are persisted. Selected
+  via `Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)`
+  — the same config-driven swap `Riptide.Auth.Verifier`/`Riptide.Tenancy.Resolver`
+  already use (Phases 3c-i/4a/4b), so tests can inject a fake store the same
+  way `config/test.exs` overrides the ordinal resolver.
+  """
+
+  alias Riptide.Authz.Policy
+
+  @callback list_policies(tenant_id :: String.t(), path_prefix :: [String.t()]) :: [Policy.t()]
+  @callback add_policy(tenant_id :: String.t(), path_prefix :: [String.t()], Policy.t()) :: :ok
+  @callback claim_tenant_if_unclaimed(tenant_id :: String.t(), subject :: String.t()) ::
+              :claimed | :already_claimed
+end

--- a/lib/riptide/authz/store/placement.ex
+++ b/lib/riptide/authz/store/placement.ex
@@ -1,0 +1,22 @@
+defmodule Riptide.Authz.Store.Placement do
+  @moduledoc """
+  Default `Riptide.Authz.Store` implementation — persists policies through
+  the existing shared placement Ra cluster (`Riptide.Placement`), rather
+  than a second Ra cluster to bootstrap and operate (see Phase 4c design
+  spec §4).
+  """
+  @behaviour Riptide.Authz.Store
+
+  alias Riptide.Placement
+
+  @impl true
+  def list_policies(tenant_id, path_prefix), do: Placement.list_policies(tenant_id, path_prefix)
+
+  @impl true
+  def add_policy(tenant_id, path_prefix, policy),
+    do: Placement.add_policy(tenant_id, path_prefix, policy)
+
+  @impl true
+  def claim_tenant_if_unclaimed(tenant_id, subject),
+    do: Placement.claim_tenant_if_unclaimed(tenant_id, subject)
+end

--- a/lib/riptide/placement.ex
+++ b/lib/riptide/placement.ex
@@ -72,6 +72,43 @@ defmodule Riptide.Placement do
     end)
   end
 
+  @spec add_policy(String.t(), [String.t()], Riptide.Authz.Policy.t(), (String.t() -> node())) ::
+          :ok
+  def add_policy(
+        tenant_id,
+        path_prefix,
+        policy,
+        resolve_fun \\ &RaCluster.default_ordinal_resolver/1
+      ) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(server_id, {:add_policy, tenant_id, path_prefix, policy})
+    end)
+  end
+
+  @spec list_policies(String.t(), [String.t()], (String.t() -> node())) :: [
+          Riptide.Authz.Policy.t()
+        ]
+  def list_policies(tenant_id, path_prefix, resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.consistent_query(
+        server_id,
+        &PlacementMachine.list_policies(&1, tenant_id, path_prefix)
+      )
+    end)
+  end
+
+  @spec claim_tenant_if_unclaimed(String.t(), String.t(), (String.t() -> node())) ::
+          :claimed | :already_claimed
+  def claim_tenant_if_unclaimed(
+        tenant_id,
+        subject,
+        resolve_fun \\ &RaCluster.default_ordinal_resolver/1
+      ) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(server_id, {:claim_tenant_if_unclaimed, tenant_id, subject})
+    end)
+  end
+
   # Tries each placement ordinal, in `RaCluster.placement_ordinals/0`'s own
   # fixed order, until one of them answers — `RaCluster.process_command/2`
   # and `consistent_query/2` both raise on failure/timeout (see their own

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -2,17 +2,36 @@ defmodule Riptide.Placement.PlacementMachine do
   @moduledoc """
   The `:ra_machine` for Riptide's placement metadata cluster — a small,
   fixed-membership Ra cluster (see `Riptide.RaCluster.placement_server_id/1,2`)
-  recording which nodes host each stream's Ra replicas. Pure and process-free
-  by design, mirroring `Riptide.Stream.RaMachine`: `init/1`/`apply/3` are the
-  only functions Ra itself calls; `get/2` is a plain query function run via
-  `Riptide.RaCluster.consistent_query/2`.
+  recording which nodes host each stream's Ra replicas, plus (Phase 4c)
+  authorization policies. Pure and process-free by design, mirroring
+  `Riptide.Stream.RaMachine`: `init/1`/`apply/3` are the only functions Ra
+  itself calls; `get/2`/`list/1`/`list_policies/3` are plain query functions
+  run via `Riptide.RaCluster.consistent_query/2`.
+
+  Internal state is `%{streams: %{stream_id() => [node()]}, policies:
+  %{tenant_id() => %{path_prefix() => [policy()]}}}` — two independent
+  namespaces in one already-hardened, already-bootstrapped Ra cluster,
+  rather than a second cluster to operate. `list/1`'s own external contract
+  is deliberately unchanged (`%{stream_id() => [node()]}` only): it backs
+  `Riptide.Placement.list_all/1`, which `Riptide.Stream.ReplicaHealer.sweep/0`
+  iterates expecting *only* `{stream_id, nodes}` entries — mixing a policies
+  key into that same flat map would make the healer call
+  `RaCluster.uid_for/1` on a non-stream-id key and crash its next sweep.
   """
   @behaviour :ra_machine
 
-  @type state :: %{String.t() => [node()]}
+  @type stream_id :: String.t()
+  @type tenant_id :: String.t()
+  @type path_prefix :: [String.t()]
+  @type policy :: struct()
+
+  @type state :: %{
+          streams: %{stream_id() => [node()]},
+          policies: %{tenant_id() => %{path_prefix() => [policy()]}}
+        }
 
   @impl :ra_machine
-  def init(_config), do: %{}
+  def init(_config), do: %{streams: %{}, policies: %{}}
 
   # Idempotent by construction — see Phase 3c-i design spec §4. Since every
   # command is serialized through Raft consensus, whichever proposal for a
@@ -22,12 +41,12 @@ defmodule Riptide.Placement.PlacementMachine do
   # This makes concurrent stream-creation races safe with no extra locking.
   @impl :ra_machine
   def apply(_meta, {:assign, stream_id, proposed_nodes}, state) do
-    case Map.fetch(state, stream_id) do
+    case Map.fetch(state.streams, stream_id) do
       {:ok, existing_nodes} ->
         {state, existing_nodes, []}
 
       :error ->
-        new_state = Map.put(state, stream_id, proposed_nodes)
+        new_state = put_in(state, [:streams, stream_id], proposed_nodes)
         {new_state, proposed_nodes, []}
     end
   end
@@ -39,11 +58,11 @@ defmodule Riptide.Placement.PlacementMachine do
   # than erroring — safe to call redundantly from a racing leader.
   @impl :ra_machine
   def apply(_meta, {:replace_member, stream_id, dead_node, new_node}, state) do
-    case Map.fetch(state, stream_id) do
+    case Map.fetch(state.streams, stream_id) do
       {:ok, nodes} ->
         if dead_node in nodes do
           new_nodes = replace_in_list(nodes, dead_node, new_node)
-          new_state = Map.put(state, stream_id, new_nodes)
+          new_state = put_in(state, [:streams, stream_id], new_nodes)
           {new_state, new_nodes, []}
         else
           {state, nodes, []}
@@ -58,11 +77,18 @@ defmodule Riptide.Placement.PlacementMachine do
     Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
   end
 
-  @spec get(state(), String.t()) :: [node()] | nil
+  @spec get(state(), stream_id()) :: [node()] | nil
   def get(state, stream_id) do
-    Map.get(state, stream_id)
+    Map.get(state.streams, stream_id)
   end
 
-  @spec list(state()) :: state()
-  def list(state), do: state
+  @spec list(state()) :: %{stream_id() => [node()]}
+  def list(state), do: state.streams
+
+  @spec list_policies(state(), tenant_id(), path_prefix()) :: [policy()]
+  def list_policies(state, tenant_id, path_prefix) do
+    state.policies
+    |> Map.get(tenant_id, %{})
+    |> Map.get(path_prefix, [])
+  end
 end

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -77,6 +77,48 @@ defmodule Riptide.Placement.PlacementMachine do
     Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
   end
 
+  # Same idempotent-by-construction shape as {:assign, ...}: every command is
+  # serialized through Raft, so concurrent `add_policy` calls for the same
+  # tenant/prefix are safely ordered by the log rather than racing.
+  @impl :ra_machine
+  def apply(_meta, {:add_policy, tenant_id, path_prefix, policy}, state) do
+    existing = state.policies |> Map.get(tenant_id, %{}) |> Map.get(path_prefix, [])
+
+    new_state =
+      put_in(state, [:policies, Access.key(tenant_id, %{}), path_prefix], existing ++ [policy])
+
+    {new_state, :ok, []}
+  end
+
+  # A tenant is "unclaimed" if it has zero policies at every path prefix —
+  # see the Phase 4c design spec §6. This must be a single Ra command (not a
+  # separate list-then-add pair of calls from the caller) so that two
+  # different agents racing to claim the same brand-new tenant resolve to
+  # exactly one winner, the same way `{:assign, ...}`'s own idempotency
+  # relies on Raft's log ordering rather than a caller-side check-then-act.
+  @impl :ra_machine
+  def apply(_meta, {:claim_tenant_if_unclaimed, tenant_id, subject}, state) do
+    if tenant_claimed?(state, tenant_id) do
+      {state, :already_claimed, []}
+    else
+      owner_policy = %Riptide.Authz.Policy{
+        effect: :allow,
+        modes: [:read, :write],
+        matcher: {:agent, subject}
+      }
+
+      new_state = put_in(state, [:policies, tenant_id], %{[] => [owner_policy]})
+      {new_state, :claimed, []}
+    end
+  end
+
+  defp tenant_claimed?(state, tenant_id) do
+    state.policies
+    |> Map.get(tenant_id, %{})
+    |> Map.values()
+    |> Enum.any?(&(&1 != []))
+  end
+
   @spec get(state(), stream_id()) :: [node()] | nil
   def get(state, stream_id) do
     Map.get(state.streams, stream_id)

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -73,10 +73,6 @@ defmodule Riptide.Placement.PlacementMachine do
     end
   end
 
-  defp replace_in_list(nodes, dead_node, new_node) do
-    Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
-  end
-
   # Same idempotent-by-construction shape as {:assign, ...}: every command is
   # serialized through Raft, so concurrent `add_policy` calls for the same
   # tenant/prefix are safely ordered by the log rather than racing.
@@ -110,6 +106,10 @@ defmodule Riptide.Placement.PlacementMachine do
       new_state = put_in(state, [:policies, tenant_id], %{[] => [owner_policy]})
       {new_state, :claimed, []}
     end
+  end
+
+  defp replace_in_list(nodes, dead_node, new_node) do
+    Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
   end
 
   defp tenant_claimed?(state, tenant_id) do

--- a/lib/riptide_web/authz/policy_controller.ex
+++ b/lib/riptide_web/authz/policy_controller.ex
@@ -9,7 +9,7 @@ defmodule RiptideWeb.Authz.PolicyController do
   holds is what's required to manage policies here, since this phase has no
   separate `Control` mode.
   """
-  use Phoenix.Controller
+  use Phoenix.Controller, formats: [:json]
 
   alias Riptide.Authz.Policy
 

--- a/lib/riptide_web/authz/policy_controller.ex
+++ b/lib/riptide_web/authz/policy_controller.ex
@@ -1,0 +1,85 @@
+defmodule RiptideWeb.Authz.PolicyController do
+  @moduledoc """
+  Minimal policy management API — `POST`/`GET /tenants/:tenant_id/policies`,
+  scoped to tenant-root policies only (see the Phase 4c design spec §8).
+  Gated by the same `:tenant`/`:auth`/`:authz` pipeline as the LDP resource
+  routes: `Authorize` maps `POST` to `:write` and `GET` to `:read`, with
+  `path_segments` defaulting to `[]` (the tenant root) since these routes
+  have no `*path` glob — the same permission the bootstrap owner already
+  holds is what's required to manage policies here, since this phase has no
+  separate `Control` mode.
+  """
+  use Phoenix.Controller
+
+  alias Riptide.Authz.Policy
+
+  def create(conn, params) do
+    tenant_id = conn.assigns.tenant_id
+    store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
+
+    case policy_from_params(params) do
+      {:ok, policy} ->
+        :ok = store.add_policy(tenant_id, [], policy)
+        send_resp(conn, 201, "")
+
+      :error ->
+        send_resp(conn, 400, "")
+    end
+  end
+
+  def index(conn, _params) do
+    tenant_id = conn.assigns.tenant_id
+    store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
+    policies = store.list_policies(tenant_id, [])
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Jason.encode!(Enum.map(policies, &policy_to_map/1)))
+  end
+
+  defp policy_from_params(%{"effect" => effect, "modes" => modes, "matcher" => matcher})
+       when is_list(modes) do
+    with {:ok, effect} <- parse_effect(effect),
+         {:ok, modes} <- parse_modes(modes),
+         {:ok, matcher} <- parse_matcher(matcher) do
+      {:ok, %Policy{effect: effect, modes: modes, matcher: matcher}}
+    end
+  end
+
+  defp policy_from_params(_params), do: :error
+
+  defp parse_effect("allow"), do: {:ok, :allow}
+  defp parse_effect("deny"), do: {:ok, :deny}
+  defp parse_effect(_other), do: :error
+
+  defp parse_modes(modes) do
+    parsed = Enum.map(modes, &parse_mode/1)
+
+    if Enum.all?(parsed, &(&1 != :error)) do
+      {:ok, parsed}
+    else
+      :error
+    end
+  end
+
+  defp parse_mode("read"), do: :read
+  defp parse_mode("write"), do: :write
+  defp parse_mode(_other), do: :error
+
+  defp parse_matcher("public"), do: {:ok, :public}
+  defp parse_matcher("authenticated"), do: {:ok, :authenticated}
+  defp parse_matcher(%{"agent" => subject}) when is_binary(subject), do: {:ok, {:agent, subject}}
+  defp parse_matcher(_other), do: :error
+
+  defp policy_to_map(%Policy{effect: effect, modes: modes, matcher: matcher}) do
+    %{
+      "effect" => Atom.to_string(effect),
+      "modes" => Enum.map(modes, &Atom.to_string/1),
+      "matcher" => matcher_to_json(matcher)
+    }
+  end
+
+  defp matcher_to_json(:public), do: "public"
+  defp matcher_to_json(:authenticated), do: "authenticated"
+  defp matcher_to_json({:agent, subject}), do: %{"agent" => subject}
+end

--- a/lib/riptide_web/ldp/resource_controller.ex
+++ b/lib/riptide_web/ldp/resource_controller.ex
@@ -133,9 +133,33 @@ defmodule RiptideWeb.LDP.ResourceController do
   def ensure_ready_status(:ok), do: :ok
   def ensure_ready_status({:error, _reason}), do: :error
 
-  defp stream_id_for(tenant_id, path_segments) do
-    "https://riptide.example/tenants/#{tenant_id}/resources/" <> Enum.join(path_segments, "/")
+  @stream_id_prefix "https://riptide.example/tenants/"
+  @resources_segment "/resources/"
+
+  @spec stream_id_for(String.t(), [String.t()]) :: String.t()
+  def stream_id_for(tenant_id, path_segments) do
+    @stream_id_prefix <> tenant_id <> @resources_segment <> Enum.join(path_segments, "/")
   end
+
+  # The exact inverse of `stream_id_for/2` — used by Phase 4c's authorization
+  # layer (`RiptideWeb.Realtime.SseController`/`ReplicationChannel`, Tasks 7-8)
+  # to recover which tenant/resource an opaque, client-supplied `stream_id`
+  # addresses, since neither transport constructs one from a path
+  # server-side (see Phase 4a design spec §5, Phase 4c design spec §7).
+  # `stream_id_for/2`'s format is a pure, deterministic, reversible string —
+  # no hashing or randomness — so parsing it back apart needs no new
+  # persisted state, at the cost of staying coupled to this exact format:
+  # the round-trip tests in `resource_controller_test.exs` exist specifically
+  # to catch a future change here breaking that coupling silently.
+  @spec parse_stream_id(String.t()) :: {:ok, String.t(), [String.t()]} | :error
+  def parse_stream_id(@stream_id_prefix <> rest) do
+    case String.split(rest, @resources_segment, parts: 2) do
+      [tenant_id, path] when tenant_id != "" -> {:ok, tenant_id, String.split(path, "/")}
+      _ -> :error
+    end
+  end
+
+  def parse_stream_id(_other), do: :error
 
   defp current_state(stream_id) do
     case stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do

--- a/lib/riptide_web/plugs/authorize.ex
+++ b/lib/riptide_web/plugs/authorize.ex
@@ -1,0 +1,55 @@
+defmodule RiptideWeb.Plugs.Authorize do
+  @moduledoc """
+  Enforces `Riptide.Authz.evaluate/4`'s decision on every tenant-scoped LDP
+  route — mirrors `RiptideWeb.Plugs.ResolveTenant`/`Authenticate`'s shape.
+  Halts with `403` on deny.
+
+  On an otherwise-denied *authenticated write*, first checks whether the
+  tenant is still unclaimed (see the Phase 4c design spec §6):
+  `Riptide.Authz.Store.claim_tenant_if_unclaimed/2` is a single atomic Ra
+  command, not a separate check-then-add pair of calls, so a race between
+  two different agents both attempting to be "first write" to the same
+  brand-new tenant resolves to exactly one owner. Anonymous requests and
+  reads never reach this path — they're just denied.
+  """
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    tenant_id = conn.assigns.tenant_id
+    current_subject = conn.assigns.current_subject
+    path_segments = Map.get(conn.params, "path") || []
+    mode = mode_for(conn.method)
+
+    case Riptide.Authz.evaluate(tenant_id, path_segments, current_subject, mode) do
+      :allow -> conn
+      :deny -> maybe_bootstrap(conn, tenant_id, current_subject, mode)
+    end
+  end
+
+  defp maybe_bootstrap(conn, tenant_id, current_subject, :write)
+       when not is_nil(current_subject) do
+    store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
+
+    case store.claim_tenant_if_unclaimed(tenant_id, current_subject["sub"]) do
+      :claimed -> conn
+      :already_claimed -> reject(conn)
+    end
+  end
+
+  defp maybe_bootstrap(conn, _tenant_id, _current_subject, _mode), do: reject(conn)
+
+  defp mode_for("GET"), do: :read
+  defp mode_for(_other), do: :write
+
+  defp reject(conn) do
+    conn
+    |> send_resp(403, "")
+    |> halt()
+  end
+end

--- a/lib/riptide_web/realtime/replication_channel.ex
+++ b/lib/riptide_web/realtime/replication_channel.ex
@@ -4,15 +4,33 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
   `"replication:<stream_id>"` with an `"after"` cursor, replies with a backlog,
   and pushes further events as `"replication_frame"` messages. Mirrors the SSE
   controller's cursor/gap semantics over Phoenix Channels instead of SSE.
+
+  Authorization (Phase 4c) recovers the joining topic's tenant/path via
+  `RiptideWeb.LDP.ResourceController.parse_stream_id/1` and checks it against
+  `socket.assigns.current_subject` (established once at `connect/3` time,
+  per Phase 4b) — a channel `join/3` never re-verifies *identity*, but it
+  does check *authorization* per topic, since one socket can join many
+  different topics over its lifetime and each may have different policies.
   """
   use Phoenix.Channel
 
   alias Riptide.Event
   alias Riptide.RDF.TurtleCodec
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias RiptideWeb.LDP.ResourceController
 
   @impl true
   def join("replication:" <> stream_id, %{"after" => cursor}, socket) do
+    with {:ok, tenant_id, path_segments} <- ResourceController.parse_stream_id(stream_id),
+         :allow <-
+           Riptide.Authz.evaluate(tenant_id, path_segments, socket.assigns.current_subject, :read) do
+      do_join(stream_id, cursor, socket)
+    else
+      _ -> {:error, %{"reason" => "unauthorized"}}
+    end
+  end
+
+  defp do_join(stream_id, cursor, socket) do
     case stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do
       :ok ->
         Phoenix.PubSub.subscribe(Riptide.PubSub, "stream:" <> stream_id)

--- a/lib/riptide_web/realtime/sse_controller.ex
+++ b/lib/riptide_web/realtime/sse_controller.ex
@@ -4,8 +4,19 @@ defmodule RiptideWeb.Realtime.SseController do
   alias Riptide.Event
   alias Riptide.RDF.TurtleCodec
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias RiptideWeb.LDP.ResourceController
 
   def subscribe(conn, %{"stream_id" => stream_id}) do
+    with {:ok, tenant_id, path_segments} <- ResourceController.parse_stream_id(stream_id),
+         :allow <-
+           Riptide.Authz.evaluate(tenant_id, path_segments, conn.assigns.current_subject, :read) do
+      do_subscribe(conn, stream_id)
+    else
+      _ -> send_resp(conn, 403, "")
+    end
+  end
+
+  defp do_subscribe(conn, stream_id) do
     case stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do
       :ok ->
         Phoenix.PubSub.subscribe(Riptide.PubSub, "stream:" <> stream_id)

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -37,5 +37,8 @@ defmodule RiptideWeb.Router do
     put "/resources/*path", RiptideWeb.LDP.ResourceController, :replace
     delete "/resources/*path", RiptideWeb.LDP.ResourceController, :delete
     patch "/resources/*path", RiptideWeb.LDP.ResourceController, :patch
+
+    post "/policies", RiptideWeb.Authz.PolicyController, :create
+    get "/policies", RiptideWeb.Authz.PolicyController, :index
   end
 end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -13,6 +13,10 @@ defmodule RiptideWeb.Router do
     plug RiptideWeb.Plugs.Authenticate
   end
 
+  pipeline :authz do
+    plug RiptideWeb.Plugs.Authorize
+  end
+
   scope "/" do
     pipe_through :api
 
@@ -26,7 +30,7 @@ defmodule RiptideWeb.Router do
   end
 
   scope "/tenants/:tenant_id" do
-    pipe_through [:api, :tenant, :auth]
+    pipe_through [:api, :tenant, :auth, :authz]
 
     get "/resources/*path", RiptideWeb.LDP.ResourceController, :show
     post "/resources/*path", RiptideWeb.LDP.ResourceController, :create_child

--- a/test/riptide/authz/store/placement_test.exs
+++ b/test/riptide/authz/store/placement_test.exs
@@ -1,0 +1,20 @@
+defmodule Riptide.Authz.Store.PlacementTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Authz.{Policy, Store}
+
+  test "add_policy/3 then list_policies/2 round-trips through the real placement cluster" do
+    tenant_id = "authz-store-test-" <> Uniq.UUID.uuid4()
+    policy = %Policy{effect: :deny, modes: [:write], matcher: :authenticated}
+
+    assert Store.Placement.add_policy(tenant_id, ["docs"], policy) == :ok
+    assert Store.Placement.list_policies(tenant_id, ["docs"]) == [policy]
+  end
+
+  test "claim_tenant_if_unclaimed/2 claims a brand-new tenant exactly once" do
+    tenant_id = "authz-store-claim-test-" <> Uniq.UUID.uuid4()
+
+    assert Store.Placement.claim_tenant_if_unclaimed(tenant_id, "user-1") == :claimed
+    assert Store.Placement.claim_tenant_if_unclaimed(tenant_id, "user-2") == :already_claimed
+  end
+end

--- a/test/riptide/authz_test.exs
+++ b/test/riptide/authz_test.exs
@@ -1,0 +1,114 @@
+defmodule Riptide.AuthzTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Authz
+  alias Riptide.Authz.Policy
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    original = Application.get_env(:riptide, :authz_store)
+    Application.put_env(:riptide, :authz_store, FakeStore)
+
+    on_exit(fn ->
+      Application.put_env(:riptide, :authz_store, original)
+      if pid = Process.whereis(FakeStore), do: Agent.stop(pid)
+    end)
+
+    :ok
+  end
+
+  test "denies when no policy matches at all (default-deny)" do
+    FakeStore.start(%{})
+    assert Authz.evaluate("acme", ["docs"], %{"sub" => "user-1"}, :read) == :deny
+  end
+
+  test "a :public matcher allows anyone, including anonymous, for the modes it lists" do
+    FakeStore.start(%{
+      {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
+    })
+
+    assert Authz.evaluate("acme", ["docs"], nil, :read) == :allow
+    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone"}, :read) == :allow
+    assert Authz.evaluate("acme", ["docs"], nil, :write) == :deny
+  end
+
+  test "an :authenticated matcher allows any non-nil subject but not anonymous" do
+    FakeStore.start(%{
+      {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :authenticated}]
+    })
+
+    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone"}, :read) == :allow
+    assert Authz.evaluate("acme", ["docs"], nil, :read) == :deny
+  end
+
+  test "an {:agent, subject} matcher only allows that exact subject" do
+    FakeStore.start(%{
+      {"acme", []} => [
+        %Policy{effect: :allow, modes: [:read, :write], matcher: {:agent, "owner"}}
+      ]
+    })
+
+    assert Authz.evaluate("acme", ["docs"], %{"sub" => "owner"}, :write) == :allow
+    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone-else"}, :write) == :deny
+  end
+
+  test "a policy only grants the modes it explicitly lists" do
+    FakeStore.start(%{
+      {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
+    })
+
+    assert Authz.evaluate("acme", ["docs"], nil, :read) == :allow
+    assert Authz.evaluate("acme", ["docs"], nil, :write) == :deny
+  end
+
+  test "deny overrides allow when both match the same request" do
+    FakeStore.start(%{
+      {"acme", []} => [
+        %Policy{effect: :allow, modes: [:read], matcher: :public},
+        %Policy{effect: :deny, modes: [:read], matcher: :authenticated}
+      ]
+    })
+
+    # Anonymous: only the :public allow matches -> allow.
+    assert Authz.evaluate("acme", ["docs"], nil, :read) == :allow
+    # Authenticated: both the :public allow and the :authenticated deny match -> deny wins.
+    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone"}, :read) == :deny
+  end
+
+  test "a policy on an ancestor container is inherited by a deeper resource" do
+    FakeStore.start(%{
+      {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
+    })
+
+    assert Authz.evaluate("acme", ["docs", "sub", "deep"], nil, :read) == :allow
+  end
+
+  test "a policy on a sibling path prefix does not apply to an unrelated resource" do
+    FakeStore.start(%{
+      {"acme", ["other"]} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
+    })
+
+    assert Authz.evaluate("acme", ["docs"], nil, :read) == :deny
+  end
+end

--- a/test/riptide/authz_test.exs
+++ b/test/riptide/authz_test.exs
@@ -31,7 +31,20 @@ defmodule Riptide.AuthzTest do
     Application.put_env(:riptide, :authz_store, FakeStore)
 
     on_exit(fn ->
-      Application.put_env(:riptide, :authz_store, original)
+      # `Application.put_env(key, nil)` leaves the key present with value
+      # `nil`, which is NOT equivalent to the key being absent:
+      # `Application.get_env(:riptide, :authz_store, SomeDefault)`'s default
+      # only applies when the key is entirely unset, so if `original` here
+      # is `nil` (as it always is in this suite — nothing configures
+      # `:authz_store` anywhere), restoring via `put_env` would permanently
+      # poison it to `nil` for the rest of the same `mix test` run instead
+      # of restoring the "absent, fall back to the real default" state.
+      if is_nil(original) do
+        Application.delete_env(:riptide, :authz_store)
+      else
+        Application.put_env(:riptide, :authz_store, original)
+      end
+
       if pid = Process.whereis(FakeStore), do: Agent.stop(pid)
     end)
 

--- a/test/riptide/placement/placement_machine_test.exs
+++ b/test/riptide/placement/placement_machine_test.exs
@@ -88,4 +88,107 @@ defmodule Riptide.Placement.PlacementMachineTest do
     assert reply == nil
     assert effects == []
   end
+
+  test "apply/3 {:add_policy, ...} appends to an empty policy list for a new tenant/prefix" do
+    state = PlacementMachine.init(%{})
+    policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1}, {:add_policy, "acme", [], policy}, state)
+
+    assert new_state == %{streams: %{}, policies: %{"acme" => %{[] => [policy]}}}
+    assert reply == :ok
+    assert effects == []
+  end
+
+  test "apply/3 {:add_policy, ...} appends to an existing policy list rather than replacing it" do
+    state = PlacementMachine.init(%{})
+    first = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+    second = %Riptide.Authz.Policy{effect: :deny, modes: [:write], matcher: :authenticated}
+
+    {state, _, _} = PlacementMachine.apply(%{index: 1}, {:add_policy, "acme", [], first}, state)
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 2}, {:add_policy, "acme", [], second}, state)
+
+    assert new_state == %{streams: %{}, policies: %{"acme" => %{[] => [first, second]}}}
+    assert reply == :ok
+    assert effects == []
+  end
+
+  test "apply/3 {:add_policy, ...} keeps different path prefixes independent" do
+    state = PlacementMachine.init(%{})
+    root_policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+    child_policy = %Riptide.Authz.Policy{effect: :deny, modes: [:write], matcher: :authenticated}
+
+    {state, _, _} =
+      PlacementMachine.apply(%{index: 1}, {:add_policy, "acme", [], root_policy}, state)
+
+    {new_state, _, _} =
+      PlacementMachine.apply(%{index: 2}, {:add_policy, "acme", ["secret"], child_policy}, state)
+
+    assert new_state ==
+             %{
+               streams: %{},
+               policies: %{"acme" => %{[] => [root_policy], ["secret"] => [child_policy]}}
+             }
+  end
+
+  test "apply/3 {:claim_tenant_if_unclaimed, ...} creates a tenant-root owner policy when the tenant has zero policies" do
+    state = PlacementMachine.init(%{})
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1}, {:claim_tenant_if_unclaimed, "acme", "user-1"}, state)
+
+    assert new_state == %{
+             streams: %{},
+             policies: %{
+               "acme" => %{
+                 [] => [
+                   %Riptide.Authz.Policy{
+                     effect: :allow,
+                     modes: [:read, :write],
+                     matcher: {:agent, "user-1"}
+                   }
+                 ]
+               }
+             }
+           }
+
+    assert reply == :claimed
+    assert effects == []
+  end
+
+  test "apply/3 {:claim_tenant_if_unclaimed, ...} is a no-op if the tenant already has any policy at any prefix" do
+    state = PlacementMachine.init(%{})
+    existing = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+
+    {state, _, _} =
+      PlacementMachine.apply(
+        %{index: 1},
+        {:add_policy, "acme", ["some", "path"], existing},
+        state
+      )
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 2}, {:claim_tenant_if_unclaimed, "acme", "user-2"}, state)
+
+    assert new_state == state
+    assert reply == :already_claimed
+    assert effects == []
+  end
+
+  test "list_policies/3 returns an empty list for a tenant/prefix with no policies" do
+    state = PlacementMachine.init(%{})
+    assert PlacementMachine.list_policies(state, "acme", []) == []
+  end
+
+  test "list_policies/3 returns exactly the policies stored at that tenant/prefix" do
+    policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+    state = %{streams: %{}, policies: %{"acme" => %{["docs"] => [policy]}}}
+
+    assert PlacementMachine.list_policies(state, "acme", ["docs"]) == [policy]
+    assert PlacementMachine.list_policies(state, "acme", []) == []
+    assert PlacementMachine.list_policies(state, "other-tenant", ["docs"]) == []
+  end
 end

--- a/test/riptide/placement/placement_machine_test.exs
+++ b/test/riptide/placement/placement_machine_test.exs
@@ -3,8 +3,8 @@ defmodule Riptide.Placement.PlacementMachineTest do
 
   alias Riptide.Placement.PlacementMachine
 
-  test "init/1 starts with an empty map" do
-    assert PlacementMachine.init(%{}) == %{}
+  test "init/1 starts with empty streams and policies" do
+    assert PlacementMachine.init(%{}) == %{streams: %{}, policies: %{}}
   end
 
   test "apply/3 stores a new stream's node list" do
@@ -13,7 +13,7 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:assign, "s1", [:a, :b, :c]}, state)
 
-    assert new_state == %{"s1" => [:a, :b, :c]}
+    assert new_state == %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
     assert reply == [:a, :b, :c]
     assert effects == []
   end
@@ -25,7 +25,7 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 2}, {:assign, "s1", [:x, :y, :z]}, state)
 
-    assert new_state == %{"s1" => [:a, :b, :c]}
+    assert new_state == %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
     assert reply == [:a, :b, :c]
     assert effects == []
   end
@@ -35,20 +35,21 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {state, _, _} = PlacementMachine.apply(%{index: 1}, {:assign, "s1", [:a, :b, :c]}, state)
     {state, _, _} = PlacementMachine.apply(%{index: 2}, {:assign, "s2", [:d, :e, :f]}, state)
 
-    assert state == %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}
+    assert state == %{streams: %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}, policies: %{}}
   end
 
   test "get/2 returns the assigned nodes for a known stream" do
-    assert PlacementMachine.get(%{"s1" => [:a, :b, :c]}, "s1") == [:a, :b, :c]
+    state = %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
+    assert PlacementMachine.get(state, "s1") == [:a, :b, :c]
   end
 
   test "get/2 returns nil for an unknown stream" do
-    assert PlacementMachine.get(%{}, "unknown") == nil
+    assert PlacementMachine.get(%{streams: %{}, policies: %{}}, "unknown") == nil
   end
 
-  test "list/1 returns the full stream_id => nodes map" do
-    state = %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}
-    assert PlacementMachine.list(state) == state
+  test "list/1 returns only the stream_id => nodes map, not the internal policies state" do
+    state = %{streams: %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}, policies: %{"acme" => %{}}}
+    assert PlacementMachine.list(state) == %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}
   end
 
   test "list/1 returns an empty map when nothing is assigned yet" do
@@ -56,34 +57,34 @@ defmodule Riptide.Placement.PlacementMachineTest do
   end
 
   test "apply/3 {:replace_member, ...} swaps a dead node for a new one in an existing assignment" do
-    state = %{"s1" => [:a, :b, :c]}
+    state = %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
 
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:replace_member, "s1", :b, :z}, state)
 
-    assert new_state == %{"s1" => [:a, :z, :c]}
+    assert new_state == %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}}
     assert reply == [:a, :z, :c]
     assert effects == []
   end
 
   test "apply/3 {:replace_member, ...} is a no-op if the named dead node is no longer present" do
-    state = %{"s1" => [:a, :z, :c]}
+    state = %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}}
 
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 2}, {:replace_member, "s1", :b, :y}, state)
 
-    assert new_state == %{"s1" => [:a, :z, :c]}
+    assert new_state == %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}}
     assert reply == [:a, :z, :c]
     assert effects == []
   end
 
   test "apply/3 {:replace_member, ...} is a no-op for an unknown stream_id" do
-    state = %{}
+    state = %{streams: %{}, policies: %{}}
 
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:replace_member, "unknown", :a, :b}, state)
 
-    assert new_state == %{}
+    assert new_state == %{streams: %{}, policies: %{}}
     assert reply == nil
     assert effects == []
   end

--- a/test/riptide/placement_test.exs
+++ b/test/riptide/placement_test.exs
@@ -90,4 +90,57 @@ defmodule Riptide.PlacementTest do
       assert Placement.lookup(stream_id) == [node()]
     end
   end
+
+  describe "add_policy/3, list_policies/2, and claim_tenant_if_unclaimed/2 against the real metadata cluster" do
+    test "add_policy/3 then list_policies/2 round-trips a real policy" do
+      tenant_id = "authz-test-" <> Uniq.UUID.uuid4()
+      policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+
+      assert Placement.add_policy(tenant_id, [], policy) == :ok
+      assert Placement.list_policies(tenant_id, []) == [policy]
+    end
+
+    test "list_policies/2 returns an empty list for a tenant/prefix with no policies" do
+      tenant_id = "authz-test-empty-" <> Uniq.UUID.uuid4()
+      assert Placement.list_policies(tenant_id, []) == []
+    end
+
+    test "claim_tenant_if_unclaimed/2 claims a brand-new tenant exactly once" do
+      tenant_id = "authz-claim-test-" <> Uniq.UUID.uuid4()
+
+      assert Placement.claim_tenant_if_unclaimed(tenant_id, "user-1") == :claimed
+      assert Placement.claim_tenant_if_unclaimed(tenant_id, "user-2") == :already_claimed
+
+      assert Placement.list_policies(tenant_id, []) == [
+               %Riptide.Authz.Policy{
+                 effect: :allow,
+                 modes: [:read, :write],
+                 matcher: {:agent, "user-1"}
+               }
+             ]
+    end
+
+    test "claim_tenant_if_unclaimed/2 resolves a real race between two simultaneous claims to exactly one winner" do
+      tenant_id = "authz-claim-race-test-" <> Uniq.UUID.uuid4()
+
+      results =
+        [
+          Task.async(fn -> Placement.claim_tenant_if_unclaimed(tenant_id, "racer-1") end),
+          Task.async(fn -> Placement.claim_tenant_if_unclaimed(tenant_id, "racer-2") end)
+        ]
+        |> Enum.map(&Task.await/1)
+
+      assert Enum.sort(results) == [:already_claimed, :claimed]
+
+      # Exactly one owner policy exists afterward, for whichever racer's
+      # command Raft's log actually ordered first — never both, never
+      # neither. Every command against this Ra cluster is serialized
+      # through consensus, so this proves the race is resolved by the log
+      # itself rather than by any check-then-act ordering on the caller side.
+      assert [%Riptide.Authz.Policy{matcher: {:agent, winner}}] =
+               Placement.list_policies(tenant_id, [])
+
+      assert winner in ["racer-1", "racer-2"]
+    end
+  end
 end

--- a/test/riptide_web/authz/policy_controller_test.exs
+++ b/test/riptide_web/authz/policy_controller_test.exs
@@ -1,0 +1,197 @@
+defmodule RiptideWeb.Authz.PolicyControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify("other-token"), do: {:ok, %{"sub" => "someone-else"}}
+    def verify("friend-token"), do: {:ok, %{"sub" => "friend-1"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    original = Application.get_env(:riptide, :auth_verifier)
+    Application.put_env(:riptide, :auth_verifier, StubVerifier)
+    on_exit(fn -> Application.put_env(:riptide, :auth_verifier, original) end)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Riptide.Authz.Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  test "the owner can add a policy and then list it back" do
+    tenant_id = "policy-api-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    body =
+      Jason.encode!(%{
+        "effect" => "allow",
+        "modes" => ["read"],
+        "matcher" => "public"
+      })
+
+    post_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/policies", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert post_conn.status == 201
+
+    get_conn =
+      :get
+      |> conn("/tenants/#{tenant_id}/policies")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert get_conn.status == 200
+
+    [owner_policy, added_policy] = Jason.decode!(get_conn.resp_body)
+    assert owner_policy["matcher"] == %{"agent" => "the-owner"}
+    assert added_policy == %{"effect" => "allow", "modes" => ["read"], "matcher" => "public"}
+  end
+
+  test "a non-owner cannot add or list policies for someone else's tenant" do
+    tenant_id = "policy-api-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    body = Jason.encode!(%{"effect" => "allow", "modes" => ["read"], "matcher" => "public"})
+
+    post_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/policies", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer other-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert post_conn.status == 403
+
+    get_conn =
+      :get
+      |> conn("/tenants/#{tenant_id}/policies")
+      |> put_req_header("authorization", "Bearer other-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert get_conn.status == 403
+  end
+
+  test "adding a policy with an unrecognized effect returns 400" do
+    tenant_id = "policy-api-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    body = Jason.encode!(%{"effect" => "maybe", "modes" => ["read"], "matcher" => "public"})
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/policies", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 400
+  end
+
+  test "an agent matcher round-trips as a nested map" do
+    tenant_id = "policy-api-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    body =
+      Jason.encode!(%{
+        "effect" => "allow",
+        "modes" => ["read", "write"],
+        "matcher" => %{"agent" => "friend-1"}
+      })
+
+    :post
+    |> conn("/tenants/#{tenant_id}/policies", body)
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("authorization", "Bearer owner-token")
+    |> RiptideWeb.Endpoint.call(@opts)
+
+    get_conn =
+      :get
+      |> conn("/tenants/#{tenant_id}/policies")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    [_owner_policy, added_policy] = Jason.decode!(get_conn.resp_body)
+    assert added_policy["matcher"] == %{"agent" => "friend-1"}
+    assert added_policy["modes"] == ["read", "write"]
+  end
+
+  # This is the capstone scenario the whole design's matcher expressiveness
+  # exists for (see the Phase 4c design spec §1/§8): an owner shares access
+  # with a specific, previously-unenumerated agent, and that agent's access
+  # actually works against a real LDP resource afterward — not just that the
+  # policy API itself accepts and echoes back the grant.
+  test "a policy granted through this API actually enables that agent's real resource access" do
+    tenant_id = "policy-api-e2e-" <> Uniq.UUID.uuid4()
+    resource_path = "/tenants/#{tenant_id}/resources/shared-doc"
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(
+        RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["shared-doc"])
+      )
+    end)
+
+    claim_tenant(tenant_id)
+
+    friend_get_before_grant =
+      :get
+      |> conn(resource_path)
+      |> put_req_header("authorization", "Bearer friend-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert friend_get_before_grant.status == 403
+
+    :put
+    |> conn(resource_path, "<https://pod.example/x> <https://pod.example/y> \"shared\" .\n")
+    |> put_req_header("content-type", "text/turtle")
+    |> put_req_header("authorization", "Bearer owner-token")
+    |> RiptideWeb.Endpoint.call(@opts)
+
+    grant_body =
+      Jason.encode!(%{
+        "effect" => "allow",
+        "modes" => ["read"],
+        "matcher" => %{"agent" => "friend-1"}
+      })
+
+    grant_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/policies", grant_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert grant_conn.status == 201
+
+    friend_get_after_grant =
+      :get
+      |> conn(resource_path)
+      |> put_req_header("authorization", "Bearer friend-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert friend_get_after_grant.status == 200
+    assert friend_get_after_grant.resp_body =~ "\"shared\""
+
+    friend_put_still_denied =
+      :put
+      |> conn(
+        resource_path,
+        "<https://pod.example/x> <https://pod.example/y> \"overwritten\" .\n"
+      )
+      |> put_req_header("content-type", "text/turtle")
+      |> put_req_header("authorization", "Bearer friend-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert friend_put_still_denied.status == 403
+  end
+end

--- a/test/riptide_web/authz/policy_controller_test.exs
+++ b/test/riptide_web/authz/policy_controller_test.exs
@@ -2,6 +2,9 @@ defmodule RiptideWeb.Authz.PolicyControllerTest do
   use ExUnit.Case, async: false
   use Plug.Test
 
+  alias Riptide.Authz.Store
+  alias RiptideWeb.LDP.ResourceController
+
   @opts RiptideWeb.Endpoint.init([])
 
   defmodule StubVerifier do
@@ -22,7 +25,7 @@ defmodule RiptideWeb.Authz.PolicyControllerTest do
   end
 
   defp claim_tenant(tenant_id) do
-    :claimed = Riptide.Authz.Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
   end
 
   test "the owner can add a policy and then list it back" do
@@ -137,7 +140,7 @@ defmodule RiptideWeb.Authz.PolicyControllerTest do
 
     on_exit(fn ->
       Riptide.RaTestHelpers.cleanup_stream(
-        RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["shared-doc"])
+        ResourceController.stream_id_for(tenant_id, ["shared-doc"])
       )
     end)
 

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -266,6 +266,23 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
              :error
   end
 
+  describe "stream_id_for/2 and parse_stream_id/1" do
+    test "parse_stream_id/1 recovers the exact tenant_id and path_segments stream_id_for/2 was built from" do
+      stream_id = ResourceController.stream_id_for("acme", ["docs", "sub"])
+      assert ResourceController.parse_stream_id(stream_id) == {:ok, "acme", ["docs", "sub"]}
+    end
+
+    test "parse_stream_id/1 round-trips for a single-segment path" do
+      stream_id = ResourceController.stream_id_for("acme", ["doc"])
+      assert ResourceController.parse_stream_id(stream_id) == {:ok, "acme", ["doc"]}
+    end
+
+    test "parse_stream_id/1 returns :error for a stream_id not shaped like a tenant resource" do
+      assert ResourceController.parse_stream_id("not-a-real-stream-id") == :error
+      assert ResourceController.parse_stream_id("https://riptide.example/health") == :error
+    end
+  end
+
   test "a %2F-encoded slash inside the tenant_id path segment is rejected with 400, not silently aliased" do
     # Regression test for the stream_id collision finding: plug_cowboy's raw
     # path splitter (deps/plug_cowboy/lib/plug/cowboy/conn.ex) splits on

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -1,10 +1,30 @@
 defmodule RiptideWeb.LDP.ResourceControllerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use Plug.Test
 
   alias RiptideWeb.LDP.ResourceController
 
   @opts RiptideWeb.Endpoint.init([])
+
+  # Every pre-existing test below exercises anonymous access against a
+  # policy-less tenant, exactly as it did before `Authorize` was wired into
+  # the router — seed a `:public` allow policy for each fixed tenant_id
+  # those tests' own helpers resolve to (`unique_path/0` always uses
+  # "test-tenant"; the tenant-isolation test below uses "tenant-a" and
+  # "tenant-b" directly) so those tests keep exercising resource behavior,
+  # not authorization. The new `describe "authorization"` tests below use
+  # their own brand-new, unseeded `authz-e2e-*` tenants instead.
+  setup do
+    for tenant_id <- ["test-tenant", "tenant-a", "tenant-b"] do
+      Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+        effect: :allow,
+        modes: [:read, :write],
+        matcher: :public
+      })
+    end
+
+    :ok
+  end
 
   defp unique_path,
     do: "/tenants/test-tenant/resources/test-#{System.unique_integer([:positive])}"
@@ -14,6 +34,15 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
   defp stream_id_for(path) do
     segments = path |> String.trim_leading("/tenants/test-tenant/resources/") |> String.split("/")
     "https://riptide.example/tenants/test-tenant/resources/" <> Enum.join(segments, "/")
+  end
+
+  # Same as stream_id_for/1, parameterized by tenant_id, for tests that use
+  # a per-test-unique tenant rather than the fixed "test-tenant" literal.
+  defp stream_id_for(tenant_id, path) do
+    segments =
+      path |> String.trim_leading("/tenants/#{tenant_id}/resources/") |> String.split("/")
+
+    "https://riptide.example/tenants/#{tenant_id}/resources/" <> Enum.join(segments, "/")
   end
 
   test "GET on a resource that was never written to returns 404" do
@@ -294,5 +323,105 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
     get_a_conn = :get |> conn(tenant_a_path) |> RiptideWeb.Endpoint.call(@opts)
     assert get_a_conn.status == 200
     assert get_a_conn.resp_body =~ "\"a\""
+  end
+
+  describe "authorization" do
+    test "an anonymous GET of a never-written resource in a brand-new tenant is denied with 403, not 404" do
+      tenant_id = "authz-e2e-" <> Uniq.UUID.uuid4()
+      path = "/tenants/#{tenant_id}/resources/doc"
+
+      conn = :get |> conn(path) |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 403
+    end
+
+    test "the first authenticated write to a brand-new tenant claims ownership and succeeds" do
+      tenant_id = "authz-e2e-" <> Uniq.UUID.uuid4()
+      path = "/tenants/#{tenant_id}/resources/doc"
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id_for(tenant_id, path)) end)
+
+      owner_claims = %{"sub" => "owner-" <> Uniq.UUID.uuid4()}
+      Application.put_env(:riptide, :authz_test_verifier_claims, owner_claims)
+      on_exit(fn -> Application.delete_env(:riptide, :authz_test_verifier_claims) end)
+
+      original_verifier = Application.get_env(:riptide, :auth_verifier)
+
+      Application.put_env(
+        :riptide,
+        :auth_verifier,
+        RiptideWeb.LDP.ResourceControllerTest.StubOwnerVerifier
+      )
+
+      on_exit(fn -> Application.put_env(:riptide, :auth_verifier, original_verifier) end)
+
+      put_conn =
+        :put
+        |> conn(path, "<https://pod.example/x> <https://pod.example/y> \"z\" .\n")
+        |> put_req_header("content-type", "text/turtle")
+        |> put_req_header("authorization", "Bearer owner-token")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert put_conn.status == 201
+
+      get_conn =
+        :get
+        |> conn(path)
+        |> put_req_header("authorization", "Bearer owner-token")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert get_conn.status == 200
+      assert get_conn.resp_body =~ "\"z\""
+    end
+
+    test "a different identity is denied access to an already-claimed tenant's resource" do
+      tenant_id = "authz-e2e-" <> Uniq.UUID.uuid4()
+      path = "/tenants/#{tenant_id}/resources/doc"
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id_for(tenant_id, path)) end)
+
+      original_verifier = Application.get_env(:riptide, :auth_verifier)
+
+      Application.put_env(
+        :riptide,
+        :auth_verifier,
+        RiptideWeb.LDP.ResourceControllerTest.StubOwnerVerifier
+      )
+
+      on_exit(fn -> Application.put_env(:riptide, :auth_verifier, original_verifier) end)
+
+      :put
+      |> conn(path, "<https://pod.example/x> <https://pod.example/y> \"z\" .\n")
+      |> put_req_header("content-type", "text/turtle")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+      other_get_conn =
+        :get
+        |> conn(path)
+        |> put_req_header("authorization", "Bearer someone-else-token")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert other_get_conn.status == 403
+
+      owner_get_conn =
+        :get
+        |> conn(path)
+        |> put_req_header("authorization", "Bearer owner-token")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert owner_get_conn.status == 200
+    end
+  end
+
+  # Any bearer token authenticates successfully (so "a different identity"
+  # tests exercise Authorize's identity-based denial, not Authenticate's
+  # invalid-token 401) — only "owner-token" maps to the tenant's actual
+  # owner subject; every other token authenticates as its own distinct,
+  # non-owner subject.
+  defmodule StubOwnerVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(token), do: {:ok, %{"sub" => token}}
   end
 end

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -2,6 +2,7 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
   use ExUnit.Case, async: false
   use Plug.Test
 
+  alias Riptide.Authz.{Policy, Store}
   alias RiptideWeb.LDP.ResourceController
 
   @opts RiptideWeb.Endpoint.init([])
@@ -16,7 +17,7 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
   # their own brand-new, unseeded `authz-e2e-*` tenants instead.
   setup do
     for tenant_id <- ["test-tenant", "tenant-a", "tenant-b"] do
-      Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+      Store.Placement.add_policy(tenant_id, [], %Policy{
         effect: :allow,
         modes: [:read, :write],
         matcher: :public

--- a/test/riptide_web/plugs/authorize_test.exs
+++ b/test/riptide_web/plugs/authorize_test.exs
@@ -1,0 +1,108 @@
+defmodule RiptideWeb.Plugs.AuthorizeTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias RiptideWeb.Plugs.Authorize
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies("acme", []),
+      do: [%Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}]
+
+    def list_policies(_tenant_id, _path_prefix), do: []
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed("unclaimed-tenant", _subject), do: :claimed
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+  end
+
+  setup do
+    original = Application.get_env(:riptide, :authz_store)
+    Application.put_env(:riptide, :authz_store, FakeStore)
+    on_exit(fn -> Application.put_env(:riptide, :authz_store, original) end)
+    :ok
+  end
+
+  defp conn_for(method, tenant_id, path_segments, current_subject) do
+    method
+    |> conn("/tenants/#{tenant_id}/resources/" <> Enum.join(path_segments, "/"))
+    |> Map.update!(:params, &Map.put(&1, "path", path_segments))
+    |> assign(:tenant_id, tenant_id)
+    |> assign(:current_subject, current_subject)
+  end
+
+  test "allows a GET matching a public policy, for an anonymous request" do
+    conn =
+      :get
+      |> conn_for("acme", ["docs"], nil)
+      |> Authorize.call(Authorize.init([]))
+
+    refute conn.halted
+  end
+
+  test "denies a POST/PUT/PATCH/DELETE with no matching write policy" do
+    for method <- [:post, :put, :patch, :delete] do
+      conn =
+        method
+        |> conn_for("acme", ["docs"], %{"sub" => "someone"})
+        |> Authorize.call(Authorize.init([]))
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+
+  test "denies a GET with no matching policy at all" do
+    conn =
+      :get
+      |> conn_for("no-such-tenant", ["docs"], nil)
+      |> Authorize.call(Authorize.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "an authenticated write to an unclaimed tenant bootstraps ownership and is allowed" do
+    conn =
+      :put
+      |> conn_for("unclaimed-tenant", ["docs"], %{"sub" => "user-1"})
+      |> Authorize.call(Authorize.init([]))
+
+    refute conn.halted
+  end
+
+  test "an anonymous write to an unclaimed tenant is denied, not treated as a claim attempt" do
+    conn =
+      :put
+      |> conn_for("unclaimed-tenant", ["docs"], nil)
+      |> Authorize.call(Authorize.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "a read (never a write) never bootstraps ownership even when authenticated" do
+    conn =
+      :get
+      |> conn_for("unclaimed-tenant", ["docs"], %{"sub" => "user-1"})
+      |> Authorize.call(Authorize.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "an authenticated write to an already-claimed tenant with no matching policy is denied" do
+    conn =
+      :put
+      |> conn_for("already-claimed-tenant", ["docs"], %{"sub" => "someone"})
+      |> Authorize.call(Authorize.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+end

--- a/test/riptide_web/plugs/authorize_test.exs
+++ b/test/riptide_web/plugs/authorize_test.exs
@@ -24,7 +24,23 @@ defmodule RiptideWeb.Plugs.AuthorizeTest do
   setup do
     original = Application.get_env(:riptide, :authz_store)
     Application.put_env(:riptide, :authz_store, FakeStore)
-    on_exit(fn -> Application.put_env(:riptide, :authz_store, original) end)
+
+    on_exit(fn ->
+      # `Application.put_env(key, nil)` leaves the key present with value
+      # `nil`, which is NOT equivalent to the key being absent:
+      # `Application.get_env(:riptide, :authz_store, SomeDefault)`'s default
+      # only applies when the key is entirely unset, so if `original` here
+      # is `nil` (as it always is in this suite — nothing configures
+      # `:authz_store` anywhere), restoring via `put_env` would permanently
+      # poison it to `nil` for the rest of the same `mix test` run instead
+      # of restoring the "absent, fall back to the real default" state.
+      if is_nil(original) do
+        Application.delete_env(:riptide, :authz_store)
+      else
+        Application.put_env(:riptide, :authz_store, original)
+      end
+    end)
+
     :ok
   end
 

--- a/test/riptide_web/realtime/replication_channel_test.exs
+++ b/test/riptide_web/realtime/replication_channel_test.exs
@@ -24,7 +24,30 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
     :ok
   end
 
-  defp unique_stream_id, do: "ws-test-#{System.unique_integer([:positive])}"
+  # The pre-existing tests below (predating authorization) use
+  # `unique_stream_id/0`'s fixed tenant ("ws-test-tenant") and no bearing on
+  # authorization itself — seed a `:public`, `[:read]` policy for it so
+  # authorization now being enforced doesn't change their expected outcomes,
+  # same pattern as `sse_controller_test.exs`'s Task 7 setup.
+  setup do
+    Riptide.Authz.Store.Placement.add_policy("ws-test-tenant", [], %Riptide.Authz.Policy{
+      effect: :allow,
+      modes: [:read],
+      matcher: :public
+    })
+
+    :ok
+  end
+
+  # A tenant-resource-shaped stream_id (not an opaque literal like the old
+  # `"ws-test-<n>"` ids), so `ReplicationChannel.join/3`'s authorization
+  # check can resolve it to a tenant. Fixed tenant, unique path segment per
+  # call — mirrors `sse_controller_test.exs`'s `unique_stream_id/0`.
+  defp unique_stream_id,
+    do:
+      RiptideWeb.LDP.ResourceController.stream_id_for("ws-test-tenant", [
+        "doc-#{System.unique_integer([:positive])}"
+      ])
 
   test "joining with after: 0 receives no backlog on an empty stream" do
     stream_id = unique_stream_id()
@@ -108,8 +131,8 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   # mailbox, so `refute_push` in the task can only match a push actually
   # delivered to socket B.
   test "an append to stream A is not pushed to a socket joined to stream B" do
-    stream_a = "stream-a-" <> Uniq.UUID.uuid4()
-    stream_b = "stream-b-" <> Uniq.UUID.uuid4()
+    stream_a = unique_stream_id()
+    stream_b = unique_stream_id()
     on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_a) end)
     on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_b) end)
 
@@ -161,5 +184,51 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
 
   test "connecting with an invalid auth_token is refused" do
     assert {:error, _reason} = connect(Socket, %{}, connect_info: %{auth_token: "garbage"})
+  end
+
+  test "joining a topic shaped like a tenant resource with no matching policy is denied, not crashed" do
+    tenant_id = "ws-authz-test-" <> Uniq.UUID.uuid4()
+    stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+
+    {:ok, socket} = connect(Socket, %{})
+
+    assert {:error, %{"reason" => "unauthorized"}} =
+             subscribe_and_join(socket, ReplicationChannel, "replication:" <> stream_id, %{
+               "after" => 0
+             })
+  end
+
+  test "joining a topic shaped like a tenant resource with a public read policy succeeds" do
+    tenant_id = "ws-authz-test-" <> Uniq.UUID.uuid4()
+    stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+    :ok =
+      Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+        effect: :allow,
+        modes: [:read],
+        matcher: :public
+      })
+
+    StreamSupervisor.ensure_ready(stream_id)
+
+    {:ok, socket} = connect(Socket, %{})
+
+    {:ok, _reply, _socket} =
+      subscribe_and_join(socket, ReplicationChannel, "replication:" <> stream_id, %{"after" => 0})
+  end
+
+  test "joining a topic not shaped like a tenant resource is denied, not crashed" do
+    {:ok, socket} = connect(Socket, %{})
+
+    assert {:error, %{"reason" => "unauthorized"}} =
+             subscribe_and_join(
+               socket,
+               ReplicationChannel,
+               "replication:some-legacy-stream-id",
+               %{
+                 "after" => 0
+               }
+             )
   end
 end

--- a/test/riptide_web/realtime/replication_channel_test.exs
+++ b/test/riptide_web/realtime/replication_channel_test.exs
@@ -2,9 +2,11 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   use ExUnit.Case, async: true
   import Phoenix.ChannelTest
 
+  alias Riptide.Authz.{Policy, Store}
   alias Riptide.Event
   alias Riptide.RDF.Patch
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias RiptideWeb.LDP.ResourceController
   alias RiptideWeb.Realtime.{ReplicationChannel, Socket}
 
   @endpoint RiptideWeb.Endpoint
@@ -30,7 +32,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   # authorization now being enforced doesn't change their expected outcomes,
   # same pattern as `sse_controller_test.exs`'s Task 7 setup.
   setup do
-    Riptide.Authz.Store.Placement.add_policy("ws-test-tenant", [], %Riptide.Authz.Policy{
+    Store.Placement.add_policy("ws-test-tenant", [], %Policy{
       effect: :allow,
       modes: [:read],
       matcher: :public
@@ -45,7 +47,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   # call — mirrors `sse_controller_test.exs`'s `unique_stream_id/0`.
   defp unique_stream_id,
     do:
-      RiptideWeb.LDP.ResourceController.stream_id_for("ws-test-tenant", [
+      ResourceController.stream_id_for("ws-test-tenant", [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -188,7 +190,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
 
   test "joining a topic shaped like a tenant resource with no matching policy is denied, not crashed" do
     tenant_id = "ws-authz-test-" <> Uniq.UUID.uuid4()
-    stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+    stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
 
     {:ok, socket} = connect(Socket, %{})
 
@@ -200,11 +202,11 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
 
   test "joining a topic shaped like a tenant resource with a public read policy succeeds" do
     tenant_id = "ws-authz-test-" <> Uniq.UUID.uuid4()
-    stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+    stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
     on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
 
     :ok =
-      Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+      Store.Placement.add_policy(tenant_id, [], %Policy{
         effect: :allow,
         modes: [:read],
         matcher: :public

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -16,9 +16,41 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
     def verify(_token), do: {:error, :invalid_token}
   end
 
-  defp unique_stream_id, do: "sse-test-#{System.unique_integer([:positive])}"
+  # The two top-level tests below (not inside any `describe` block) predate
+  # authorization being enforced and use fixed tenants of their own
+  # (`unique_stream_id/0`'s "sse-test-tenant", and the gap test's
+  # "sse-gap-test-tenant") — seed a `:public`, `[:read]` policy for each so
+  # authorization now being enforced doesn't change their expected statuses,
+  # same pattern as `resource_controller_test.exs`'s Task 5 setup.
+  setup do
+    for tenant_id <- ["sse-test-tenant", "sse-gap-test-tenant"] do
+      Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+        effect: :allow,
+        modes: [:read],
+        matcher: :public
+      })
+    end
 
-  defp unique_auth_stream_id, do: "sse-auth-test-#{System.unique_integer([:positive])}"
+    :ok
+  end
+
+  defp unique_stream_id,
+    do:
+      RiptideWeb.LDP.ResourceController.stream_id_for("sse-test-tenant", [
+        "doc-#{System.unique_integer([:positive])}"
+      ])
+
+  # A tenant-resource-shaped stream_id (not just an opaque literal like
+  # `unique_stream_id/0` above), so `SseController.subscribe/2`'s new
+  # authorization check can resolve it to a tenant. Fixed tenant, unique
+  # path segment per call — mirrors `resource_controller_test.exs`'s fixed
+  # "test-tenant" pattern (Task 5), with the matching policy seeded in the
+  # "authentication" describe block's own `setup` below.
+  defp unique_auth_stream_id,
+    do:
+      RiptideWeb.LDP.ResourceController.stream_id_for("sse-auth-test-tenant", [
+        "doc-#{System.unique_integer([:positive])}"
+      ])
 
   test "subscribing with no Last-Event-ID and then appending pushes one SSE frame" do
     stream_id = unique_stream_id()
@@ -43,7 +75,11 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   end
 
   test "subscribing with a cursor older than the retention window returns 409 with a gap signal" do
-    stream_id = "sse-gap-test-#{System.unique_integer([:positive])}"
+    stream_id =
+      RiptideWeb.LDP.ResourceController.stream_id_for("sse-gap-test-tenant", [
+        "doc-#{System.unique_integer([:positive])}"
+      ])
+
     on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
     {:ok, _pid} = StreamServer.start_link({stream_id, retention: 1})
 
@@ -75,10 +111,22 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   end
 
   describe "authentication" do
+    # These pre-existing tests exercise *authentication* behavior against a
+    # tenant-shaped stream_id with no bearing on authorization — seed a
+    # `:public`, `[:read]` policy for that fixed tenant (same pattern as
+    # `resource_controller_test.exs`'s Task 5 setup) so authorization now
+    # being enforced doesn't change their expected statuses.
     setup do
       original = Application.get_env(:riptide, :auth_verifier)
       Application.put_env(:riptide, :auth_verifier, StubVerifier)
       on_exit(fn -> Application.put_env(:riptide, :auth_verifier, original) end)
+
+      Riptide.Authz.Store.Placement.add_policy("sse-auth-test-tenant", [], %Riptide.Authz.Policy{
+        effect: :allow,
+        modes: [:read],
+        matcher: :public
+      })
+
       :ok
     end
 
@@ -87,7 +135,10 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
       on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
       StreamSupervisor.ensure_ready(stream_id)
 
-      conn = :get |> conn("/streams/#{stream_id}/subscribe") |> RiptideWeb.Endpoint.call(@opts)
+      conn =
+        :get
+        |> conn("/streams/#{URI.encode_www_form(stream_id)}/subscribe")
+        |> RiptideWeb.Endpoint.call(@opts)
 
       assert conn.status == 200
     end
@@ -99,7 +150,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
       conn =
         :get
-        |> conn("/streams/#{stream_id}/subscribe?token=valid-token")
+        |> conn("/streams/#{URI.encode_www_form(stream_id)}/subscribe?token=valid-token")
         |> RiptideWeb.Endpoint.call(@opts)
 
       assert conn.status == 200
@@ -110,10 +161,55 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
       conn =
         :get
-        |> conn("/streams/#{stream_id}/subscribe?token=garbage")
+        |> conn("/streams/#{URI.encode_www_form(stream_id)}/subscribe?token=garbage")
         |> RiptideWeb.Endpoint.call(@opts)
 
       assert conn.status == 401
+    end
+  end
+
+  describe "authorization" do
+    test "subscribing to a stream_id shaped like a tenant resource with no matching policy is denied with 403" do
+      tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
+      stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+
+      conn =
+        :get
+        |> conn("/streams/#{URI.encode_www_form(stream_id)}/subscribe")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 403
+    end
+
+    test "subscribing to a stream_id shaped like a tenant resource with a public read policy succeeds" do
+      tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
+      stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+      :ok =
+        Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+          effect: :allow,
+          modes: [:read],
+          matcher: :public
+        })
+
+      Riptide.Stream.StreamSupervisor.ensure_ready(stream_id)
+
+      conn =
+        :get
+        |> conn("/streams/#{URI.encode_www_form(stream_id)}/subscribe")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 200
+    end
+
+    test "a stream_id not shaped like a tenant resource (e.g. a legacy non-tenant-scoped id) is denied, not crashed" do
+      conn =
+        :get
+        |> conn("/streams/some-legacy-stream-id/subscribe")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 403
     end
   end
 end

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -2,8 +2,10 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   use ExUnit.Case, async: false
   use Plug.Test
 
+  alias Riptide.Authz.{Policy, Store}
   alias Riptide.Event
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias RiptideWeb.LDP.ResourceController
   alias RiptideWeb.Realtime.SseController
 
   @opts RiptideWeb.Endpoint.init([])
@@ -24,7 +26,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   # same pattern as `resource_controller_test.exs`'s Task 5 setup.
   setup do
     for tenant_id <- ["sse-test-tenant", "sse-gap-test-tenant"] do
-      Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+      Store.Placement.add_policy(tenant_id, [], %Policy{
         effect: :allow,
         modes: [:read],
         matcher: :public
@@ -36,7 +38,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
   defp unique_stream_id,
     do:
-      RiptideWeb.LDP.ResourceController.stream_id_for("sse-test-tenant", [
+      ResourceController.stream_id_for("sse-test-tenant", [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -48,7 +50,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   # "authentication" describe block's own `setup` below.
   defp unique_auth_stream_id,
     do:
-      RiptideWeb.LDP.ResourceController.stream_id_for("sse-auth-test-tenant", [
+      ResourceController.stream_id_for("sse-auth-test-tenant", [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -76,7 +78,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
   test "subscribing with a cursor older than the retention window returns 409 with a gap signal" do
     stream_id =
-      RiptideWeb.LDP.ResourceController.stream_id_for("sse-gap-test-tenant", [
+      ResourceController.stream_id_for("sse-gap-test-tenant", [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -121,7 +123,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
       Application.put_env(:riptide, :auth_verifier, StubVerifier)
       on_exit(fn -> Application.put_env(:riptide, :auth_verifier, original) end)
 
-      Riptide.Authz.Store.Placement.add_policy("sse-auth-test-tenant", [], %Riptide.Authz.Policy{
+      Store.Placement.add_policy("sse-auth-test-tenant", [], %Policy{
         effect: :allow,
         modes: [:read],
         matcher: :public
@@ -171,7 +173,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   describe "authorization" do
     test "subscribing to a stream_id shaped like a tenant resource with no matching policy is denied with 403" do
       tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
-      stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
 
       conn =
         :get
@@ -183,17 +185,17 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
     test "subscribing to a stream_id shaped like a tenant resource with a public read policy succeeds" do
       tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
-      stream_id = RiptideWeb.LDP.ResourceController.stream_id_for(tenant_id, ["doc"])
+      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
       on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
 
       :ok =
-        Riptide.Authz.Store.Placement.add_policy(tenant_id, [], %Riptide.Authz.Policy{
+        Store.Placement.add_policy(tenant_id, [], %Policy{
           effect: :allow,
           modes: [:read],
           matcher: :public
         })
 
-      Riptide.Stream.StreamSupervisor.ensure_ready(stream_id)
+      StreamSupervisor.ensure_ready(stream_id)
 
       conn =
         :get


### PR DESCRIPTION
## Summary

Riptide previously had tenant-scoped addressing (Phase 4a) and pluggable authentication (Phase 4b), but nothing enforced anything — any caller who knew or guessed a `tenant_id` and resource path could fully read/write it regardless of identity. This closes that gap with an ACP-inspired (not full Solid ACP spec) authorization model.

- `Riptide.Authz.Policy` — `%Policy{effect: :allow | :deny, modes: [:read | :write], matcher: :public | :authenticated | {:agent, subject}}`.
- `Riptide.Authz.Store` — pluggable behaviour (config-selected, default `Riptide.Authz.Store.Placement`), persisting policies via the *existing* shared placement Ra cluster (`PlacementMachine`'s state restructured from a flat `%{stream_id => nodes}` map to `%{streams: ..., policies: ...}`) rather than a second Ra cluster.
- `Riptide.Authz.evaluate/4` — pure, transport-agnostic decision function: container-inheritance (a policy on a path prefix applies to everything under it) + deny-overrides-allow + default-deny.
- `RiptideWeb.Plugs.Authorize` — enforces this on LDP HTTP routes, with an implicit bootstrap: the first authenticated write to a tenant with zero policies atomically claims tenant-root ownership (single Ra command, so two racing claims resolve to exactly one winner) — no separate tenant registry needed.
- SSE and WebSocket each recover `tenant_id`/path from their opaque, client-supplied `stream_id` via a new `parse_stream_id/1` (the exact inverse of the existing `stream_id_for/2`), then call the same `evaluate/4`.
- A minimal, tenant-root-only policy management API (`POST`/`GET /tenants/:tenant_id/policies`) lets an owner grant other agents access — gated by ordinary `:write`/`:read` (no `Control` mode this phase).

Deliberately out of scope (see spec §3): full Solid ACP compliance (Access Control Resources as discoverable resources, `Link` header discovery, client/VC/issuer matchers), a `Control` mode, sub-container policy management API, policy revocation.

Spec: `docs/superpowers/specs/2026-08-26-phase-4c-authorization-design.md`
Plan: `docs/superpowers/plans/2026-08-26-phase-4c-authorization.md`

## Known, deliberately-parked residual

`RiptideWeb.LDP.ResourceController.parse_stream_id/1` cannot distinguish a stream_id built from `path_segments: []` (tenant-root container) vs `[""]` (a single empty segment) — both encode to the identical string via Phase 4a's own `stream_id_for/2` string-join. This is an inherent, irresolvable ambiguity in that pre-existing encoding (not fixable at this phase's layer without changing Phase 4a's own format). Confirmed benign by two independent task reviews and the final whole-branch review: only affects SSE/WebSocket subscriptions to a tenant's exact root container, and only adds one harmless no-op evaluation prefix — never a policy bypass or cross-tenant leak.

## Test plan

- [x] Full suite: 219 tests, 0 failures
- [x] `mix credo --strict`: clean (exit 0)
- [x] `mix format --check-formatted`: clean
- [x] Per-task review (10/10 tasks) + final whole-branch review (opus) + one optional cleanup pass, all clean
- [x] Capstone end-to-end test: an owner grants a specific, previously-unenumerated agent read access via the policy API, and that agent's real LDP resource read then works while write stays correctly denied
- [x] Bootstrap race-safety proven via a real concurrent `Task.async` test against the live placement cluster (two simultaneous claims resolve to exactly one winner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)