### PR TITLE
Phase 4d: TLS (Ingress + cert-manager example manifests)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -343,9 +343,19 @@ sub-project 3 was decomposed into phases 3a-3d.
   full Solid ACP compliance — no Access Control Resources as discoverable resources, no
   client/VC/issuer matchers, no `Control` mode, no policy revocation yet; see the design spec §3
   for the complete list of deliberate omissions.
-- **Phase 4d — TLS.** Not yet designed.
+- **Phase 4d — TLS.** **Shipped 2026-08-26** — see
+  `docs/superpowers/specs/2026-08-26-phase-4d-tls-design.md`. TLS terminates at the Kubernetes
+  ingress, not in-app — no Elixir changes, confirmed by reading (not assuming) that
+  `config/prod.exs`'s `force_ssl` and `config/runtime.exs`'s `url: [scheme: "https"]` already
+  anticipate this. New example manifests: `k8s/ingress.yaml` (ingress-nginx, with
+  `proxy-buffering: "off"` and a 3600s `proxy-read-timeout` for Riptide's long-lived SSE/WebSocket
+  connections) and `k8s/cluster-issuer.yaml` (Let's Encrypt via ACME HTTP-01, staging + prod).
+  Wildcard/DNS-01 certs for the subdomain tenancy resolver are deliberately out of scope — see the
+  design spec's Out of scope section. Verified via `kubectl apply --dry-run=server` against a
+  scratch namespace on a live cluster (schema-valid), not a live-issued certificate — real ACME
+  issuance needs public DNS + a reachable ingress IP, which this phase does not provision.
 
-**Status**: Phases 4a-4c shipped 2026-08-26. Phase 4d not yet designed.
+**Status**: Phases 4a-4d shipped 2026-08-26. Sub-project 4 (Security & multi-tenancy) complete.
 
 ## 5. Not yet started
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,54 @@ docker compose up
 with `openssl rand -base64 48` or `mix phx.gen.secret`. `PHX_HOST` defaults to `localhost` in the
 compose file — set it to your real hostname for anything beyond local testing.
 
+## Running via Kubernetes
+
+Example manifests live in `k8s/` — a 3-replica `StatefulSet` (`k8s/statefulset.yaml`), a
+`ClusterIP` Service for client traffic (`k8s/service.yaml`), a headless Service for internal Ra/
+Erlang-distribution peer discovery (`k8s/headless-service.yaml`), and a Secret template for the
+two required env vars (`k8s/secret.example.yaml`). These assume a Kubernetes cluster and `kubectl`
+access already exist — copy `k8s/secret.example.yaml` to `secret.yaml` (git-ignored), fill in real
+values per its own comments, then:
+
+```bash
+kubectl apply -f k8s/secret.yaml
+kubectl apply -f k8s/headless-service.yaml -f k8s/service.yaml -f k8s/statefulset.yaml
+```
+
+### TLS
+
+`k8s/ingress.yaml` and `k8s/cluster-issuer.yaml` add TLS termination at the ingress, per this
+project's design (see `docs/superpowers/specs/2026-08-26-phase-4d-tls-design.md`) — Riptide itself
+never holds a certificate or speaks TLS directly. This requires
+[ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/) and
+[cert-manager](https://cert-manager.io/docs/installation/) already installed on your cluster.
+
+1. Edit `k8s/cluster-issuer.yaml`: replace both `REPLACE_ME@example.com` placeholders with a real
+   email address (Let's Encrypt uses this for expiry/problem notifications, not for
+   authentication), then `kubectl apply -f k8s/cluster-issuer.yaml`.
+2. Edit `k8s/ingress.yaml`: replace both `riptide.example.com` placeholders with your real
+   hostname, then `kubectl apply -f k8s/ingress.yaml`.
+3. Point that hostname's DNS at your ingress controller's external IP
+   (`kubectl get svc -n <ingress-nginx-namespace> ingress-nginx-controller`).
+4. Update `k8s/statefulset.yaml`'s `PHX_HOST` value to the same hostname (see the comment above
+   that field) and re-apply the StatefulSet.
+5. Verify: `kubectl describe certificate riptide-tls` should reach `Ready: True` once cert-manager
+   completes the ACME HTTP-01 challenge. While testing, point `k8s/ingress.yaml`'s
+   `cert-manager.io/cluster-issuer` annotation at `letsencrypt-staging` instead of
+   `letsencrypt-prod` first — Let's Encrypt's production endpoint has strict per-hostname rate
+   limits that a first attempt can easily exceed while debugging DNS/ingress setup. Staging certs
+   aren't trusted by browsers, so switch the annotation to `letsencrypt-prod` and re-apply once
+   staging succeeds.
+
+**Not covered by these manifests:** the subdomain-based tenancy resolver (see
+`docs/superpowers/specs/2026-08-26-phase-4a-multi-tenancy-data-model-design.md`) routes tenants by
+hostname (`tenant.riptide.example.com`), which needs a *wildcard* certificate — HTTP-01 (used
+above) cannot issue wildcards. If you're using that resolver, switch to a DNS-01 solver instead
+(provider-specific; see
+[cert-manager's ACME DNS-01 provider docs](https://cert-manager.io/docs/configuration/acme/dns01/))
+and request `*.riptide.example.com` in `k8s/ingress.yaml`'s `tls.hosts` instead of a single
+hostname.
+
 ## Releasing
 
 Riptide uses plain [semver](https://semver.org/) tags (`vMAJOR.MINOR.PATCH`, optionally with a

--- a/README.md
+++ b/README.md
@@ -99,22 +99,27 @@ never holds a certificate or speaks TLS directly. This requires
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/) and
 [cert-manager](https://cert-manager.io/docs/installation/) already installed on your cluster.
 
+Let's Encrypt's production endpoint has strict per-hostname rate limits that a first attempt can
+easily exceed while debugging DNS/ingress setup, so the steps below have you verify against the
+`letsencrypt-staging` issuer first — staging certs aren't trusted by browsers, but they prove the
+HTTP-01 challenge mechanics work before you spend a production issuance attempt on it.
+
 1. Edit `k8s/cluster-issuer.yaml`: replace both `REPLACE_ME@example.com` placeholders with a real
    email address (Let's Encrypt uses this for expiry/problem notifications, not for
    authentication), then `kubectl apply -f k8s/cluster-issuer.yaml`.
 2. Edit `k8s/ingress.yaml`: replace both `riptide.example.com` placeholders with your real
-   hostname, then `kubectl apply -f k8s/ingress.yaml`.
+   hostname, and change the `cert-manager.io/cluster-issuer` annotation from `letsencrypt-prod` to
+   `letsencrypt-staging` — then `kubectl apply -f k8s/ingress.yaml`.
 3. Point that hostname's DNS at your ingress controller's external IP
    (`kubectl get svc -n <ingress-nginx-namespace> ingress-nginx-controller`).
 4. Update `k8s/statefulset.yaml`'s `PHX_HOST` value to the same hostname (see the comment above
    that field) and re-apply the StatefulSet.
-5. Verify: `kubectl describe certificate riptide-tls` should reach `Ready: True` once cert-manager
-   completes the ACME HTTP-01 challenge. While testing, point `k8s/ingress.yaml`'s
-   `cert-manager.io/cluster-issuer` annotation at `letsencrypt-staging` instead of
-   `letsencrypt-prod` first — Let's Encrypt's production endpoint has strict per-hostname rate
-   limits that a first attempt can easily exceed while debugging DNS/ingress setup. Staging certs
-   aren't trusted by browsers, so switch the annotation to `letsencrypt-prod` and re-apply once
-   staging succeeds.
+5. Verify staging works: `kubectl describe certificate riptide-tls` should reach `Ready: True`
+   once cert-manager completes the ACME HTTP-01 challenge against the staging endpoint.
+6. Switch to production: edit `k8s/ingress.yaml` again, changing the annotation from
+   `letsencrypt-staging` to `letsencrypt-prod`, then re-apply and re-check
+   `kubectl describe certificate riptide-tls` for `Ready: True` against the real Let's Encrypt
+   endpoint.
 
 **Not covered by these manifests:** the subdomain-based tenancy resolver (see
 `docs/superpowers/specs/2026-08-26-phase-4a-multi-tenancy-data-model-design.md`) routes tenants by

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -52,3 +52,9 @@ kubectl delete -f statefulset.yaml -f service.yaml -f headless-service.yaml -f s
 
 `secret.yaml` is git-ignored (see the repo's `.gitignore`) — never commit real
 `RELEASE_COOKIE`/`SECRET_KEY_BASE` values.
+
+## TLS
+
+`ingress.yaml` and `cluster-issuer.yaml` (added in Phase 4d) add TLS termination at the ingress —
+see the top-level [`README.md`'s "Running via Kubernetes" § TLS](../README.md#tls) for the full
+setup walkthrough, rather than duplicating it here.

--- a/k8s/cluster-issuer.yaml
+++ b/k8s/cluster-issuer.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: REPLACE_ME@example.com
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: REPLACE_ME@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: riptide
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: ["riptide.example.com"]
+      secretName: riptide-tls
+  rules:
+    - host: riptide.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: riptide
+                port:
+                  number: 4000

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -30,6 +30,12 @@ spec:
                   fieldPath: status.podIP
             - name: PHX_SERVER
               value: "true"
+            # "riptide-headless" (the StatefulSet's own headless Service, k8s/headless-service.yaml)
+            # is correct for internal Erlang clustering with no public TLS configured yet. Once
+            # you apply k8s/ingress.yaml + k8s/cluster-issuer.yaml, change this to the real public
+            # hostname you configured there (e.g. "riptide.example.com") — Socket.check_origin for
+            # the /replication WebSocket validates against this value, and force_ssl's redirect
+            # target depends on it matching what clients actually connect to.
             - name: PHX_HOST
               value: "riptide-headless"
             - name: RELEASE_COOKIE


### PR DESCRIPTION
## Summary

Closes out sub-project 4 (Security & multi-tenancy) with its final phase: TLS. Terminates TLS at the Kubernetes ingress, not in-app — confirmed by reading (not assuming) that `config/prod.exs`'s `force_ssl` and `config/runtime.exs`'s `url: [scheme: "https"]` already anticipate this, so no Elixir code changes are part of this phase.

- `k8s/ingress.yaml` — example ingress-nginx Ingress with a cert-manager `ClusterIssuer` annotation, plus `proxy-buffering: "off"` and a 3600s `proxy-read-timeout` for Riptide's long-lived SSE/WebSocket connections.
- `k8s/cluster-issuer.yaml` — Let's Encrypt `ClusterIssuer`s (staging + prod) via ACME HTTP-01.
- `k8s/statefulset.yaml` — documents that `PHX_HOST` must become the real public hostname once TLS is configured.
- `README.md` — new "Running via Kubernetes" section (the whole `k8s/` directory was previously undocumented) covering the existing StatefulSet/Services plus the new TLS setup.
- `PROGRESS.md` — Phase 4d marked shipped; sub-project 4 marked complete.

Wildcard/DNS-01 certs (needed for Phase 4a's subdomain tenancy resolver) are explicitly out of scope — see the design spec.

Design spec: `docs/superpowers/specs/2026-08-26-phase-4d-tls-design.md`
Plan: `docs/superpowers/plans/2026-08-26-phase-4d-tls.md`

## Test plan

- [x] `mix test` — 220 tests, 0 failures (no lib/test changes in this phase; run to confirm nothing broke)
- [x] `kubectl apply --dry-run=server` against a scratch namespace on a live cluster — both new manifests schema-valid (Ingress against core `networking.k8s.io/v1`, ClusterIssuer against cert-manager's installed CRD)
- [x] Per-task and final whole-branch review, both clean (two Minor doc-consistency nits noted, not blocking — see PR description below)

## Known follow-ups (not blocking)

1. README's "test `letsencrypt-staging` first" guidance (step 5) reads after the ingress-apply step (step 2), which ships with the `letsencrypt-prod` annotation by default — an operator following the doc top-to-bottom could hit Let's Encrypt's prod rate limits before reading the staging advice.
2. `k8s/README.md` (pre-existing, Phase 3b-era) is now stale relative to the new top-level README "Running via Kubernetes" section — two partially-divergent K8s guides exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)