### PR TITLE
Phase 5a: health/readiness probes

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Riptide — Production Readiness Roadmap
 
-**Last updated:** 2026-08-26
+**Last updated:** 2026-08-27
 
 This tracks Riptide's path from "working reference implementation" (shipped: see
 [PR #1](https://github.com/OpenFASTER-Standard/riptide/pull/1)) to "production-grade centerpiece
@@ -15,7 +15,7 @@ first place to check for current status, not a historical log.
 | 2 | Docker image + CI/CD | **Shipped** — see below |
 | 3 | Clustering / horizontal scale / HA | **Decomposed into phases 3a-3d** — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
-| 5 | Observability & operability (metrics, logging, health probes) | Not started |
+| 5 | Observability & operability (metrics, logging, health probes) | **Decomposed into phases 5a-5c** — see below |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -357,6 +357,23 @@ sub-project 3 was decomposed into phases 3a-3d.
 
 **Status**: Phases 4a-4d shipped 2026-08-26. Sub-project 4 (Security & multi-tenancy) complete.
 
-## 5. Not yet started
+## 5. Observability & operability — decomposed into phases
 
-Will be filled in as this sub-project reaches design.
+**Goal for this sub-project**: health/readiness probes, structured logging, and metrics — three
+independent concerns, decomposed into phases the same way sub-projects 3 and 4 were, rather than
+one monolithic spec.
+
+**Phasing:**
+
+- **Phase 5a — Health & readiness probes.** **Shipped 2026-08-27** — see
+  `docs/superpowers/specs/2026-08-27-phase-5a-health-probes-design.md`. The single, always-`200`
+  `/health` route (which checked nothing) is replaced by `/health/live` (unconditional `200`, used
+  for the StatefulSet's `livenessProbe`) and `/health/ready` (a real check — a cheap
+  `Riptide.Placement.lookup/1` call against the shared placement Ra cluster, since every
+  LDP/SSE/WebSocket request needs that cluster reachable to resolve stream placement; used for the
+  `readinessProbe`). A node cut off from placement now stops receiving traffic instead of silently
+  reporting healthy. No supervision-tree changes; the old route was removed outright with no alias.
+- **Phase 5b — Structured logging.** Not yet designed.
+- **Phase 5c — Metrics.** Not yet designed.
+
+**Status**: Phase 5a shipped 2026-08-27. Phases 5b/5c not yet designed.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,7 +7,7 @@ config :riptide, RiptideWeb.Endpoint,
   force_ssl: [
     rewrite_on: [:x_forwarded_proto],
     exclude: [
-      paths: ["/health"],
+      paths: ["/health/live", "/health/ready"],
       hosts: ["localhost", "127.0.0.1"]
     ]
   ]

--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -51,15 +51,24 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+          # readinessProbe calls Riptide.Placement.lookup/1, which retries
+          # across all 3 placement ordinals on failure. Each attempt carries
+          # :ra's own 5000ms default query timeout (deps/ra/src/ra.hrl's
+          # DEFAULT_TIMEOUT), so a fully-unreachable placement cluster can
+          # take up to ~15s to resolve to a 503. timeoutSeconds is set to 5s
+          # (one ordinal attempt's worth) rather than k8s's 1s default, which
+          # was already too short even for a single healthy attempt under
+          # any real network latency or in-flight leader election.
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 4000
             initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /health
+              path: /health/live
               port: 4000
             initialDelaySeconds: 10
             periodSeconds: 30

--- a/lib/riptide_web/health_controller.ex
+++ b/lib/riptide_web/health_controller.ex
@@ -1,7 +1,26 @@
 defmodule RiptideWeb.HealthController do
   use Phoenix.Controller
 
-  def show(conn, _params) do
+  # Never a real stream — just needs to reach `PlacementMachine.get/2`'s O(1)
+  # map lookup so `/health/ready` proves the placement Ra cluster answers,
+  # without the cost of `Placement.list_all/1`'s full streams-map payload.
+  @health_check_stream_id "__riptide_health_check__"
+
+  # Deliberately checks nothing beyond "is Phoenix itself responsive" — a
+  # degraded downstream dependency (e.g. an unreachable placement cluster)
+  # must never trigger a pod restart, only a readiness failure (see ready/2).
+  def live(conn, _params) do
     send_resp(conn, 200, "ok")
+  end
+
+  # Riptide.Placement.lookup/1 raises (via with_ordinal_fallback/2 exhausting
+  # all 3 placement ordinals) when the shared placement Ra cluster is
+  # unreachable — every LDP/SSE/WebSocket request needs this cluster to
+  # resolve stream placement, so its reachability is what "ready" means here.
+  def ready(conn, _params) do
+    Riptide.Placement.lookup(@health_check_stream_id)
+    send_resp(conn, 200, "ok")
+  rescue
+    _ -> send_resp(conn, 503, "not ready")
   end
 end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -20,7 +20,8 @@ defmodule RiptideWeb.Router do
   scope "/" do
     pipe_through :api
 
-    get "/health", RiptideWeb.HealthController, :show
+    get "/health/live", RiptideWeb.HealthController, :live
+    get "/health/ready", RiptideWeb.HealthController, :ready
   end
 
   scope "/" do

--- a/test/riptide_web/health_test.exs
+++ b/test/riptide_web/health_test.exs
@@ -33,7 +33,7 @@ defmodule RiptideWeb.HealthTest do
     # this override never races a concurrently-running async test.
     test "returns 503 when the placement cluster is unreachable" do
       original = Application.get_env(:riptide, :ordinal_resolver)
-      Application.put_env(:riptide, :ordinal_resolver, fn _ordinal -> :"nonexistent@nohost" end)
+      Application.put_env(:riptide, :ordinal_resolver, fn _ordinal -> :nonexistent@nohost end)
       on_exit(fn -> Application.put_env(:riptide, :ordinal_resolver, original) end)
 
       conn =

--- a/test/riptide_web/health_test.exs
+++ b/test/riptide_web/health_test.exs
@@ -1,16 +1,47 @@
 defmodule RiptideWeb.HealthTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use Plug.Test
 
   @opts RiptideWeb.Endpoint.init([])
 
-  test "GET /health returns 200 ok" do
-    conn =
-      :get
-      |> conn("/health")
-      |> RiptideWeb.Endpoint.call(@opts)
+  describe "GET /health/live" do
+    test "returns 200 ok unconditionally" do
+      conn =
+        :get
+        |> conn("/health/live")
+        |> RiptideWeb.Endpoint.call(@opts)
 
-    assert conn.status == 200
-    assert conn.resp_body == "ok"
+      assert conn.status == 200
+      assert conn.resp_body == "ok"
+    end
+  end
+
+  describe "GET /health/ready" do
+    test "returns 200 ok when the placement cluster is reachable" do
+      conn =
+        :get
+        |> conn("/health/ready")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 200
+      assert conn.resp_body == "ok"
+    end
+
+    # :ordinal_resolver is global Application state that every other test
+    # touching Riptide.Placement/RaCluster also reads (config/test.exs:33
+    # sets it suite-wide) — this test module is async: false specifically so
+    # this override never races a concurrently-running async test.
+    test "returns 503 when the placement cluster is unreachable" do
+      original = Application.get_env(:riptide, :ordinal_resolver)
+      Application.put_env(:riptide, :ordinal_resolver, fn _ordinal -> :"nonexistent@nohost" end)
+      on_exit(fn -> Application.put_env(:riptide, :ordinal_resolver, original) end)
+
+      conn =
+        :get
+        |> conn("/health/ready")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 503
+    end
   end
 end


### PR DESCRIPTION
## Summary

First phase of sub-project 5 (Observability & operability). Replaces the single, always-`200` `/health` endpoint — which checked nothing — with two real probes:

- `/health/live` — unconditional `200`, identical to today's behavior. Deliberately has zero external dependency, so a degraded downstream system never triggers a pod restart.
- `/health/ready` — a real check: a cheap `Riptide.Placement.lookup/1` call (O(1) map lookup via a fixed sentinel stream ID) against the shared placement Ra cluster, since every LDP/SSE/WebSocket request needs that cluster reachable to resolve stream placement. Returns `503` (never a crash) if the cluster is unreachable.

A node cut off from placement now stops receiving traffic instead of silently reporting healthy.

- `k8s/statefulset.yaml` — `readinessProbe` → `/health/ready` (+ new `timeoutSeconds: 5`, since Ra's own 5000ms default query timeout × 3 ordinal fallback attempts means a full outage can take ~15s to resolve), `livenessProbe` → `/health/live`.
- `config/prod.exs` — `force_ssl` exclude paths updated to both new routes.
- Old `/health` route removed outright, no alias — Riptide's own manifests are the only real consumer.
- `PROGRESS.md` — Phase 5a marked shipped; sub-project 5 now shows phases 5a-5c (5b/5c not yet designed).

Design spec: `docs/superpowers/specs/2026-08-27-phase-5a-health-probes-design.md`
Plan: `docs/superpowers/plans/2026-08-27-phase-5a-health-probes.md`

## Test plan

- [x] `mix test` — 222 tests, 0 failures, including a new failure-case test that forces the placement cluster unreachable (overrides `:ordinal_resolver` to an unreachable node, `async: false`, restores in `on_exit`) and asserts `503`
- [x] `MIX_ENV=prod mix compile --force` — confirms `config/prod.exs` actually loads and parses (plain `mix compile` never touches it, since `Mix.env()` defaults to `:dev`)
- [x] `kubectl` dry-run YAML validation for the statefulset probe changes
- [x] Per-task and final whole-branch review, both clean

## Known follow-up (not blocking)

The readiness probe's `timeoutSeconds: 5` means Kubernetes abandons the HTTP request before `/health/ready`'s own ~15s full-outage worst case ever resolves to an explicit `503` — the readiness *outcome* is identical either way (pod goes unready), but a partial outage where the first ordinal is merely slow could cause a false-negative readiness flap right at the 5s boundary. Spec explicitly deferred a custom timeout wrapper; worth revisiting in a later 5b/5c-era pass if it becomes a real operational issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)