### PR TITLE
Fix single-node deployments (Fly.io, docker-compose) and add a Fly.io deployment path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,6 @@ VOLUME ["/data"]
 EXPOSE 4000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:4000/health || exit 1
+  CMD curl -f http://localhost:4000/health/live || exit 1
 
 CMD ["bin/riptide", "start"]

--- a/README.md
+++ b/README.md
@@ -163,6 +163,62 @@ metadata:
 Setting up Prometheus itself (and any Grafana dashboards/alerting on top of it) is your own
 deployment's concern — these manifests only expose the metrics, they don't install a scraper.
 
+## Running on Fly.io
+
+`fly.toml` (included in this repo) deploys Riptide as a single Fly Machine with a persistent Fly
+Volume mounted at `/data` — the same single-node model as `docker-compose.yml` above, just on
+Fly's infrastructure instead of your own. This needs `flyctl` and an authenticated Fly.io org.
+
+```bash
+fly apps create <your-app-name>          # update fly.toml's `app` and `PHX_HOST` to match
+fly volumes create riptide_data --region <region> --size 1 -a <your-app-name>
+fly secrets set -a <your-app-name> \
+  SECRET_KEY_BASE="$(openssl rand -base64 48)" \
+  RELEASE_DISTRIBUTION=name \
+  RELEASE_NODE=riptide@127.0.0.1 \
+  RELEASE_COOKIE="$(openssl rand -hex 16)"
+fly deploy -a <your-app-name>
+```
+
+`RELEASE_DISTRIBUTION`/`RELEASE_NODE`/`RELEASE_COOKIE` enable Erlang distribution scoped to
+loopback only (`127.0.0.1` — not reachable from outside the machine), solely so `bin/riptide rpc`
+can attach for one-off administrative calls (see "Seeding data" below) — this is the Fly
+equivalent of `iex -S mix phx.server`'s attached shell in local dev.
+
+**Why `RELEASE_NODE=riptide@127.0.0.1`, not `@localhost`:** Erlang's longname distribution mode
+(`RELEASE_DISTRIBUTION=name`) requires the host part to be a real IP or fully-qualified hostname —
+`localhost` is rejected outright ("Hostname localhost is illegal"). This mirrors
+`rel/env.sh.eex`'s own `riptide@$POD_IP` choice for the Kubernetes path, just with the loopback
+address in place of a pod IP.
+
+`fly.toml` also sets `HOSTNAME=riptide-0` and `RIPTIDE_SINGLE_NODE=true` — required together for
+any single-machine deployment (Fly, plain `docker run`, `docker-compose`) to actually pass
+`/health/ready`: see the comment on `RIPTIDE_SINGLE_NODE` in `config/runtime.exs` for why.
+
+### Seeding data
+
+There's no HTTP endpoint for tenant/policy administration (deliberately — it's an Elixir-native,
+operator-only action, same as local dev's `setup.exs`). Attach via `bin/riptide rpc`, not
+`bin/riptide remote`: the latter's `--remsh` silently falls back to a disconnected local session
+over a non-tty connection (exactly what `fly ssh console -C "..."` gives you), which looks like it
+worked but never touches the running app. `rpc` doesn't need a tty:
+
+```bash
+fly ssh console -a <your-app-name> -C \
+  "/app/bin/riptide rpc 'Code.eval_string(Base.decode64!(\"$(base64 -w0 examples/live-story/setup.exs)\"))'"
+```
+
+(Base64-encoding the script sidesteps quoting a multi-line Elixir expression through two layers of
+shell — `fly ssh console -C` and the SSH session itself.) For a one-off tenant policy without the
+full live-story seed, pass a shorter expression the same way — `rpc` accepts any single Elixir
+expression.
+
+### Verified
+
+Setup → deploy → seed → verify (health check, `PATCH` a line, confirm it via `GET` and over SSE) →
+complete teardown (`fly apps destroy <app> --yes`), run 3 times end-to-end with no manual
+intervention between runs, 2026-08-27.
+
 ## Performance
 
 Measured 2026-08-27 against the code at this point in `main`. Every number below is from a real

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -41,6 +41,24 @@ if config_env() != :test do
     data_dir: System.get_env("RIPTIDE_RA_DATA_DIR", "priv/ra_data") |> String.to_charlist()
 end
 
