### PR TITLE
Comprehensive audit remediation: correctness, security, concurrency, resilience, resources, observability

### DIFF
--- a/k8s/statefulset.yaml
+++ b/k8s/statefulset.yaml
@@ -14,12 +14,37 @@ spec:
     metadata:
       labels:
         app: riptide
+      annotations:
+        # No-op unless a Prometheus configured for annotation-based scrape
+        # discovery is present in the cluster — see README.md's "Metrics"
+        # section. Shipped on by default rather than left as a README-only
+        # step an operator has to remember to add themselves.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
       securityContext:
         fsGroup: 1000
       containers:
         - name: riptide
           image: ghcr.io/openfaster-standard/riptide:latest
+          securityContext:
+            # Matches the Dockerfile's own `USER riptide` (uid/gid 1000) —
+            # defense in depth, not a bypass: the image already never runs
+            # as root, this just makes Kubernetes enforce the same thing
+            # even if a future image change regresses that.
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
           ports:
             - name: http
               containerPort: 4000

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -59,7 +59,21 @@ defmodule Riptide.Application do
   defp placement_bootstrap_children do
     if System.get_env("HOSTNAME") in Riptide.RaCluster.placement_ordinals() do
       [
-        {Task, &Riptide.RaCluster.ensure_placement_cluster_started/0},
+        # `Task`'s own default child_spec restarts as `:temporary` — fine
+        # for `ensure_placement_cluster_started/0`'s own {:error, _} branch,
+        # which already retries forever internally, but NOT fine for any
+        # exception that isn't already anticipated there (e.g. `:ra.start_cluster/2`
+        # exiting instead of returning): a `:temporary` Task that dies from
+        # one of those is never restarted, silently leaving this ordinal
+        # permanently out of the placement cluster for the rest of the
+        # pod's lifetime. `ensure_placement_cluster_started/0` is itself
+        # documented as safe to call redundantly (self-corrects on
+        # `{:error, :cluster_not_formed}` from an already-formed cluster),
+        # so a supervisor-driven restart on `:permanent` is a safe, correct
+        # recovery path with no special-casing needed here.
+        Supervisor.child_spec({Task, &Riptide.RaCluster.ensure_placement_cluster_started/0},
+          restart: :permanent
+        ),
         Riptide.Stream.ReplicaHealer
       ]
     else

--- a/lib/riptide/auth/jwks_strategy.ex
+++ b/lib/riptide/auth/jwks_strategy.ex
@@ -12,7 +12,22 @@ defmodule Riptide.Auth.JwksStrategy do
   """
   use JokenJwks.DefaultStrategyTemplate
 
+  # Without an explicit timeout, `Tesla.Adapter.Httpc` (this project's
+  # configured adapter — see config/config.exs) defaults `:httpc`'s own
+  # `timeout`/`connect_timeout` to `:infinity`. `fetch_signers/2` runs
+  # synchronously inside this GenServer's own `handle_info(:check_fetch, ...)`
+  # callback, and the NEXT check is only scheduled after that call returns —
+  # so a JWKS endpoint that accepts the TCP connection but never responds (a
+  # flaky or attacker-influenced IdP) would otherwise wedge this process
+  # forever: no future re-fetch ever fires, and any JWT with a new/rotated
+  # `kid` becomes permanently unverifiable on this node until it restarts.
+  @http_timeout_ms 5_000
+
   def init_opts(opts) do
-    Keyword.put_new(opts, :jwks_url, Application.get_env(:riptide, :oidc_jwks_url))
+    opts
+    |> Keyword.put_new(:jwks_url, Application.get_env(:riptide, :oidc_jwks_url))
+    |> Keyword.put_new(:http_middlewares, [
+      {Tesla.Middleware.Timeout, timeout: @http_timeout_ms}
+    ])
   end
 end

--- a/lib/riptide/auth/token_config.ex
+++ b/lib/riptide/auth/token_config.ex
@@ -26,11 +26,23 @@ defmodule Riptide.Auth.TokenConfig do
   the *token's own* decoded claims and only runs a claim's validator when
   that claim is actually present — it never enforces that a configured
   claim key show up in the token at all. Left alone, this means a validly
-  signed token that simply omits `exp`, `iss`, or `aud` would skip that
-  claim's check entirely and be accepted. `verify_and_validate_required_claims/1`
-  closes that gap by requiring all three to be present *and non-null*, on
+  signed token that simply omits `exp`, `iss`, `aud`, or `sub` would skip
+  that claim's check entirely and be accepted. `verify_and_validate_required_claims/1`
+  closes that gap by requiring all four to be present *and non-null*, on
   top of whatever `verify_and_validate/1` (Joken.Config's own generated
   function) already checks for claims that are present.
+
+  `sub` is required for a security reason distinct from the other three:
+  `Riptide.Authz`'s `{:agent, subject}` matcher (and the tenant-bootstrap
+  path in `RiptideWeb.Plugs.Authorize.maybe_bootstrap/4` that creates it)
+  compares `current_subject["sub"] == subject`. A token that validly omits
+  `sub` would make `current_subject["sub"]` evaluate to `nil` — and if such
+  a token happened to be the first to write to a brand-new tenant, the
+  stored owner policy would become `{:agent, nil}`, which then matches
+  *any other* authenticated request whose token also lacks `sub`, granting
+  a completely different principal full access to that tenant. Requiring
+  `sub` here closes that off at the token-verification boundary, before it
+  can ever reach the authorization layer.
 
   The non-null part matters on its own: a token with an explicit `"exp":
   null` (present, not omitted) still passes Joken's own default `exp`
@@ -47,7 +59,7 @@ defmodule Riptide.Auth.TokenConfig do
 
   add_hook(JokenJwks, strategy: Riptide.Auth.JwksStrategy)
 
-  @required_claims ~w(exp iss aud)
+  @required_claims ~w(exp iss aud sub)
 
   @impl Joken.Config
   def token_config do

--- a/lib/riptide/authz.ex
+++ b/lib/riptide/authz.ex
@@ -21,11 +21,24 @@ defmodule Riptide.Authz do
       |> Enum.flat_map(&store.list_policies(tenant_id, &1))
       |> Enum.filter(&applies?(&1, current_subject, mode))
 
-    cond do
-      Enum.any?(matching_policies, &(&1.effect == :deny)) -> :deny
-      Enum.any?(matching_policies, &(&1.effect == :allow)) -> :allow
-      true -> :deny
-    end
+    effect =
+      cond do
+        Enum.any?(matching_policies, &(&1.effect == :deny)) -> :deny
+        Enum.any?(matching_policies, &(&1.effect == :allow)) -> :allow
+        true -> :deny
+      end
+
+    # `effect`/`mode` are both small, fixed sets (2 values each) — safe to
+    # tag without violating the cardinality constraint every other metric in
+    # this codebase follows (see Riptide.Telemetry's own moduledoc). Without
+    # this, a systemic authz failure (e.g. the policy store starts returning
+    # empty for an unrelated reason, so `evaluate/4`'s own default-deny
+    # kicks in for every request) is invisible on any dashboard — the only
+    # signal would be an HTTP 403-rate bump on the LDP routes, and SSE/WS
+    # authorization denials have no equivalent status-coded metric at all.
+    :telemetry.execute([:riptide, :authz, :decision], %{}, %{effect: effect, mode: mode})
+
+    effect
   end
 
   # Every prefix of path_segments, including the empty one (the tenant
@@ -41,6 +54,17 @@ defmodule Riptide.Authz do
 
   defp matches?(:public, _current_subject), do: true
   defp matches?(:authenticated, current_subject), do: not is_nil(current_subject)
+
+  # `subject: nil` never matches, even against a `current_subject` that also
+  # lacks a `sub` claim — an `{:agent, nil}` policy would otherwise mean "any
+  # authenticated request whose token happens to omit `sub`," which defeats
+  # the whole point of an agent-scoped policy (one specific principal, not a
+  # class of them). `Riptide.Auth.TokenConfig` now requires `sub` on every
+  # verified token, so a `nil` matcher subject should never be created going
+  # forward — this guard is defense in depth for any policy that predates
+  # that requirement or is inserted through a path other than token-based
+  # bootstrap.
+  defp matches?({:agent, nil}, _current_subject), do: false
 
   defp matches?({:agent, subject}, current_subject),
     do: not is_nil(current_subject) and current_subject["sub"] == subject

--- a/lib/riptide/authz/store.ex
+++ b/lib/riptide/authz/store.ex
@@ -10,7 +10,8 @@ defmodule Riptide.Authz.Store do
   alias Riptide.Authz.Policy
 
   @callback list_policies(tenant_id :: String.t(), path_prefix :: [String.t()]) :: [Policy.t()]
-  @callback add_policy(tenant_id :: String.t(), path_prefix :: [String.t()], Policy.t()) :: :ok
+  @callback add_policy(tenant_id :: String.t(), path_prefix :: [String.t()], Policy.t()) ::
+              :ok | {:error, :too_many_policies}
   @callback claim_tenant_if_unclaimed(tenant_id :: String.t(), subject :: String.t()) ::
               :claimed | :already_claimed
 end

--- a/lib/riptide/placement.ex
+++ b/lib/riptide/placement.ex
@@ -17,6 +17,8 @@ defmodule Riptide.Placement do
   cluster stayed healthy via its other members the whole time.
   """
 
+  require Logger
+
   alias Riptide.Placement.PlacementMachine
   alias Riptide.RaCluster
 
@@ -83,7 +85,7 @@ defmodule Riptide.Placement do
   end
 
   @spec add_policy(String.t(), [String.t()], Riptide.Authz.Policy.t(), (String.t() -> node())) ::
-          :ok
+          :ok | {:error, :too_many_policies}
   def add_policy(
         tenant_id,
         path_prefix,
@@ -139,6 +141,35 @@ defmodule Riptide.Placement do
   defp try_ordinals([ordinal | rest], resolve_fun, fun) do
     fun.(RaCluster.placement_server_id(ordinal, resolve_fun))
   rescue
-    _ -> try_ordinals(rest, resolve_fun, fun)
+    e ->
+      log_ordinal_fallback(ordinal, Exception.message(e))
+      try_ordinals(rest, resolve_fun, fun)
+  catch
+    # `RaCluster.process_command/2`/`consistent_query/2` now always raise
+    # rather than exit (see their own `catch :exit` doc) — this remains as
+    # defense in depth for any other failure this call chain could
+    # eventually surface as a raw exit, so a single ordinal's failure keeps
+    # falling through to the next one instead of defeating the whole point
+    # of this fallback.
+    :exit, reason ->
+      log_ordinal_fallback(ordinal, inspect(reason))
+      try_ordinals(rest, resolve_fun, fun)
+  end
+
+  # A single ordinal failing over is expected/routine during a rolling
+  # restart or a transient network blip — this is intentionally a warning,
+  # not swallowed silently, so a *persistently* unreachable ordinal (one
+  # that fails on every call for an extended period) is at least visible in
+  # logs even though only total failure (all 3 ordinals down) is reflected
+  # in the `riptide.placement.lookup/assign.errors` metrics.
+  defp log_ordinal_fallback(ordinal, reason) do
+    Logger.warning(
+      "Riptide.Placement: ordinal #{inspect(ordinal)} failed, falling back to the next one " <>
+        "(#{reason})",
+      ordinal: ordinal,
+      reason: reason
+    )
+
+    :telemetry.execute([:riptide, :placement, :ordinal_fallback], %{}, %{})
   end
 end

--- a/lib/riptide/placement.ex
+++ b/lib/riptide/placement.ex
@@ -84,6 +84,31 @@ defmodule Riptide.Placement do
     end)
   end
 
+  # See Riptide.Placement.PlacementMachine's own moduledoc ("Repair claims")
+  # for the full rationale: fences Riptide.Stream.ReplicaHealer's repair
+  # against two placement ordinals both believing they're the leader at
+  # once. `now_ts` is computed here (the caller), not inside `apply/3` —
+  # reading the wall clock inside a Ra machine callback would break replica
+  # determinism.
+  @spec claim_repair(String.t(), node(), (String.t() -> node())) :: :claimed | :already_claimed
+  def claim_repair(stream_id, dead_node, resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
+    now_ts = System.system_time(:second)
+
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(
+        server_id,
+        {:claim_repair, stream_id, dead_node, node(), now_ts}
+      )
+    end)
+  end
+
+  @spec release_repair(String.t(), (String.t() -> node())) :: :ok
+  def release_repair(stream_id, resolve_fun \\ &RaCluster.default_ordinal_resolver/1) do
+    with_ordinal_fallback(resolve_fun, fn server_id ->
+      RaCluster.process_command(server_id, {:release_repair, stream_id, node()})
+    end)
+  end
+
   @spec add_policy(String.t(), [String.t()], Riptide.Authz.Policy.t(), (String.t() -> node())) ::
           :ok | {:error, :too_many_policies}
   def add_policy(

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -9,14 +9,42 @@ defmodule Riptide.Placement.PlacementMachine do
   run via `Riptide.RaCluster.consistent_query/2`.
 
   Internal state is `%{streams: %{stream_id() => [node()]}, policies:
-  %{tenant_id() => %{path_prefix() => [policy()]}}}` — two independent
-  namespaces in one already-hardened, already-bootstrapped Ra cluster,
-  rather than a second cluster to operate. `list/1`'s own external contract
-  is deliberately unchanged (`%{stream_id() => [node()]}` only): it backs
+  %{tenant_id() => %{path_prefix() => [policy()]}}, repair_claims:
+  %{stream_id() => repair_claim()}}` — three independent namespaces in one
+  already-hardened, already-bootstrapped Ra cluster, rather than a second
+  cluster to operate. `list/1`'s own external contract is deliberately
+  unchanged (`%{stream_id() => [node()]}` only): it backs
   `Riptide.Placement.list_all/1`, which `Riptide.Stream.ReplicaHealer.sweep/0`
   iterates expecting *only* `{stream_id, nodes}` entries — mixing a policies
-  key into that same flat map would make the healer call
+  or repair_claims key into that same flat map would make the healer call
   `RaCluster.uid_for/1` on a non-stream-id key and crash its next sweep.
+
+  ## Repair claims (audit remediation, 2026-08-27)
+
+  `RaCluster.placement_leader?/0` is an unfenced, point-in-time local read
+  with no lease — during a leadership handoff or partition, two different
+  placement ordinals can both briefly believe they're the leader and both
+  run `Riptide.Stream.ReplicaHealer.sweep/0` concurrently for the same dead
+  replica. Since `pick_replacement/2`'s own determinism guarantee only holds
+  "as long as the cluster is fully connected" (see its own doc) — exactly
+  the condition a partition breaks — the two racing healers can pick
+  *different* replacement nodes and each fully add/join their own choice to
+  the stream's real Ra cluster before either gets to `remove_member`,
+  leaving a genuinely over-replicated, untracked extra member with no
+  cleanup path.
+
+  `{:claim_repair, ...}`/`{:release_repair, ...}` route the *decision to
+  start repairing a given `{stream_id, dead_node}` pair* through this same
+  Raft-serialized state machine, so only one committed claim can ever be
+  granted at a time for a given stream — not just one leader's point-in-time
+  belief. `claimed_at` is a timestamp the CALLER computes and passes in as
+  part of the command (never read from the wall clock inside `apply/3`
+  itself, which would break replica determinism); a claim older than
+  `@claim_ttl_seconds` can be stolen by a fresh claimant, so a claimer that
+  crashes or fails to release doesn't permanently wedge that stream's repair
+  path — the TTL is generous relative to both the sweep interval and a
+  realistic repair's own duration, so it should essentially never fire in
+  the normal case where the original claimant successfully releases.
   """
   @behaviour :ra_machine
 
@@ -24,14 +52,18 @@ defmodule Riptide.Placement.PlacementMachine do
   @type tenant_id :: String.t()
   @type path_prefix :: [String.t()]
   @type policy :: struct()
+  @type repair_claim :: %{dead_node: node(), claimant: node(), claimed_at: integer()}
 
   @type state :: %{
           streams: %{stream_id() => [node()]},
-          policies: %{tenant_id() => %{path_prefix() => [policy()]}}
+          policies: %{tenant_id() => %{path_prefix() => [policy()]}},
+          repair_claims: %{stream_id() => repair_claim()}
         }
 
+  @claim_ttl_seconds 120
+
   @impl :ra_machine
-  def init(_config), do: %{streams: %{}, policies: %{}}
+  def init(_config), do: %{streams: %{}, policies: %{}, repair_claims: %{}}
 
   # Idempotent by construction — see Phase 3c-i design spec §4. Since every
   # command is serialized through Raft consensus, whichever proposal for a
@@ -73,6 +105,47 @@ defmodule Riptide.Placement.PlacementMachine do
     end
   end
 
+  # Grants exclusive right to repair `{stream_id, dead_node}` to `claimant`,
+  # unless: (a) no claim exists yet, (b) the existing claim already belongs
+  # to this same claimant/dead_node pair (idempotent retry — e.g. the same
+  # leader's sweep running again before it got to release), or (c) the
+  # existing claim has aged past `@claim_ttl_seconds` (its holder presumably
+  # crashed or otherwise failed to release). Otherwise denies — a DIFFERENT
+  # claimant already holds a live claim on this stream.
+  @impl :ra_machine
+  def apply(_meta, {:claim_repair, stream_id, dead_node, claimant, now_ts}, state) do
+    case Map.get(state.repair_claims, stream_id) do
+      nil ->
+        grant_repair_claim(state, stream_id, dead_node, claimant, now_ts)
+
+      %{claimant: ^claimant, dead_node: ^dead_node} ->
+        grant_repair_claim(state, stream_id, dead_node, claimant, now_ts)
+
+      %{claimed_at: claimed_at} when now_ts - claimed_at > @claim_ttl_seconds ->
+        grant_repair_claim(state, stream_id, dead_node, claimant, now_ts)
+
+      _held_by_someone_else ->
+        {state, :already_claimed, []}
+    end
+  end
+
+  # Releases `claimant`'s own claim, if it still holds one — a release from
+  # a claimant that doesn't currently hold the claim (already expired and
+  # stolen by a fresh claimant, or never held one) is a safe no-op rather
+  # than an error, so a stale/duplicate release can never clear someone
+  # else's active claim.
+  @impl :ra_machine
+  def apply(_meta, {:release_repair, stream_id, claimant}, state) do
+    case Map.get(state.repair_claims, stream_id) do
+      %{claimant: ^claimant} ->
+        new_state = %{state | repair_claims: Map.delete(state.repair_claims, stream_id)}
+        {new_state, :ok, []}
+
+      _not_this_claimant ->
+        {state, :ok, []}
+    end
+  end
+
   # Bounds unbounded growth from a client (malicious, or merely a buggy
   # retry loop) calling `POST /tenants/:id/policies` with the same or
   # near-identical body repeatedly: `existing ++ [policy]` with no cap would
@@ -100,7 +173,11 @@ defmodule Riptide.Placement.PlacementMachine do
 
       true ->
         new_state =
-          put_in(state, [:policies, Access.key(tenant_id, %{}), path_prefix], existing ++ [policy])
+          put_in(
+            state,
+            [:policies, Access.key(tenant_id, %{}), path_prefix],
+            existing ++ [policy]
+          )
 
         {new_state, :ok, []}
     end
@@ -130,6 +207,12 @@ defmodule Riptide.Placement.PlacementMachine do
 
   defp replace_in_list(nodes, dead_node, new_node) do
     Enum.map(nodes, fn n -> if n == dead_node, do: new_node, else: n end)
+  end
+
+  defp grant_repair_claim(state, stream_id, dead_node, claimant, now_ts) do
+    claim = %{dead_node: dead_node, claimant: claimant, claimed_at: now_ts}
+    new_state = put_in(state, [:repair_claims, stream_id], claim)
+    {new_state, :claimed, []}
   end
 
   defp tenant_claimed?(state, tenant_id) do

--- a/lib/riptide/placement/placement_machine.ex
+++ b/lib/riptide/placement/placement_machine.ex
@@ -73,17 +73,37 @@ defmodule Riptide.Placement.PlacementMachine do
     end
   end
 
-  # Same idempotent-by-construction shape as {:assign, ...}: every command is
-  # serialized through Raft, so concurrent `add_policy` calls for the same
-  # tenant/prefix are safely ordered by the log rather than racing.
+  # Bounds unbounded growth from a client (malicious, or merely a buggy
+  # retry loop) calling `POST /tenants/:id/policies` with the same or
+  # near-identical body repeatedly: `existing ++ [policy]` with no cap would
+  # otherwise grow this in-memory, Raft-replicated list forever, and every
+  # entry is scanned linearly on every `Riptide.Authz.evaluate/4` call for
+  # that tenant, so unbounded growth here also degrades every authorization
+  # decision's latency. Deduplicating exact-duplicate policies closes the
+  # most common case (identical retries) for free; `@max_policies_per_prefix`
+  # bounds the rest. Same idempotent-by-construction shape as {:assign, ...}
+  # otherwise: every command is serialized through Raft, so concurrent
+  # `add_policy` calls for the same tenant/prefix are safely ordered by the
+  # log rather than racing.
+  @max_policies_per_prefix 1000
+
   @impl :ra_machine
   def apply(_meta, {:add_policy, tenant_id, path_prefix, policy}, state) do
     existing = state.policies |> Map.get(tenant_id, %{}) |> Map.get(path_prefix, [])
 
-    new_state =
-      put_in(state, [:policies, Access.key(tenant_id, %{}), path_prefix], existing ++ [policy])
+    cond do
+      policy in existing ->
+        {state, :ok, []}
 
-    {new_state, :ok, []}
+      length(existing) >= @max_policies_per_prefix ->
+        {state, {:error, :too_many_policies}, []}
+
+      true ->
+        new_state =
+          put_in(state, [:policies, Access.key(tenant_id, %{}), path_prefix], existing ++ [policy])
+
+        {new_state, :ok, []}
+    end
   end
 
   # A tenant is "unclaimed" if it has zero policies at every path prefix —

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -6,6 +6,8 @@ defmodule Riptide.RaCluster do
   differs from what's written here, this is the one place to fix it.
   """
 
+  require Logger
+
   @system :default
 
   @spec server_id(String.t()) :: :ra.server_id()
@@ -173,6 +175,18 @@ defmodule Riptide.RaCluster do
   # multi-node membership, these paths need graceful handling/retry (e.g.
   # redirecting to the current leader on `{:error, {:redirect, _}}` or backing
   # off and retrying a transient `{:timeout, _}`) rather than raising.
+  # Wrapped in `catch :exit` for the same reason `placement_leader?/0` and
+  # `member_alive?/1` already are (see their own docs): `gen_statem_safe_call/3`
+  # only converts `timeout`/`noproc`/`nodedown`/`shutdown` exits into a
+  # return value this `case` can match — any OTHER exit (e.g. the target
+  # `ra_server_proc` crashing for an unrelated reason mid-call) propagates as
+  # a raw `exit` a plain `case` can't catch, which previously meant callers
+  # relying on "this function always raises, never exits" (e.g.
+  # `Riptide.Placement.with_ordinal_fallback/2`'s `rescue`-based ordinal
+  # fallback) could still crash outright on that one failure class. Uniformly
+  # `raise`ing here — whether the underlying failure came back as an
+  # `{:error, _}`/`{:timeout, _}` tuple or a raw `exit` — restores that
+  # "always raises" contract for every caller.
   @spec process_command(:ra.server_id(), term()) :: term()
   def process_command(server_id, command) do
     case :ra.process_command(server_id, command) do
@@ -180,6 +194,8 @@ defmodule Riptide.RaCluster do
       {:error, reason} -> raise "Ra command failed for #{inspect(server_id)}: #{inspect(reason)}"
       {:timeout, _} -> raise "Ra command timed out for #{inspect(server_id)}"
     end
+  catch
+    :exit, reason -> raise "Ra command exited for #{inspect(server_id)}: #{inspect(reason)}"
   end
 
   # A fast, *possibly stale* read of the local server's already-applied
@@ -191,6 +207,7 @@ defmodule Riptide.RaCluster do
   # everything committed so far (e.g. asserting durability right after a
   # crash-restart). Same single-node error-handling caveat as
   # `process_command/2` above applies.
+  # See `process_command/2`'s own `catch :exit` for why this is needed.
   @spec local_query(:ra.server_id(), (term() -> term())) :: term()
   def local_query(server_id, query_fun) do
     case :ra.local_query(server_id, query_fun) do
@@ -198,6 +215,8 @@ defmodule Riptide.RaCluster do
       {:error, reason} -> raise "Ra query failed for #{inspect(server_id)}: #{inspect(reason)}"
       {:timeout, _} -> raise "Ra query timed out for #{inspect(server_id)}"
     end
+  catch
+    :exit, reason -> raise "Ra query exited for #{inspect(server_id)}: #{inspect(reason)}"
   end
 
   # Linearizable read: unlike `local_query/2` this goes through the leader and,
@@ -205,6 +224,7 @@ defmodule Riptide.RaCluster do
   # committed as of the query — so it deterministically observes the fully
   # recovered log even immediately after a restart. Reply shape is
   # `{:ok, Reply, Leader}` (no index/term wrapper, unlike `local_query`).
+  # See `process_command/2`'s own `catch :exit` for why this is needed.
   @spec consistent_query(:ra.server_id(), (term() -> term())) :: term()
   def consistent_query(server_id, query_fun) do
     case :ra.consistent_query(server_id, query_fun) do
@@ -217,6 +237,9 @@ defmodule Riptide.RaCluster do
       {:timeout, _} ->
         raise "Ra consistent query timed out for #{inspect(server_id)}"
     end
+  catch
+    :exit, reason ->
+      raise "Ra consistent query exited for #{inspect(server_id)}: #{inspect(reason)}"
   end
 
   @spec force_delete(String.t()) :: :ok
@@ -365,13 +388,42 @@ defmodule Riptide.RaCluster do
         retry_interval_ms \\ 1000,
         attempt_fun \\ &attempt_start_placement_cluster/0
       ) do
+    do_ensure_placement_cluster_started(retry_interval_ms, attempt_fun, 1)
+  end
+
+  # Every failed attempt was previously silent — an operator watching
+  # `/health/ready` = 503 forever had no log line or metric explaining why,
+  # only a real `:ra`-state introspection session to diagnose it. Logs the
+  # first attempt's failure immediately (so the very first sign of trouble
+  # is visible right away) and then only every 30th attempt thereafter (with
+  # the default 1s retry interval, roughly once every 30s) to avoid log-spam
+  # during a startup window where early failures are routine and expected
+  # (sibling ordinals legitimately not resolvable yet). Every attempt still
+  # increments the telemetry counter regardless of whether it logs.
+  @log_every_nth_attempt 30
+  defp do_ensure_placement_cluster_started(retry_interval_ms, attempt_fun, attempt) do
     case attempt_fun.() do
       :ok ->
         :ok
 
-      {:error, _reason} ->
+      {:error, reason} ->
+        :telemetry.execute(
+          [:riptide, :ra, :placement_cluster_formation_attempts],
+          %{},
+          %{result: :error}
+        )
+
+        if attempt == 1 or rem(attempt, @log_every_nth_attempt) == 0 do
+          Logger.warning(
+            "Placement cluster not yet formed, still retrying (attempt #{attempt}): " <>
+              inspect(reason),
+            attempt: attempt,
+            reason: inspect(reason)
+          )
+        end
+
         Process.sleep(retry_interval_ms)
-        ensure_placement_cluster_started(retry_interval_ms, attempt_fun)
+        do_ensure_placement_cluster_started(retry_interval_ms, attempt_fun, attempt + 1)
     end
   end
 
@@ -564,13 +616,72 @@ defmodule Riptide.RaCluster do
 
     with :ok <- add_member(survivor_ids, new_id),
          :ok <- start_joining_server(cluster_name, new_id, machine, survivor_ids),
-         {:ok, _reply, _leader} <-
-           retry_cluster_change(fn -> :ra.remove_member(survivor_ids, dead_id) end) do
+         :ok <- remove_member(survivor_ids, dead_id) do
       :ok
     else
       {:error, reason} -> {:error, reason}
       {:timeout, _} -> {:error, :timeout}
     end
+  end
+
+  # Self-corrects the same "redundant retry after a partial prior success"
+  # shape `add_member/2` and `start_joining_server/4` already handle for
+  # their own steps of this same `replace_member/5` pipeline (see their own
+  # docs) — but unlike `:ra.add_member/2`, which has a dedicated
+  # `{:error, :already_member}` atom to self-correct on, `:ra.remove_member/2`
+  # returns the SAME `{:error, :not_member}` for two different situations:
+  # `dead_id` was never a member (a genuine caller bug) and `dead_id` was
+  # ALREADY removed by an earlier, otherwise-successful `replace_member/5`
+  # attempt (e.g. this process/node crashed, or the caller's subsequent
+  # `Riptide.Placement.replace_member/3` metadata update failed/raised,
+  # before this step's own success was ever observed) — confirmed against
+  # `deps/ra/src/ra.erl:618-633` and this module's own
+  # `ra_cluster_test.exs:330-331` assertion of that literal return value.
+  # Without this self-correction, a redundant retry after that exact partial
+  # success permanently fails at this step forever: the real Ra cluster
+  # already has the correct membership, but `Riptide.Stream.ReplicaHealer`'s
+  # caller never reaches the `:ok` branch that updates placement metadata,
+  # so the metadata stays wrongly stuck pointing at the already-evicted
+  # `dead_id` — and any node whose replacement was a *different* replica for
+  # the same repair (e.g. a second concurrent attempt racing this one) can
+  # then never be reconciled either. Disambiguates by checking the surviving
+  # cluster's own real membership via `:ra.members/1` rather than trusting
+  # the ambiguous error atom alone.
+  @spec remove_member([:ra.server_id()], :ra.server_id()) ::
+          :ok | {:error, term()} | {:timeout, term()}
+  defp remove_member(survivor_ids, dead_id) do
+    case retry_cluster_change(fn -> :ra.remove_member(survivor_ids, dead_id) end) do
+      {:ok, _reply, _leader} -> :ok
+      {:error, :not_member} -> if member_removed?(survivor_ids, dead_id), do: :ok, else: {:error, :not_member}
+      {:error, reason} -> {:error, reason}
+      {:timeout, _} = timeout -> timeout
+    end
+  end
+
+  # Asks each survivor in turn (any single one being briefly unreachable
+  # shouldn't block this check) whether `dead_id` is still in its own
+  # locally-known membership list, and trusts the first one that answers —
+  # Ra membership changes are themselves consensus commands, so any
+  # caught-up member's view of current membership is authoritative, not
+  # merely a hint. Defaults to `false` (i.e. "not confirmed removed," so the
+  # caller keeps the original ambiguous error and the next sweep retries)
+  # if every survivor is unreachable — the safe direction to be wrong in,
+  # since it costs a retry rather than a false "removed" reported swallowing
+  # a genuine failure.
+  @spec member_removed?([:ra.server_id()], :ra.server_id()) :: boolean()
+  defp member_removed?(survivor_ids, dead_id) do
+    Enum.reduce_while(survivor_ids, false, fn survivor_id, _acc ->
+      try do
+        case :ra.members(survivor_id) do
+          {:ok, members, _leader} -> {:halt, dead_id not in members}
+          _ -> {:cont, false}
+        end
+      rescue
+        _ -> {:cont, false}
+      catch
+        :exit, _ -> {:cont, false}
+      end
+    end)
   end
 
   # Self-corrects the exact same "redundant retry after a partial prior

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -651,10 +651,17 @@ defmodule Riptide.RaCluster do
           :ok | {:error, term()} | {:timeout, term()}
   defp remove_member(survivor_ids, dead_id) do
     case retry_cluster_change(fn -> :ra.remove_member(survivor_ids, dead_id) end) do
-      {:ok, _reply, _leader} -> :ok
-      {:error, :not_member} -> if member_removed?(survivor_ids, dead_id), do: :ok, else: {:error, :not_member}
-      {:error, reason} -> {:error, reason}
-      {:timeout, _} = timeout -> timeout
+      {:ok, _reply, _leader} ->
+        :ok
+
+      {:error, :not_member} ->
+        if member_removed?(survivor_ids, dead_id), do: :ok, else: {:error, :not_member}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      {:timeout, _} = timeout ->
+        timeout
     end
   end
 

--- a/lib/riptide/rdf/turtle_codec.ex
+++ b/lib/riptide/rdf/turtle_codec.ex
@@ -5,8 +5,29 @@ defmodule Riptide.RDF.TurtleCodec do
   library's own (bang vs non-bang) function-naming conventions directly.
   """
 
+  # Turtle's grammar allows unbounded nesting of collections `( ( ( ... ) ) )`
+  # and blank-node property lists `[ :p [ :p [ ... ] ] ]`, and the underlying
+  # `rdf` library's decoder recurses once per nesting level with no depth
+  # limit of its own. Confirmed empirically: a ~3MB body containing 1.5M
+  # levels of `(` nesting (well within Plug's default ~8MB body-size cap)
+  # drove ~863MB of heap growth and ~19s of CPU in the decoding process
+  # before this guard existed — a straightforward, request-sized DoS against
+  # any authenticated caller (self-service tenant bootstrap grants any
+  # authenticated principal write access to a fresh tenant).
+  #
+  # `decode/1`'s only callers today (`RiptideWeb.LDP.ResourceController`) run
+  # in a short-lived, per-request Phoenix/Cowboy process, so bounding *that
+  # process's* heap here is safe — it isn't a long-lived process any other
+  # unrelated work shares. 50_000_000 words (~400MB on a 64-bit VM) is
+  # generous relative to any legitimate Turtle body under the same ~8MB
+  # request-size cap, while still well short of exhausting a typical pod's
+  # memory from a single request.
+  @max_heap_size_words 50_000_000
+
   @spec decode(String.t()) :: {:ok, RDF.Graph.t()} | {:error, term()}
   def decode(turtle_string) when is_binary(turtle_string) do
+    Process.flag(:max_heap_size, %{size: @max_heap_size_words, kill: true, error_logger: true})
+
     case RDF.Turtle.read_string(turtle_string) do
       {:ok, graph} -> {:ok, graph}
       {:error, reason} -> {:error, reason}

--- a/lib/riptide/stream/placement.ex
+++ b/lib/riptide/stream/placement.ex
@@ -209,7 +209,18 @@ defmodule Riptide.Stream.Placement do
       {:ok, _server_ids} = ok ->
         ok
 
-      {:error, _} = error when attempts_left <= 1 ->
+      {:error, reason} = error when attempts_left <= 1 ->
+        # Previously silent: a caller (LDP GET/POST, SSE subscribe, WS join)
+        # sees a bare 503 with nothing in Riptide's own logs/metrics
+        # explaining that this specific stream's replica formation is what
+        # failed, as opposed to any other reason a request can 503.
+        Logger.warning(
+          "Stream cluster formation exhausted retries for #{inspect(uid)}: #{inspect(reason)}",
+          uid: uid,
+          reason: inspect(reason)
+        )
+
+        :telemetry.execute([:riptide, :stream, :formation_failure], %{}, %{})
         error
 
       {:error, _} ->

--- a/lib/riptide/stream/placement.ex
+++ b/lib/riptide/stream/placement.ex
@@ -25,6 +25,25 @@ defmodule Riptide.Stream.Placement do
   @max_formation_attempts 3
   @formation_retry_backoff_ms 250
 
+  # Bounds unbounded stream creation — e.g. a POST-to-container loop
+  # minting a brand-new 3-replica Ra cluster + placement-map entry + ETS
+  # cache entry per call, with no delete path to ever reclaim any of it
+  # (a real, confirmed DoS against any authenticated caller — self-service
+  # tenant bootstrap grants write access to a fresh tenant to anyone).
+  # Applied only to genuinely NEW streams — `backfill_or_propose/1`'s
+  # `on_disk?/1` branch is pre-existing legacy data, not new resource
+  # creation, and is never quota-limited. Checked before `Placement.assign/2`
+  # rather than inside the placement Ra machine itself: `Placement.assign/2`
+  # is idempotent-by-construction (Phase 3c-i), so a small burst of
+  # concurrent creates right at this boundary can land slightly over quota
+  # (TOCTOU — multiple callers can all pass this check before any of them
+  # commits their `assign`), a known, accepted soft-bound trade-off rather
+  # than the stronger (and substantially more invasive) guarantee a
+  # dedicated Ra-consensus-level quota command would provide.
+  @max_streams_per_tenant 10_000
+  @stream_id_tenant_prefix "https://riptide.example/tenants/"
+  @stream_id_resources_segment "/resources/"
+
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -85,7 +104,7 @@ defmodule Riptide.Stream.Placement do
           (String.t(), [node()], :ra_machine.machine() ->
              {:ok, [:ra.server_id()]} | {:error, term()}),
           (pos_integer() -> :ok)
-        ) :: {:ok, [:ra.server_id()]} | {:error, :cluster_not_formed}
+        ) :: {:ok, [:ra.server_id()]} | {:error, :cluster_not_formed | :quota_exceeded}
   def ensure_started(
         stream_id,
         machine,
@@ -129,6 +148,9 @@ defmodule Riptide.Stream.Placement do
     uid = RaCluster.uid_for(stream_id)
 
     case resolve_nodes(stream_id) do
+      {:error, :quota_exceeded} = error ->
+        error
+
       {:member, nodes} ->
         case start_with_retry(
                uid,
@@ -163,11 +185,15 @@ defmodule Riptide.Stream.Placement do
   # fail (`:ra.start_cluster/2` can't succeed for a node whose id was never
   # in the config), even though the stream is perfectly healthy elsewhere
   # (Phase 3c-iii design spec §1/§4).
-  @spec resolve_nodes(String.t()) :: {:member, [node()]} | {:remote, [node()]}
+  @spec resolve_nodes(String.t()) ::
+          {:member, [node()]} | {:remote, [node()]} | {:error, :quota_exceeded}
   defp resolve_nodes(stream_id) do
     case Placement.lookup(stream_id) do
       nil ->
-        {:member, backfill_or_propose(stream_id)}
+        case backfill_or_propose(stream_id) do
+          {:error, :quota_exceeded} = error -> error
+          nodes -> {:member, nodes}
+        end
 
       nodes ->
         if node() in nodes do
@@ -189,11 +215,19 @@ defmodule Riptide.Stream.Placement do
   # same node they always have — already an implicit assumption of today's
   # pre-3c-ii code, fully closed only once Phase 3c-iii's real routing
   # ships.
+  #
+  # The quota check applies only to the genuinely-new (`else`) branch — the
+  # `on_disk?/1` backfill branch is pre-existing legacy data, not new
+  # resource creation, and is never quota-limited.
+  @spec backfill_or_propose(String.t()) :: [node()] | {:error, :quota_exceeded}
   defp backfill_or_propose(stream_id) do
     if on_disk?(stream_id) do
       Placement.assign(stream_id, [node()])
     else
-      Placement.assign(stream_id, Placement.propose_nodes(@replication_factor))
+      case check_tenant_quota(stream_id) do
+        :ok -> Placement.assign(stream_id, Placement.propose_nodes(@replication_factor))
+        {:error, :quota_exceeded} = error -> error
+      end
     end
   end
 
@@ -202,6 +236,44 @@ defmodule Riptide.Stream.Placement do
     uid = RaCluster.uid_for(stream_id)
     data_dir = RaCluster.data_dir() |> to_string()
     File.dir?(Path.join(data_dir, uid))
+  end
+
+  @spec check_tenant_quota(String.t()) :: :ok | {:error, :quota_exceeded}
+  defp check_tenant_quota(stream_id) do
+    case tenant_id_from_stream_id(stream_id) do
+      nil ->
+        :ok
+
+      tenant_id ->
+        if tenant_stream_count(tenant_id) >= @max_streams_per_tenant do
+          :telemetry.execute([:riptide, :stream, :quota_exceeded], %{}, %{})
+          {:error, :quota_exceeded}
+        else
+          :ok
+        end
+    end
+  end
+
+  # Mirrors RiptideWeb.LDP.ResourceController.stream_id_for/2's own format
+  # exactly (intentionally duplicated here rather than this domain-layer
+  # module depending on that web-layer one) — a stream_id not shaped like
+  # an LDP resource (e.g. a plain string used directly by a test) simply
+  # isn't quota-checked at all.
+  defp tenant_id_from_stream_id(@stream_id_tenant_prefix <> rest) do
+    case String.split(rest, @stream_id_resources_segment, parts: 2) do
+      [tenant_id, _path] when tenant_id != "" -> tenant_id
+      _ -> nil
+    end
+  end
+
+  defp tenant_id_from_stream_id(_other), do: nil
+
+  defp tenant_stream_count(tenant_id) do
+    prefix = @stream_id_tenant_prefix <> tenant_id <> @stream_id_resources_segment
+
+    Placement.list_all()
+    |> Map.keys()
+    |> Enum.count(&String.starts_with?(&1, prefix))
   end
 
   defp start_with_retry(uid, nodes, machine, formation_fun, sleep_fun, attempts_left) do

--- a/lib/riptide/stream/ra_machine.ex
+++ b/lib/riptide/stream/ra_machine.ex
@@ -8,6 +8,8 @@ defmodule Riptide.Stream.RaMachine do
   """
   @behaviour :ra_machine
 
+  require Logger
+
   alias Riptide.Event
 
   # `events` holds each event's *encoded* wire-form map (see `Riptide.Event.encode/1`),
@@ -28,12 +30,45 @@ defmodule Riptide.Stream.RaMachine do
 
   @impl :ra_machine
   def apply(meta, {:append, wire}, state) do
-    event = Event.decode(wire)
-    stamped = Event.with_sequence(event, state.next_sequence)
-    stamped_wire = Event.encode(stamped)
-    {events, trimmed?} = trim(state.events ++ [stamped_wire], state.retention)
-    new_state = %{state | next_sequence: state.next_sequence + 1, events: events}
-    {new_state, stamped, release_cursor_effects(trimmed?, meta, new_state)}
+    case safe_decode(wire) do
+      {:ok, event} ->
+        stamped = Event.with_sequence(event, state.next_sequence)
+        stamped_wire = Event.encode(stamped)
+        {events, trimmed?} = trim(state.events ++ [stamped_wire], state.retention)
+        new_state = %{state | next_sequence: state.next_sequence + 1, events: events}
+        {new_state, stamped, release_cursor_effects(trimmed?, meta, new_state)}
+
+      {:error, reason} ->
+        # This command is already durably committed to this stream's Ra log
+        # — every replica (including ones that join or restart later) will
+        # replay this exact entry forever. Dropping it (state unchanged, no
+        # sequence consumed) rather than crashing is deliberate: an uncaught
+        # exception here would crash `apply/3` on every replica, on every
+        # future replay of this entry, turning one bad command into a
+        # permanently crash-looping stream with no automatic recovery. The
+        # most plausible real trigger is a rolling upgrade: a newer node
+        # commits an event using a future `Riptide.Event` wire version
+        # before every replica has upgraded to understand it.
+        Logger.error(
+          "Riptide.Stream.RaMachine dropped an unparseable committed event " <>
+            "(#{reason}) — state left unchanged rather than crashing this " <>
+            "replica; likely a wire-version mismatch from a rolling upgrade"
+        )
+
+        :telemetry.execute([:riptide, :stream, :poison_command], %{}, %{})
+        {state, {:error, {:undecodable_event, reason}}, []}
+    end
+  end
+
+  # `Event.decode/1` can raise — on an unrecognized wire version explicitly
+  # (`raise("Unknown Event wire version: ...")`) or on any structurally
+  # malformed wire map (e.g. `KeyError`/`FunctionClauseError`). See `apply/3`
+  # above for why that must never propagate out of this callback.
+  @spec safe_decode(map()) :: {:ok, Event.t()} | {:error, String.t()}
+  defp safe_decode(wire) do
+    {:ok, Event.decode(wire)}
+  rescue
+    e -> {:error, Exception.message(e)}
   end
 
   # Ra keeps every applied command on disk in its raft log indefinitely

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -33,11 +33,36 @@ defmodule Riptide.Stream.ReplicaHealer do
   @impl GenServer
   def handle_info(:sweep, state) do
     if RaCluster.placement_leader?() do
-      sweep()
+      safe_sweep()
     end
 
     schedule_sweep()
     {:noreply, state}
+  end
+
+  # `sweep/0` can raise/exit if the placement cluster is fully unreachable
+  # (`Placement.list_all/1`'s own documented total-failure behavior) — left
+  # unguarded here, that would crash this GenServer every ~30s for the
+  # duration of any placement-cluster outage. The default supervisor's
+  # restart intensity tolerates that (30s spacing is well under
+  # `max_restarts: 3, max_seconds: 5`), so it self-heals, but it's noisy and
+  # inconsistent with `discover_retention/2`'s own "skip this tick and log a
+  # warning" pattern one level down in this same module — mirroring that
+  # here instead.
+  defp safe_sweep do
+    sweep()
+  rescue
+    e ->
+      Logger.warning(
+        "ReplicaHealer sweep failed, skipping this tick (#{Exception.message(e)})",
+        reason: Exception.message(e)
+      )
+  catch
+    :exit, reason ->
+      Logger.warning(
+        "ReplicaHealer sweep failed, skipping this tick (#{inspect(reason)})",
+        reason: inspect(reason)
+      )
   end
 
   defp schedule_sweep do

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -98,7 +98,32 @@ defmodule Riptide.Stream.ReplicaHealer do
     end
   end
 
+  # Fences this repair through the placement Ra cluster's own consensus
+  # (see Riptide.Placement.PlacementMachine's moduledoc, "Repair claims")
+  # rather than trusting `RaCluster.placement_leader?/0`'s unfenced,
+  # point-in-time belief alone — closes a dual-leader race where two
+  # placement ordinals both briefly believing they're the leader during a
+  # handoff/partition could each fully commit a *different* replacement
+  # node for the same dead replica, leaving an untracked, over-replicated
+  # extra member with no cleanup path. `release_repair/1` always runs (even
+  # if the repair itself raises/fails) so a crash mid-repair doesn't
+  # permanently wedge this stream's repair path any longer than the claim's
+  # own TTL.
   defp repair(stream_id, uid, nodes, dead_node) do
+    case Placement.claim_repair(stream_id, dead_node) do
+      :already_claimed ->
+        :ok
+
+      :claimed ->
+        try do
+          do_claimed_repair(stream_id, uid, nodes, dead_node)
+        after
+          Placement.release_repair(stream_id)
+        end
+    end
+  end
+
+  defp do_claimed_repair(stream_id, uid, nodes, dead_node) do
     survivor_nodes = nodes -- [dead_node]
 
     case pick_replacement(nodes) do

--- a/lib/riptide/stream/stream_server.ex
+++ b/lib/riptide/stream/stream_server.ex
@@ -44,8 +44,11 @@ defmodule Riptide.Stream.StreamServer do
   @spec append(String.t(), Event.t()) :: Event.t()
   def append(stream_id, %Event{} = event) do
     :telemetry.span([:riptide, :stream, :append], %{}, fn ->
-      server_id = hd(Placement.server_ids!(stream_id))
-      stamped = RaCluster.process_command(server_id, {:append, Event.encode(event)})
+      stamped =
+        try_replicas(stream_id, fn server_id ->
+          RaCluster.process_command(server_id, {:append, Event.encode(event)})
+        end)
+
       Phoenix.PubSub.broadcast(Riptide.PubSub, "stream:" <> stream_id, {:new_event, stamped})
       {stamped, %{}}
     end)
@@ -62,8 +65,10 @@ defmodule Riptide.Stream.StreamServer do
           {:ok, [Event.t()]} | {:gap, pos_integer() | nil}
   def get_since(stream_id, cursor) do
     :telemetry.span([:riptide, :stream, :get_since], %{}, fn ->
-      server_id = hd(Placement.server_ids!(stream_id))
-      result = RaCluster.consistent_query(server_id, &RaMachine.get_since(&1, cursor))
+      result =
+        try_replicas(stream_id, fn server_id ->
+          RaCluster.consistent_query(server_id, &RaMachine.get_since(&1, cursor))
+        end)
 
       case result do
         {:gap, _oldest} -> :telemetry.execute([:riptide, :stream, :get_since, :gap], %{}, %{})
@@ -72,6 +77,34 @@ defmodule Riptide.Stream.StreamServer do
 
       {result, %{}}
     end)
+  end
+
+  # Mirrors Riptide.Placement.with_ordinal_fallback/2's own "try each
+  # member in turn" shape (see its own moduledoc for the SPOF finding this
+  # pattern originally fixed for the placement cluster): a stream's replica
+  # list is fixed once assigned, and any one of them being briefly
+  # unreachable or mid-restart shouldn't fail the whole operation while the
+  # other replicas are healthy — previously `append/2`/`get_since/2` always
+  # addressed only `hd(Placement.server_ids!(stream_id))`, making that one
+  # replica a de-facto single point of failure for the entire stream even
+  # though its underlying multi-member Ra cluster stayed healthy. The very
+  # last replica's exception is deliberately left to propagate uncaught: if
+  # none of a stream's own replicas can serve the request, that's a
+  # genuine, fully-down stream cluster, not something a caller here can
+  # paper over.
+  @spec try_replicas(String.t(), (:ra.server_id() -> term())) :: term()
+  defp try_replicas(stream_id, fun) do
+    try_server_ids(Placement.server_ids!(stream_id), fun)
+  end
+
+  defp try_server_ids([server_id], fun), do: fun.(server_id)
+
+  defp try_server_ids([server_id | rest], fun) do
+    fun.(server_id)
+  rescue
+    _ -> try_server_ids(rest, fun)
+  catch
+    :exit, _ -> try_server_ids(rest, fun)
   end
 
   # Bridges a liveness gap that only exists because `Placement.ensure_started/2`

--- a/lib/riptide/telemetry.ex
+++ b/lib/riptide/telemetry.ex
@@ -187,6 +187,13 @@ defmodule Riptide.Telemetry do
         event_name: [:riptide, :stream, :poison_command]
       ),
 
+      # A tenant hit its per-tenant live-stream quota — see
+      # Riptide.Stream.Placement's own comment on the resource-exhaustion
+      # this bounds.
+      counter("riptide.stream.quota_exceeded",
+        event_name: [:riptide, :stream, :quota_exceeded]
+      ),
+
       # Authorization decisions — :effect/:mode are both small, fixed sets
       # (2 values each), safe to tag. Without this, a systemic authz failure
       # (e.g. the policy store starts returning empty for an unrelated

--- a/lib/riptide/telemetry.ex
+++ b/lib/riptide/telemetry.ex
@@ -65,18 +65,53 @@ defmodule Riptide.Telemetry do
         reporter_options: [buckets: [10, 25, 50, 100, 250, 500, 1000, 2500, 5000]]
       ),
 
+      # A raised/exited controller action is a SEPARATE event from :stop
+      # (Phoenix never emits both for the same request) — Riptide's own
+      # placement layer is documented as deliberately raise-on-total-failure
+      # (see Riptide.Placement's moduledoc), so a full placement-cluster
+      # outage would otherwise be completely invisible in Prometheus (only
+      # the readiness probe would hint at it), with request-level failure
+      # volume/rate dark. `route`/`method` are the same small, fixed-set
+      # tags :stop already uses — `status` isn't meaningful here since no
+      # response was ever produced.
+      counter("riptide.http.exceptions",
+        event_name: [:phoenix, :router_dispatch, :exception],
+        tags: [:route, :method],
+        tag_values: &phoenix_router_dispatch_exception_tag_values/1
+      ),
+
+      # Total HTTP request volume, including requests that never matched a
+      # route at all (:router_dispatch never fires for those — see this
+      # module's own moduledoc) — [:phoenix, :endpoint, :stop] fires for
+      # every request regardless of route match (it's the same event Phase
+      # 5b's AccessLog already consumes). Tagged only by :status (a small,
+      # fixed set) — not :route, since an unmatched request has none.
+      counter("phoenix.endpoint.requests",
+        event_name: [:phoenix, :endpoint, :stop],
+        tags: [:status],
+        tag_values: &phoenix_endpoint_stop_tag_values/1
+      ),
+
       # WebSocket — Phoenix's own existing telemetry events, no new
-      # instrumentation.
+      # instrumentation. Tagged by :result (:ok/:error — Phoenix already
+      # attaches this to both events for free) so an auth-failure or
+      # authorization-denial spike on this transport is distinguishable
+      # from ordinary latency, the same way the HTTP metric above
+      # distinguishes by :status.
       distribution("phoenix.socket_connected.duration",
         event_name: [:phoenix, :socket_connected],
         measurement: :duration,
         unit: {:native, :millisecond},
+        tags: [:result],
+        tag_values: &result_tag_value/1,
         reporter_options: [buckets: [10, 25, 50, 100, 250, 500, 1000, 2500, 5000]]
       ),
       distribution("phoenix.channel_joined.duration",
         event_name: [:phoenix, :channel_joined],
         measurement: :duration,
         unit: {:native, :millisecond},
+        tags: [:result],
+        tag_values: &result_tag_value/1,
         reporter_options: [buckets: [10, 25, 50, 100, 250, 500, 1000, 2500, 5000]]
       ),
 
@@ -120,6 +155,14 @@ defmodule Riptide.Telemetry do
         event_name: [:riptide, :placement, :assign, :exception]
       ),
 
+      # Falling back past one placement ordinal to the next — previously
+      # silent (rescued with no log/metric), so a persistently unreachable
+      # (but not yet totally-down) ordinal had no visibility beyond a subtle
+      # latency increase in the aggregate duration distributions above.
+      counter("riptide.placement.ordinal_fallback",
+        event_name: [:riptide, :placement, :ordinal_fallback]
+      ),
+
       # Replica healer — new :telemetry.execute calls added in Task 5
       # (Riptide.Stream.ReplicaHealer), alongside its existing Logger calls.
       counter("riptide.replica_healer.repairs",
@@ -128,6 +171,38 @@ defmodule Riptide.Telemetry do
       ),
       counter("riptide.replica_healer.dead_replicas_detected",
         event_name: [:riptide, :replica_healer, :dead_replica_detected]
+      ),
+
+      # A stream's own Ra cluster exhausting its bounded formation retries —
+      # previously silent; surfaces as a bare 503 to the caller with nothing
+      # in Riptide's own logs/metrics explaining why.
+      counter("riptide.stream.formation_failures",
+        event_name: [:riptide, :stream, :formation_failure]
+      ),
+
+      # A committed event that failed to decode (e.g. a future wire version
+      # from a rolling upgrade) — see Riptide.Stream.RaMachine's own comment
+      # on why this is dropped rather than crashing the replica.
+      counter("riptide.stream.poison_commands",
+        event_name: [:riptide, :stream, :poison_command]
+      ),
+
+      # Authorization decisions — :effect/:mode are both small, fixed sets
+      # (2 values each), safe to tag. Without this, a systemic authz failure
+      # (e.g. the policy store starts returning empty for an unrelated
+      # reason, so evaluate/4's own default-deny applies to everything) is
+      # invisible on any dashboard.
+      counter("riptide.authz.decisions",
+        event_name: [:riptide, :authz, :decision],
+        tags: [:effect, :mode]
+      ),
+
+      # The placement cluster's own boot-time cluster-formation retry loop
+      # failing — previously silent; an operator saw only "pod NotReady"
+      # with no explanation in Riptide's own logs/metrics.
+      counter("riptide.ra.placement_cluster_formation_attempts",
+        event_name: [:riptide, :ra, :placement_cluster_formation_attempts],
+        tags: [:result]
       ),
 
       # Ra placement-cluster leadership — a gauge sampled by the
@@ -141,5 +216,17 @@ defmodule Riptide.Telemetry do
 
   defp phoenix_router_dispatch_tag_values(%{route: route, conn: conn}) do
     %{route: route, method: conn.method, status: conn.status}
+  end
+
+  defp phoenix_router_dispatch_exception_tag_values(%{route: route, conn: conn}) do
+    %{route: route, method: conn.method}
+  end
+
+  defp phoenix_endpoint_stop_tag_values(%{conn: conn}) do
+    %{status: conn.status}
+  end
+
+  defp result_tag_value(%{result: result}) do
+    %{result: result}
   end
 end

--- a/lib/riptide_web/authz/policy_controller.ex
+++ b/lib/riptide_web/authz/policy_controller.ex
@@ -27,6 +27,14 @@ defmodule RiptideWeb.Authz.PolicyController do
       :error ->
         send_resp(conn, 400, "")
     end
+  rescue
+    _ -> send_resp(conn, 503, "")
+  catch
+    # store.add_policy/3 (and list_policies/2 below) can raise/exit if the
+    # placement cluster is fully unreachable — see RiptideWeb.Plugs.
+    # Authorize's own rescue/catch on this same failure mode, immediately
+    # upstream of this same route.
+    :exit, _ -> send_resp(conn, 503, "")
   end
 
   def index(conn, _params) do
@@ -37,6 +45,10 @@ defmodule RiptideWeb.Authz.PolicyController do
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(200, Jason.encode!(Enum.map(policies, &policy_to_map/1)))
+  rescue
+    _ -> send_resp(conn, 503, "")
+  catch
+    :exit, _ -> send_resp(conn, 503, "")
   end
 
   defp policy_from_params(%{"effect" => effect, "modes" => modes, "matcher" => matcher})

--- a/lib/riptide_web/authz/policy_controller.ex
+++ b/lib/riptide_web/authz/policy_controller.ex
@@ -19,8 +19,10 @@ defmodule RiptideWeb.Authz.PolicyController do
 
     case policy_from_params(params) do
       {:ok, policy} ->
-        :ok = store.add_policy(tenant_id, [], policy)
-        send_resp(conn, 201, "")
+        case store.add_policy(tenant_id, [], policy) do
+          :ok -> send_resp(conn, 201, "")
+          {:error, :too_many_policies} -> send_resp(conn, 429, "")
+        end
 
       :error ->
         send_resp(conn, 400, "")

--- a/lib/riptide_web/health_controller.ex
+++ b/lib/riptide_web/health_controller.ex
@@ -22,5 +22,13 @@ defmodule RiptideWeb.HealthController do
     send_resp(conn, 200, "ok")
   rescue
     _ -> send_resp(conn, 503, "not ready")
+  catch
+    # Riptide.Placement.lookup/1 can genuinely `exit` (not just `raise`) if
+    # the local placement Ra member crashes mid-query — see
+    # Riptide.RaCluster.process_command/2's own `catch :exit` doc. A plain
+    # `rescue` alone doesn't catch that, which would otherwise surface as an
+    # uncaught exit (a connection reset) instead of the clean 503 this probe
+    # exists to provide.
+    :exit, _ -> send_resp(conn, 503, "not ready")
   end
 end

--- a/lib/riptide_web/ldp/resource_controller.ex
+++ b/lib/riptide_web/ldp/resource_controller.ex
@@ -1,5 +1,6 @@
 defmodule RiptideWeb.LDP.ResourceController do
   use Phoenix.Controller
+  require Logger
 
   alias Riptide.Event
   alias Riptide.RDF.{Patch, TurtleCodec}
@@ -96,42 +97,91 @@ defmodule RiptideWeb.LDP.ResourceController do
 
     case TurtleCodec.decode(body) do
       {:ok, child_graph} ->
-        child_id = Uniq.UUID.uuid4()
-        child_stream_id = container_stream_id <> "/" <> child_id
-
-        with :ok <- child_stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status(),
-             :ok <-
-               container_stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do
-          StreamServer.append(child_stream_id, Event.new(child_stream_id, :replace, child_graph))
-
-          containment_triple =
-            {RDF.iri(container_stream_id), @ldp_contains, RDF.iri(child_stream_id)}
-
-          containment_patch = %Patch{additions: [containment_triple], removals: []}
-
-          StreamServer.append(
-            container_stream_id,
-            Event.new(container_stream_id, :patch, containment_patch)
-          )
-
-          location =
-            "/tenants/#{tenant_id}/resources/" <> Enum.join(path_segments, "/") <> "/" <> child_id
-
-          conn
-          |> put_resp_header("location", location)
-          |> send_resp(201, "")
-        else
-          :error -> send_resp(conn, 503, "")
-        end
+        finish_create_child(conn, tenant_id, path_segments, container_stream_id, child_graph)
 
       {:error, _reason} ->
         send_resp(conn, 400, "")
     end
   end
 
+  defp finish_create_child(conn, tenant_id, path_segments, container_stream_id, child_graph) do
+    child_id = Uniq.UUID.uuid4()
+    child_stream_id = container_stream_id <> "/" <> child_id
+
+    with :ok <- child_stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status(),
+         :ok <-
+           container_stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do
+      StreamServer.append(child_stream_id, Event.new(child_stream_id, :replace, child_graph))
+
+      containment_triple =
+        {RDF.iri(container_stream_id), @ldp_contains, RDF.iri(child_stream_id)}
+
+      containment_patch = %Patch{additions: [containment_triple], removals: []}
+
+      case append_containment_patch(container_stream_id, containment_patch) do
+        :ok ->
+          location =
+            "/tenants/#{tenant_id}/resources/" <> Enum.join(path_segments, "/") <> "/" <> child_id
+
+          conn
+          |> put_resp_header("location", location)
+          |> send_resp(201, "")
+
+        :error ->
+          cleanup_orphaned_child(child_stream_id)
+          send_resp(conn, 503, "")
+      end
+    else
+      :error -> send_resp(conn, 503, "")
+    end
+  end
+
   @spec ensure_ready_status(:ok | {:error, term()}) :: :ok | :error
   def ensure_ready_status(:ok), do: :ok
   def ensure_ready_status({:error, _reason}), do: :error
+
+  # StreamServer.append/2 can raise if the container's own replicas are all
+  # unreachable at this exact moment (e.g. a transient partition after the
+  # child's own append already succeeded) — without catching it here, an
+  # uncaught exception would leave the child resource durably created and
+  # independently readable, but permanently un-referenced by its
+  # container's `ldp:contains` listing, with no retry or cleanup.
+  @spec append_containment_patch(String.t(), Patch.t()) :: :ok | :error
+  defp append_containment_patch(container_stream_id, patch) do
+    StreamServer.append(container_stream_id, Event.new(container_stream_id, :patch, patch))
+    :ok
+  rescue
+    _ -> :error
+  catch
+    :exit, _ -> :error
+  end
+
+  # Best-effort: append a :delete event for the just-created, now-orphaned
+  # child so it stops being independently readable even though it was never
+  # linked from its container. If THIS also fails (the child's own replicas
+  # are unreachable too), there is no automated reconciliation path today —
+  # log loudly so an operator can find and clean it up manually rather than
+  # it silently persisting forever.
+  @spec cleanup_orphaned_child(String.t()) :: :ok
+  defp cleanup_orphaned_child(child_stream_id) do
+    StreamServer.append(child_stream_id, Event.new(child_stream_id, :delete, RDF.Graph.new()))
+    :ok
+  rescue
+    e -> log_orphaned_child_cleanup_failure(child_stream_id, Exception.message(e))
+  catch
+    :exit, reason -> log_orphaned_child_cleanup_failure(child_stream_id, inspect(reason))
+  end
+
+  defp log_orphaned_child_cleanup_failure(child_stream_id, reason) do
+    Logger.error(
+      "create_child: container patch failed AND cleanup of orphaned child " <>
+        "#{child_stream_id} also failed (#{reason}) — manual cleanup needed",
+      child_stream_id: child_stream_id,
+      reason: reason
+    )
+
+    :ok
+  end
 
   @stream_id_prefix "https://riptide.example/tenants/"
   @resources_segment "/resources/"

--- a/lib/riptide_web/plugs/authenticate.ex
+++ b/lib/riptide_web/plugs/authenticate.ex
@@ -12,6 +12,16 @@ defmodule RiptideWeb.Plugs.Authenticate do
   halts with `401` — a token that can't be checked is never silently treated
   as though it had passed. Nothing yet enforces that `current_subject` be
   non-nil for any route; that's Phase 4c's job.
+
+  The `?token=` query-param fallback (browsers' native `EventSource` API
+  can't set custom request headers, so SSE has no other way to send a
+  bearer token) is opt-in via `allow_query_param: true`, not a blanket
+  behavior of this plug — see `RiptideWeb.Router`'s `:auth_query_param`
+  pipeline, used only by the SSE subscribe route. A bearer token in a query
+  string is a durable leak risk (proxy/access logs, browser history,
+  `Referer` forwarding) that should never be enabled for routes that have a
+  perfectly good `Authorization` header available, which is every route but
+  SSE.
   """
   import Plug.Conn
   require Logger
@@ -22,8 +32,8 @@ defmodule RiptideWeb.Plugs.Authenticate do
   def init(opts), do: opts
 
   @impl true
-  def call(conn, _opts) do
-    case extract_token(conn) do
+  def call(conn, opts) do
+    case extract_token(conn, opts) do
       nil ->
         assign(conn, :current_subject, nil)
 
@@ -35,7 +45,9 @@ defmodule RiptideWeb.Plugs.Authenticate do
             maybe_set_subject_metadata(claims)
             assign(conn, :current_subject, claims)
 
-          {:error, _reason} ->
+          {:error, reason} ->
+            Logger.warning("auth verification failed", reason: inspect(reason))
+
             conn
             |> send_resp(401, "")
             |> halt()
@@ -51,14 +63,12 @@ defmodule RiptideWeb.Plugs.Authenticate do
 
   # Header takes precedence over the query param when both are present, to
   # avoid ambiguity about which one is authoritative (Phase 4b design spec
-  # §5). The query-param fallback exists only for SSE — browsers' native
-  # `EventSource` API can't set custom request headers — but is accepted
-  # here unconditionally rather than gated per-route: an LDP HTTP request
-  # simply never sends a `?token=` param today, so this costs nothing there.
-  defp extract_token(conn) do
+  # §5). The query-param fallback only applies when the pipeline explicitly
+  # opts in via `allow_query_param: true` — see moduledoc.
+  defp extract_token(conn, opts) do
     case get_req_header(conn, "authorization") do
       ["Bearer " <> token] -> token
-      _ -> fallback_token(conn)
+      _ -> if Keyword.get(opts, :allow_query_param, false), do: fallback_token(conn)
     end
   end
 

--- a/lib/riptide_web/plugs/authorize.ex
+++ b/lib/riptide_web/plugs/authorize.ex
@@ -32,11 +32,18 @@ defmodule RiptideWeb.Plugs.Authorize do
     end
   end
 
-  defp maybe_bootstrap(conn, tenant_id, current_subject, :write)
-       when not is_nil(current_subject) do
+  # Guards against `current_subject["sub"]` being `nil` (bootstrapping the
+  # tenant with an `{:agent, nil}` owner policy that would then match any
+  # other subject-less token — see `Riptide.Authz`'s own guard on this same
+  # shape). `Riptide.Auth.TokenConfig` requires `sub` on every verified
+  # token, so this should not be reachable in practice; kept as defense in
+  # depth rather than trusting that invariant to hold from this call site
+  # alone.
+  defp maybe_bootstrap(conn, tenant_id, %{"sub" => sub}, :write)
+       when not is_nil(sub) do
     store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
 
-    case store.claim_tenant_if_unclaimed(tenant_id, current_subject["sub"]) do
+    case store.claim_tenant_if_unclaimed(tenant_id, sub) do
       :claimed -> conn
       :already_claimed -> reject(conn)
     end

--- a/lib/riptide_web/plugs/authorize.ex
+++ b/lib/riptide_web/plugs/authorize.ex
@@ -30,6 +30,19 @@ defmodule RiptideWeb.Plugs.Authorize do
       :allow -> conn
       :deny -> maybe_bootstrap(conn, tenant_id, current_subject, mode)
     end
+  rescue
+    _ -> service_unavailable(conn)
+  catch
+    # Riptide.Authz.evaluate/4 (and claim_tenant_if_unclaimed/2 below) can
+    # raise/exit if the placement cluster backing the policy store is fully
+    # unreachable (Riptide.Placement's own documented raise-on-total-failure
+    # behavior) — every authenticated LDP/policy route goes through this
+    # plug, so left uncaught this surfaces as a generic Phoenix 500 with no
+    # way for a caller/load-balancer to tell "genuinely forbidden" apart
+    # from "transient, back off and retry," the same distinction
+    # RiptideWeb.HealthController's /health/ready already makes for this
+    # exact failure mode.
+    :exit, _ -> service_unavailable(conn)
   end
 
   # Guards against `current_subject["sub"]` being `nil` (bootstrapping the
@@ -57,6 +70,12 @@ defmodule RiptideWeb.Plugs.Authorize do
   defp reject(conn) do
     conn
     |> send_resp(403, "")
+    |> halt()
+  end
+
+  defp service_unavailable(conn) do
+    conn
+    |> send_resp(503, "")
     |> halt()
   end
 end

--- a/lib/riptide_web/realtime/replication_channel.ex
+++ b/lib/riptide_web/realtime/replication_channel.ex
@@ -40,6 +40,15 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
       _ ->
         {:error, %{"reason" => "unauthorized"}}
     end
+  rescue
+    _ -> {:error, %{"reason" => "service_unavailable"}}
+  catch
+    # Riptide.Authz.evaluate/4 can raise/exit if the placement cluster
+    # backing the policy store is fully unreachable — this transport calls
+    # it directly rather than through RiptideWeb.Plugs.Authorize (see that
+    # plug's own rescue/catch on this same failure mode), so needs the same
+    # protection here.
+    :exit, _ -> {:error, %{"reason" => "service_unavailable"}}
   end
 
   # Mirrors Authenticate/Socket.connect's own guard: subject stays genuinely

--- a/lib/riptide_web/realtime/replication_channel.ex
+++ b/lib/riptide_web/realtime/replication_channel.ex
@@ -54,6 +54,11 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
   defp do_join(stream_id, cursor, socket) do
     case stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do
       :ok ->
+        # Same subscribe-before-read ordering (and the same duplicate-delivery
+        # window it opens) as RiptideWeb.Realtime.SseController.do_subscribe/3
+        # — see its own comment. `handle_info/2` below drops any live event
+        # whose sequence isn't strictly greater than the highest one already
+        # sent in the backlog.
         Phoenix.PubSub.subscribe(Riptide.PubSub, "stream:" <> stream_id)
 
         case StreamServer.get_since(stream_id, cursor) do
@@ -61,7 +66,13 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
             {:error, %{"oldestAvailable" => oldest}}
 
           {:ok, events} ->
-            socket = assign(socket, :stream_id, stream_id)
+            last_sequence = events |> List.last() |> then(&(&1 && &1.sequence)) || cursor || 0
+
+            socket =
+              socket
+              |> assign(:stream_id, stream_id)
+              |> assign(:last_sequence, last_sequence)
+
             {:ok, %{"backlog" => Enum.map(events, &frame/1)}, socket}
         end
 
@@ -71,8 +82,14 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
   end
 
   @impl true
-  def handle_info({:new_event, %Event{} = event}, socket) do
+  def handle_info({:new_event, %Event{sequence: sequence} = event}, socket)
+      when sequence > socket.assigns.last_sequence do
     push(socket, "replication_frame", frame(event))
+    {:noreply, assign(socket, :last_sequence, sequence)}
+  end
+
+  @impl true
+  def handle_info({:new_event, %Event{}}, socket) do
     {:noreply, socket}
   end
 

--- a/lib/riptide_web/realtime/socket.ex
+++ b/lib/riptide_web/realtime/socket.ex
@@ -35,6 +35,7 @@ defmodule RiptideWeb.Realtime.Socket do
             {:ok, assign(socket, :current_subject, claims)}
 
           {:error, reason} ->
+            Logger.warning("auth verification failed", reason: inspect(reason))
             {:error, reason}
         end
     end

--- a/lib/riptide_web/realtime/sse_controller.ex
+++ b/lib/riptide_web/realtime/sse_controller.ex
@@ -20,6 +20,15 @@ defmodule RiptideWeb.Realtime.SseController do
       _ ->
         send_resp(conn, 403, "")
     end
+  rescue
+    _ -> send_resp(conn, 503, "")
+  catch
+    # Riptide.Authz.evaluate/4 can raise/exit if the placement cluster
+    # backing the policy store is fully unreachable — this transport calls
+    # it directly rather than through RiptideWeb.Plugs.Authorize (see that
+    # plug's own rescue/catch on this same failure mode), so needs the same
+    # protection here.
+    :exit, _ -> send_resp(conn, 503, "")
   end
 
   defp do_subscribe(conn, stream_id) do

--- a/lib/riptide_web/realtime/sse_controller.ex
+++ b/lib/riptide_web/realtime/sse_controller.ex
@@ -23,10 +23,23 @@ defmodule RiptideWeb.Realtime.SseController do
   end
 
   defp do_subscribe(conn, stream_id) do
+    case last_event_id(conn) do
+      {:ok, cursor} -> do_subscribe(conn, stream_id, cursor)
+      :error -> send_resp(conn, 400, "")
+    end
+  end
+
+  defp do_subscribe(conn, stream_id, cursor) do
     case stream_id |> StreamSupervisor.ensure_ready() |> ensure_ready_status() do
       :ok ->
+        # Subscribing before reading the backlog avoids ever missing an event
+        # (Plug.Conn.chunk order: below), but opens a duplicate-delivery
+        # window instead — a concurrent StreamServer.append/2 that commits
+        # between this subscribe and the get_since read below can land in
+        # both the backlog AND a live {:new_event, ...} broadcast. `loop/1`
+        # drops any live event whose sequence isn't strictly greater than the
+        # highest one already delivered, closing that window.
         Phoenix.PubSub.subscribe(Riptide.PubSub, "stream:" <> stream_id)
-        cursor = last_event_id(conn)
 
         case StreamServer.get_since(stream_id, cursor) do
           {:gap, oldest} ->
@@ -41,7 +54,8 @@ defmodule RiptideWeb.Realtime.SseController do
               |> send_chunked(200)
 
             conn = Enum.reduce(backlog, conn, &write_event(&2, &1))
-            loop(conn)
+            last_sequence = backlog |> List.last() |> then(&(&1 && &1.sequence)) || cursor || 0
+            loop(conn, last_sequence)
         end
 
       :error ->
@@ -53,11 +67,14 @@ defmodule RiptideWeb.Realtime.SseController do
   def ensure_ready_status(:ok), do: :ok
   def ensure_ready_status({:error, _reason}), do: :error
 
-  defp loop(conn) do
+  defp loop(conn, last_sequence) do
     receive do
-      {:new_event, event} ->
+      {:new_event, event} when event.sequence > last_sequence ->
         conn = write_event(conn, event)
-        loop(conn)
+        loop(conn, event.sequence)
+
+      {:new_event, _already_delivered} ->
+        loop(conn, last_sequence)
     after
       1_000 -> conn
     end
@@ -70,10 +87,17 @@ defmodule RiptideWeb.Realtime.SseController do
     conn
   end
 
+  @spec last_event_id(Plug.Conn.t()) :: {:ok, integer() | nil} | :error
   defp last_event_id(conn) do
     case Plug.Conn.get_req_header(conn, "last-event-id") do
-      [id] -> String.to_integer(id)
-      [] -> nil
+      [id] ->
+        case Integer.parse(id) do
+          {n, ""} -> {:ok, n}
+          _ -> :error
+        end
+
+      [] ->
+        {:ok, nil}
     end
   end
 end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -13,6 +13,13 @@ defmodule RiptideWeb.Router do
     plug RiptideWeb.Plugs.Authenticate
   end
 
+  # SSE-only: browsers' native EventSource API can't set custom request
+  # headers, so this is the only route allowed to accept a bearer token via
+  # `?token=` — see RiptideWeb.Plugs.Authenticate's own moduledoc.
+  pipeline :auth_query_param do
+    plug RiptideWeb.Plugs.Authenticate, allow_query_param: true
+  end
+
   pipeline :authz do
     plug RiptideWeb.Plugs.Authorize
   end
@@ -25,7 +32,7 @@ defmodule RiptideWeb.Router do
   end
 
   scope "/" do
-    pipe_through [:api, :auth]
+    pipe_through [:api, :auth_query_param]
 
     get "/streams/:stream_id/subscribe", RiptideWeb.Realtime.SseController, :subscribe
   end

--- a/test/riptide/auth/verifier/oidc_test.exs
+++ b/test/riptide/auth/verifier/oidc_test.exs
@@ -54,7 +54,8 @@ defmodule Riptide.Auth.Verifier.OIDCTest do
     default_claims = %{
       "iss" => @issuer,
       "aud" => @audience,
-      "exp" => System.system_time(:second) + 3600
+      "exp" => System.system_time(:second) + 3600,
+      "sub" => "user-1"
     }
 
     Joken.generate_and_sign!(%{}, Map.merge(default_claims, claims), signer)
@@ -130,6 +131,16 @@ defmodule Riptide.Auth.Verifier.OIDCTest do
 
   test "rejects a validly-signed token that omits aud entirely", %{signer: signer} do
     assert {:error, _reason} = Verifier.OIDC.verify(token_missing("aud", signer))
+  end
+
+  # A validly-signed token that omits `sub` would otherwise pass verification
+  # with `current_subject["sub"] == nil` — if such a token were the first
+  # write to a brand-new tenant, the stored owner policy would become
+  # `{:agent, nil}`, matching any OTHER subject-less token too (see
+  # Riptide.Auth.TokenConfig's own moduledoc). Requiring `sub` here closes
+  # that off before it can ever reach the authorization layer.
+  test "rejects a validly-signed token that omits sub entirely", %{signer: signer} do
+    assert {:error, {:missing_claims, ["sub"]}} = Verifier.OIDC.verify(token_missing("sub", signer))
   end
 
   # Regression test: `"exp": null` (present, not omitted) previously passed

--- a/test/riptide/auth/verifier/oidc_test.exs
+++ b/test/riptide/auth/verifier/oidc_test.exs
@@ -140,7 +140,8 @@ defmodule Riptide.Auth.Verifier.OIDCTest do
   # Riptide.Auth.TokenConfig's own moduledoc). Requiring `sub` here closes
   # that off before it can ever reach the authorization layer.
   test "rejects a validly-signed token that omits sub entirely", %{signer: signer} do
-    assert {:error, {:missing_claims, ["sub"]}} = Verifier.OIDC.verify(token_missing("sub", signer))
+    assert {:error, {:missing_claims, ["sub"]}} =
+             Verifier.OIDC.verify(token_missing("sub", signer))
   end
 
   # Regression test: `"exp": null` (present, not omitted) previously passed

--- a/test/riptide/placement/placement_machine_test.exs
+++ b/test/riptide/placement/placement_machine_test.exs
@@ -3,8 +3,8 @@ defmodule Riptide.Placement.PlacementMachineTest do
 
   alias Riptide.Placement.PlacementMachine
 
-  test "init/1 starts with empty streams and policies" do
-    assert PlacementMachine.init(%{}) == %{streams: %{}, policies: %{}}
+  test "init/1 starts with empty streams, policies, and repair_claims" do
+    assert PlacementMachine.init(%{}) == %{streams: %{}, policies: %{}, repair_claims: %{}}
   end
 
   test "apply/3 stores a new stream's node list" do
@@ -13,7 +13,12 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:assign, "s1", [:a, :b, :c]}, state)
 
-    assert new_state == %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
+    assert new_state == %{
+             streams: %{"s1" => [:a, :b, :c]},
+             policies: %{},
+             repair_claims: %{}
+           }
+
     assert reply == [:a, :b, :c]
     assert effects == []
   end
@@ -25,7 +30,12 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 2}, {:assign, "s1", [:x, :y, :z]}, state)
 
-    assert new_state == %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
+    assert new_state == %{
+             streams: %{"s1" => [:a, :b, :c]},
+             policies: %{},
+             repair_claims: %{}
+           }
+
     assert reply == [:a, :b, :c]
     assert effects == []
   end
@@ -35,20 +45,30 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {state, _, _} = PlacementMachine.apply(%{index: 1}, {:assign, "s1", [:a, :b, :c]}, state)
     {state, _, _} = PlacementMachine.apply(%{index: 2}, {:assign, "s2", [:d, :e, :f]}, state)
 
-    assert state == %{streams: %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}, policies: %{}}
+    assert state == %{
+             streams: %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]},
+             policies: %{},
+             repair_claims: %{}
+           }
   end
 
   test "get/2 returns the assigned nodes for a known stream" do
-    state = %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
+    state = %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}, repair_claims: %{}}
     assert PlacementMachine.get(state, "s1") == [:a, :b, :c]
   end
 
   test "get/2 returns nil for an unknown stream" do
-    assert PlacementMachine.get(%{streams: %{}, policies: %{}}, "unknown") == nil
+    assert PlacementMachine.get(%{streams: %{}, policies: %{}, repair_claims: %{}}, "unknown") ==
+             nil
   end
 
-  test "list/1 returns only the stream_id => nodes map, not the internal policies state" do
-    state = %{streams: %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}, policies: %{"acme" => %{}}}
+  test "list/1 returns only the stream_id => nodes map, not the internal policies/repair_claims state" do
+    state = %{
+      streams: %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]},
+      policies: %{"acme" => %{}},
+      repair_claims: %{"s1" => %{dead_node: :b, claimant: :a, claimed_at: 0}}
+    }
+
     assert PlacementMachine.list(state) == %{"s1" => [:a, :b, :c], "s2" => [:d, :e, :f]}
   end
 
@@ -57,34 +77,44 @@ defmodule Riptide.Placement.PlacementMachineTest do
   end
 
   test "apply/3 {:replace_member, ...} swaps a dead node for a new one in an existing assignment" do
-    state = %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}}
+    state = %{streams: %{"s1" => [:a, :b, :c]}, policies: %{}, repair_claims: %{}}
 
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:replace_member, "s1", :b, :z}, state)
 
-    assert new_state == %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}}
+    assert new_state == %{
+             streams: %{"s1" => [:a, :z, :c]},
+             policies: %{},
+             repair_claims: %{}
+           }
+
     assert reply == [:a, :z, :c]
     assert effects == []
   end
 
   test "apply/3 {:replace_member, ...} is a no-op if the named dead node is no longer present" do
-    state = %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}}
+    state = %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}, repair_claims: %{}}
 
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 2}, {:replace_member, "s1", :b, :y}, state)
 
-    assert new_state == %{streams: %{"s1" => [:a, :z, :c]}, policies: %{}}
+    assert new_state == %{
+             streams: %{"s1" => [:a, :z, :c]},
+             policies: %{},
+             repair_claims: %{}
+           }
+
     assert reply == [:a, :z, :c]
     assert effects == []
   end
 
   test "apply/3 {:replace_member, ...} is a no-op for an unknown stream_id" do
-    state = %{streams: %{}, policies: %{}}
+    state = %{streams: %{}, policies: %{}, repair_claims: %{}}
 
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:replace_member, "unknown", :a, :b}, state)
 
-    assert new_state == %{streams: %{}, policies: %{}}
+    assert new_state == %{streams: %{}, policies: %{}, repair_claims: %{}}
     assert reply == nil
     assert effects == []
   end
@@ -96,7 +126,12 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 1}, {:add_policy, "acme", [], policy}, state)
 
-    assert new_state == %{streams: %{}, policies: %{"acme" => %{[] => [policy]}}}
+    assert new_state == %{
+             streams: %{},
+             policies: %{"acme" => %{[] => [policy]}},
+             repair_claims: %{}
+           }
+
     assert reply == :ok
     assert effects == []
   end
@@ -111,8 +146,47 @@ defmodule Riptide.Placement.PlacementMachineTest do
     {new_state, reply, effects} =
       PlacementMachine.apply(%{index: 2}, {:add_policy, "acme", [], second}, state)
 
-    assert new_state == %{streams: %{}, policies: %{"acme" => %{[] => [first, second]}}}
+    assert new_state == %{
+             streams: %{},
+             policies: %{"acme" => %{[] => [first, second]}},
+             repair_claims: %{}
+           }
+
     assert reply == :ok
+    assert effects == []
+  end
+
+  test "apply/3 {:add_policy, ...} deduplicates an exact-duplicate policy instead of appending it again" do
+    state = PlacementMachine.init(%{})
+    policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
+
+    {state, _, _} = PlacementMachine.apply(%{index: 1}, {:add_policy, "acme", [], policy}, state)
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 2}, {:add_policy, "acme", [], policy}, state)
+
+    assert new_state == state
+    assert reply == :ok
+    assert effects == []
+  end
+
+  test "apply/3 {:add_policy, ...} rejects once a tenant/prefix hits the policy cap" do
+    state = PlacementMachine.init(%{})
+
+    state =
+      Enum.reduce(1..1000, state, fn n, acc ->
+        policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: {:agent, "u#{n}"}}
+        {acc, _, _} = PlacementMachine.apply(%{index: n}, {:add_policy, "acme", [], policy}, acc)
+        acc
+      end)
+
+    one_more = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: {:agent, "u1001"}}
+
+    {new_state, reply, effects} =
+      PlacementMachine.apply(%{index: 1001}, {:add_policy, "acme", [], one_more}, state)
+
+    assert new_state == state
+    assert reply == {:error, :too_many_policies}
     assert effects == []
   end
 
@@ -130,7 +204,8 @@ defmodule Riptide.Placement.PlacementMachineTest do
     assert new_state ==
              %{
                streams: %{},
-               policies: %{"acme" => %{[] => [root_policy], ["secret"] => [child_policy]}}
+               policies: %{"acme" => %{[] => [root_policy], ["secret"] => [child_policy]}},
+               repair_claims: %{}
              }
   end
 
@@ -152,7 +227,8 @@ defmodule Riptide.Placement.PlacementMachineTest do
                    }
                  ]
                }
-             }
+             },
+             repair_claims: %{}
            }
 
     assert reply == :claimed
@@ -185,10 +261,142 @@ defmodule Riptide.Placement.PlacementMachineTest do
 
   test "list_policies/3 returns exactly the policies stored at that tenant/prefix" do
     policy = %Riptide.Authz.Policy{effect: :allow, modes: [:read], matcher: :public}
-    state = %{streams: %{}, policies: %{"acme" => %{["docs"] => [policy]}}}
+    state = %{streams: %{}, policies: %{"acme" => %{["docs"] => [policy]}}, repair_claims: %{}}
 
     assert PlacementMachine.list_policies(state, "acme", ["docs"]) == [policy]
     assert PlacementMachine.list_policies(state, "acme", []) == []
     assert PlacementMachine.list_policies(state, "other-tenant", ["docs"]) == []
+  end
+
+  describe "{:claim_repair, ...} / {:release_repair, ...} (audit remediation, 2026-08-27)" do
+    test "grants a claim when none exists yet" do
+      state = PlacementMachine.init(%{})
+
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      assert reply == :claimed
+      assert effects == []
+
+      assert new_state.repair_claims == %{
+               "s1" => %{dead_node: :dead, claimant: :node_a, claimed_at: 1000}
+             }
+    end
+
+    test "denies a claim held by a different claimant" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 2}, {:claim_repair, "s1", :dead, :node_b, 1001}, state)
+
+      assert reply == :already_claimed
+      assert effects == []
+      assert new_state == state
+    end
+
+    test "re-granting the same claimant/dead_node pair is idempotent (safe retry)" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 2}, {:claim_repair, "s1", :dead, :node_a, 1050}, state)
+
+      assert reply == :claimed
+      assert effects == []
+      # Refreshes claimed_at on the same claimant's re-claim.
+      assert new_state.repair_claims["s1"].claimed_at == 1050
+    end
+
+    test "a different claimant can steal an expired claim (TTL exceeded)" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      # 1000 + 121 > @claim_ttl_seconds (120) past the original claim.
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 2}, {:claim_repair, "s1", :dead, :node_b, 1121}, state)
+
+      assert reply == :claimed
+      assert effects == []
+
+      assert new_state.repair_claims == %{
+               "s1" => %{dead_node: :dead, claimant: :node_b, claimed_at: 1121}
+             }
+    end
+
+    test "a different claimant cannot steal a claim still within its TTL" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      {new_state, reply, _effects} =
+        PlacementMachine.apply(%{index: 2}, {:claim_repair, "s1", :dead, :node_b, 1119}, state)
+
+      assert reply == :already_claimed
+      assert new_state == state
+    end
+
+    test "release_repair clears the claimant's own claim" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 2}, {:release_repair, "s1", :node_a}, state)
+
+      assert reply == :ok
+      assert effects == []
+      assert new_state.repair_claims == %{}
+    end
+
+    test "release_repair from a claimant that doesn't hold the claim is a safe no-op" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 2}, {:release_repair, "s1", :node_b}, state)
+
+      assert reply == :ok
+      assert effects == []
+      # node_a's claim is untouched — a stale/duplicate release from a
+      # different claimant never clears someone else's active claim.
+      assert new_state == state
+    end
+
+    test "release_repair for a stream with no claim at all is a safe no-op" do
+      state = PlacementMachine.init(%{})
+
+      {new_state, reply, effects} =
+        PlacementMachine.apply(%{index: 1}, {:release_repair, "s1", :node_a}, state)
+
+      assert reply == :ok
+      assert effects == []
+      assert new_state == state
+    end
+
+    test "claims on different streams are independent" do
+      state = PlacementMachine.init(%{})
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 1}, {:claim_repair, "s1", :dead, :node_a, 1000}, state)
+
+      {state, :claimed, _} =
+        PlacementMachine.apply(%{index: 2}, {:claim_repair, "s2", :dead, :node_b, 1000}, state)
+
+      assert state.repair_claims == %{
+               "s1" => %{dead_node: :dead, claimant: :node_a, claimed_at: 1000},
+               "s2" => %{dead_node: :dead, claimant: :node_b, claimed_at: 1000}
+             }
+    end
   end
 end

--- a/test/riptide/ra_cluster_test.exs
+++ b/test/riptide/ra_cluster_test.exs
@@ -323,12 +323,19 @@ defmodule Riptide.RaClusterTest do
       # `node()` is already a member here, so `add_member`/`start_server` both
       # self-correct on their own respective "already there" outcomes (finding
       # 3, Phase 3d-ii final review — see `RaCluster.add_member/2` and
-      # `start_joining_server/4`'s own docs) and the call proceeds all the way
-      # to `remove_member`, which is where this contrived scenario's real
-      # error surfaces: `:dead@nowhere` was never actually a member of this
-      # single-member cluster to begin with.
-      assert RaCluster.replace_member(uid, [node()], :dead@nowhere, node(), machine) ==
-               {:error, :not_member}
+      # `start_joining_server/4`'s own docs), and `remove_member` now
+      # self-corrects too (audit remediation, 2026-08-27 — see
+      # `RaCluster.remove_member/2`'s own doc): `:dead@nowhere` was never
+      # actually a member of this single-member cluster, so
+      # `:ra.remove_member/2` returns `{:error, :not_member}`, but
+      # `member_removed?/2` observes that `:dead@nowhere` is indeed absent
+      # from the cluster's real membership and treats that as the desired
+      # end state already holding, not a distinguishable failure — the same
+      # ambiguity `:ra.remove_member/2` itself has between "never a member"
+      # and "already removed by an earlier attempt," resolved in favor of
+      # the idempotent, self-correcting outcome every other step of this
+      # same pipeline already uses.
+      assert RaCluster.replace_member(uid, [node()], :dead@nowhere, node(), machine) == :ok
     end
   end
 end

--- a/test/riptide/stream/stream_server_test.exs
+++ b/test/riptide/stream/stream_server_test.exs
@@ -164,4 +164,68 @@ defmodule Riptide.Stream.StreamServerTest do
 
     assert_received {[:riptide, :stream, :get_since, :gap], ^ref, %{}, %{}}
   end
+
+  describe "replica fallback (audit remediation, 2026-08-27)" do
+    # append/2 and get_since/2 previously always addressed only
+    # `hd(Placement.server_ids!(stream_id))` — a de-facto single point of
+    # failure for the whole stream even if its other replicas were healthy.
+    # This directly manipulates Riptide.Stream.Placement's own cache (a
+    # public, named ETS table — see its moduledoc) to inject an unreachable
+    # server id ahead of the real, already-running one, mirroring the same
+    # "collapsed/synthetic multi-member" testing pattern already used
+    # elsewhere in this codebase (e.g. RaClusterTest's own collapsed-node
+    # test) rather than standing up a real multi-node :peer cluster just to
+    # prove this fallback logic.
+    test "append/2 falls back to the next replica when the first is unreachable" do
+      stream_id = "stream-fallback-append-" <> Uniq.UUID.uuid4()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+      {:ok, _pid} = StreamServer.start_link(stream_id)
+      real_server_id = hd(:ets.lookup_element(:riptide_stream_placement_cache, stream_id, 2))
+      uid = Riptide.RaCluster.uid_for(stream_id)
+      unreachable_server_id = {String.to_atom(uid), :nonexistent@nohost}
+
+      :ets.insert(
+        :riptide_stream_placement_cache,
+        {stream_id, [unreachable_server_id, real_server_id]}
+      )
+
+      appended =
+        StreamServer.append(stream_id, Event.new(stream_id, :replace, RDF.Graph.new()))
+
+      assert appended.sequence == 1
+    end
+
+    test "get_since/2 falls back to the next replica when the first is unreachable" do
+      stream_id = "stream-fallback-get-since-" <> Uniq.UUID.uuid4()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+      {:ok, _pid} = StreamServer.start_link(stream_id)
+      StreamServer.append(stream_id, Event.new(stream_id, :replace, RDF.Graph.new()))
+
+      real_server_id = hd(:ets.lookup_element(:riptide_stream_placement_cache, stream_id, 2))
+      uid = Riptide.RaCluster.uid_for(stream_id)
+      unreachable_server_id = {String.to_atom(uid), :nonexistent@nohost}
+
+      :ets.insert(
+        :riptide_stream_placement_cache,
+        {stream_id, [unreachable_server_id, real_server_id]}
+      )
+
+      assert {:ok, [%{sequence: 1}]} = StreamServer.get_since(stream_id, 0)
+    end
+
+    test "append/2 raises when every replica is unreachable" do
+      stream_id = "stream-fallback-total-failure-" <> Uniq.UUID.uuid4()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
+
+      uid = Riptide.RaCluster.uid_for(stream_id)
+      unreachable_server_id = {String.to_atom(uid), :nonexistent@nohost}
+      :ets.insert(:riptide_stream_placement_cache, {stream_id, [unreachable_server_id]})
+
+      assert_raise RuntimeError, fn ->
+        StreamServer.append(stream_id, Event.new(stream_id, :replace, RDF.Graph.new()))
+      end
+    end
+  end
 end

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -2,6 +2,8 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
   use ExUnit.Case, async: false
   use Plug.Test
 
+  import ExUnit.CaptureLog
+
   alias Riptide.Authz.{Policy, Store}
   alias RiptideWeb.LDP.ResourceController
 
@@ -258,6 +260,42 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
 
     container_get_conn = :get |> conn(container_path) |> RiptideWeb.Endpoint.call(@opts)
     assert container_get_conn.resp_body =~ "ldp#contains"
+  end
+
+  test "POST to a container whose containment patch fails cleans up the orphaned child instead of leaving it dangling" do
+    container_path = unique_path()
+    container_stream_id = stream_id_for(container_path)
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(container_stream_id) end)
+
+    # Pre-seeds the container's placement cache with an unreachable server
+    # id — Riptide.Stream.Placement.ensure_started/2's cache-hit path trusts
+    # the cache without re-validating reachability, so StreamSupervisor.
+    # ensure_ready/1 still reports :ok for the container (the child's own
+    # stream is a fresh, real, non-seeded one and succeeds normally), but
+    # the container's own StreamServer.append/2 — the containment patch —
+    # then genuinely fails against that unreachable address.
+    uid = Riptide.RaCluster.uid_for(container_stream_id)
+    unreachable_server_id = {String.to_atom(uid), :nonexistent@nohost}
+    :ets.insert(:riptide_stream_placement_cache, {container_stream_id, [unreachable_server_id]})
+
+    child_turtle = "<https://pod.example/a> <https://pod.example/b> \"c\" .\n"
+
+    log =
+      capture_log(fn ->
+        post_conn =
+          :post
+          |> conn(container_path, child_turtle)
+          |> put_req_header("content-type", "text/turtle")
+          |> RiptideWeb.Endpoint.call(@opts)
+
+        assert post_conn.status == 503
+      end)
+
+    # If cleanup of the orphaned child had ALSO failed, that failure logs
+    # loudly (see ResourceController.log_orphaned_child_cleanup_failure/2) —
+    # its absence here means the child's own :delete append succeeded, i.e.
+    # the orphan was actually cleaned up rather than left dangling.
+    refute log =~ "manual cleanup needed"
   end
 
   test "ensure_ready_status/1 maps :ok and {:error, _} correctly" do

--- a/test/riptide_web/plugs/authenticate_test.exs
+++ b/test/riptide_web/plugs/authenticate_test.exs
@@ -52,13 +52,27 @@ defmodule RiptideWeb.Plugs.AuthenticateTest do
     assert conn.status == 401
   end
 
-  test "falls back to a ?token= query param when no header is present" do
+  test "falls back to a ?token= query param when no header is present and allow_query_param is set" do
     conn =
       :get
       |> conn("/streams/abc/subscribe?token=valid-token")
-      |> Authenticate.call(Authenticate.init([]))
+      |> Authenticate.call(Authenticate.init(allow_query_param: true))
 
     assert conn.assigns.current_subject == %{"sub" => "user-1"}
+    refute conn.halted
+  end
+
+  test "ignores a ?token= query param when allow_query_param is not set (default)" do
+    # A bearer token in a query string is a durable leak risk (proxy/access
+    # logs, browser history, Referer forwarding) — the fallback only applies
+    # when a pipeline explicitly opts in (see RiptideWeb.Router's
+    # :auth_query_param pipeline, used only by the SSE subscribe route).
+    conn =
+      :get
+      |> conn("/resources/foo?token=valid-token")
+      |> Authenticate.call(Authenticate.init([]))
+
+    assert conn.assigns.current_subject == nil
     refute conn.halted
   end
 
@@ -67,7 +81,7 @@ defmodule RiptideWeb.Plugs.AuthenticateTest do
       :get
       |> conn("/streams/abc/subscribe?token=garbage")
       |> put_req_header("authorization", "Bearer valid-token")
-      |> Authenticate.call(Authenticate.init([]))
+      |> Authenticate.call(Authenticate.init(allow_query_param: true))
 
     assert conn.assigns.current_subject == %{"sub" => "user-1"}
     refute conn.halted

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -227,5 +227,25 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
       assert conn.status == 403
       assert Logger.metadata()[:tenant_id] == tenant_id
     end
+
+    # Riptide.Authz.evaluate/4 (called directly here, not through
+    # RiptideWeb.Plugs.Authorize) raises when the placement cluster backing
+    # the policy store is totally unreachable — this must surface as a
+    # clean 503 (retry-able), not an uncaught crash / generic 500.
+    test "subscribing when the placement cluster is fully unreachable returns 503, not a crash" do
+      original = Application.get_env(:riptide, :ordinal_resolver)
+      Application.put_env(:riptide, :ordinal_resolver, fn _ordinal -> :nonexistent@nohost end)
+      on_exit(fn -> Application.put_env(:riptide, :ordinal_resolver, original) end)
+
+      tenant_id = "sse-authz-down-test-" <> Uniq.UUID.uuid4()
+      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+
+      conn =
+        :get
+        |> conn("/streams/#{URI.encode_www_form(stream_id)}/subscribe")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 503
+    end
   end
 end


### PR DESCRIPTION
## Summary

Full-repo audit (7 parallel passes: correctness, security, concurrency, error handling, resource management, data integrity, observability) with every Critical/Important finding fixed and re-verified. See the accompanying PR comment / conversation for the complete finding-by-finding report.

Highlights:
- **Security**: closed a tenant-hijack path (sub-less JWTs sharing a bootstrapped owner policy), scoped the `?token=` auth fallback to SSE only, added a per-process heap cap after confirming empirically that a ~3MB deeply-nested Turtle body drives ~863MB/~19s in the decoding process.
- **Concurrency/data-integrity**: fenced `ReplicaHealer`'s repair through the placement Ra cluster's own consensus (new `{:claim_repair, ...}`/`{:release_repair, ...}` commands) instead of trusting an unfenced leader check — closes a dual-leader race that could permanently orphan a Ra member; made `RaCluster.replace_member/5`'s `remove_member` step fully idempotent.
- **Correctness**: `StreamServer.append/2`/`get_since/2` now fall back across all of a stream's replicas (previously a de-facto SPOF on the first one); fixed `create_child`'s orphaned-child risk on partial failure.
- **Error handling**: `RaMachine.apply/3` no longer crash-loops a replica forever on an undecodable committed event; `RaCluster`'s core Ra wrappers now catch `:exit` uniformly; placement-cluster-down now maps to 503 everywhere (`Authorize`, `PolicyController`, SSE, WS), not a generic 500.
- **Resource management**: per-tenant live-stream quota (bounds unbounded Ra-cluster creation via a POST loop), JWKS fetch timeout, policy-list dedup/cap, k8s resource limits + hardened securityContext.
- **Observability**: new telemetry for authz decisions, HTTP exceptions, WS connect/join results, ordinal fallback, placement-cluster formation attempts, stream formation failures, dropped poison commands, quota rejections; logging added for previously-silent failure paths.

## Test plan

- [x] Full suite green: 261 tests, 0 failures (from 243 baseline — 18 new tests covering the new claim mechanism, replica fallback, orphan cleanup, and placement-down → 503 paths)
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean (435 mods/funs, 0 issues)
- [x] Turtle DoS finding confirmed via live empirical repro before and after the fix
- [x] Every finding independently re-verified against real code/library source before being fixed (not taken at face value from the audit passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)