+# Opt-in single-node override, mirroring config/dev.exs's and config/test.exs's
+# own identical `ordinal_resolver` override (see either's comment for the full
+# rationale) — collapses all 3 placement ordinals to whatever node this
+# process actually is. A real single-machine deployment outside Kubernetes
+# (Fly.io, plain `docker run`/`docker-compose`) has no headless-service DNS
+# resolving "riptide-0"/"riptide-1"/"riptide-2" the way
+# `default_ordinal_resolver/1`'s real-DNS fallback expects. Without this,
+# `/health/ready` — and every LDP/SSE/WebSocket request, all of which route
+# through `Riptide.Placement.lookup/1` — permanently 503s on any such
+# deployment (confirmed live on Fly.io: `nxdomain` resolving each ordinal).
+# A deployment opting into this must ALSO run with `HOSTNAME` set to one of
+# the 3 fixed ordinals ("riptide-0"/"riptide-1"/"riptide-2") for
+# `Riptide.Application.placement_bootstrap_children/0`'s own separate gate to
+# even attempt bootstrapping the (now single-member) placement cluster.
+if System.get_env("RIPTIDE_SINGLE_NODE") do
+  config :riptide, ordinal_resolver: fn _ordinal -> node() end
+end
+
 # Only present when the k8s/statefulset.yaml pod spec's Downward API sets it —
 # everywhere else (local dev, docker-compose, tests) libcluster stays configured
 # with an empty topology list, making Cluster.Supervisor an inert no-op (see

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,29 @@
+app = "riptide-live-story"
+primary_region = "fra"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PHX_HOST = "riptide-live-story.fly.dev"
+  PORT = "4000"
+  HOSTNAME = "riptide-0"
+  RIPTIDE_SINGLE_NODE = "true"
+
+[[mounts]]
+  source = "riptide_data"
+  destination = "/data"
+
+[http_service]
+  internal_port = 4000
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[http_service.checks]]
+  interval = "30s"
+  timeout = "5s"
+  grace_period = "15s"
+  method = "GET"
+  path = "/health/ready"


### PR DESCRIPTION
## Summary
- Fixes a real, previously-undetected bug: `/health/ready` (and every LDP/SSE/WebSocket request, all of which route through `Riptide.Placement.lookup/1`) permanently 503s on any single-node deployment outside a real Kubernetes StatefulSet, because there's no DNS for the `riptide-0`/`riptide-1`/`riptide-2` placement ordinals it tries to resolve. This silently affected the already-documented `docker-compose`/plain `docker run` path too, not just Fly.io.
- Adds an opt-in `RIPTIDE_SINGLE_NODE` runtime override (`config/runtime.exs`) that collapses all 3 placement ordinals to the local node, mirroring `config/dev.exs`'s and `config/test.exs`'s own identical trick.
- Fixes the Dockerfile's own `HEALTHCHECK`, which curled a route that has never existed (`/health`) instead of the liveness-only `/health/live`.
- Adds a documented, checked-in Fly.io deployment path (`fly.toml` + a new README section): single Fly Machine + persistent Fly Volume, using the single-node override above. Documents two non-obvious gotchas found along the way: `RELEASE_NODE=riptide@127.0.0.1` (not `@localhost` — Erlang longnames reject it outright), and `bin/riptide rpc` for seeding data instead of `bin/riptide remote` (whose `--remsh` silently no-ops over a non-tty SSH connection).

## Test plan
- [x] `mix test` — 268 tests, 0 failures, 2 excluded
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — no issues
- [x] 3 full live cycles against the real Divizend Fly.io org: create app + volume + secrets → deploy → confirm `/health/ready` 200 → seed the tenant/story via `bin/riptide rpc` → confirm the resource, a live `PATCH`, and SSE backlog all work → `fly apps destroy` → confirmed no resources left. Repeated 3 times end-to-end with no manual intervention between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)