### PR TITLE
Harden Fly.io deployment: pin HOSTNAME, make live-story demo point at any server

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ for why. This isn't strictly required (the default target size of 3 still gracef
 whatever's actually present), but leaving it unset means the ambient join loop keeps periodically
 probing for 2 more nodes that will never appear.
 
+`fly.toml` also pins `HOSTNAME=riptide` — unlike Kubernetes, Fly Machines don't export a `HOSTNAME`
+env var at all (confirmed live: it's absent from `fly ssh console`'s own environment, even though
+the `hostname` command reports the machine ID), and `Riptide.RaCluster.data_dir/0` keys `:ra`'s
+on-disk data directory off that variable. Leaving it unset still works today — it just falls
+through to a hardcoded `"nonode"` default — but pins the data directory's name to an accident of
+Fly's current platform behavior rather than a deliberate value; see `data_dir/0`'s moduledoc.
+
 ### Seeding data
 
 There's no HTTP endpoint for tenant/policy administration (deliberately — it's an Elixir-native,
@@ -217,11 +224,21 @@ shell — `fly ssh console -C` and the SSH session itself.) For a one-off tenant
 full live-story seed, pass a shorter expression the same way — `rpc` accepts any single Elixir
 expression.
 
+### Using the live-story browser demo against this deployment
+
+`examples/live-story/app.js` defaults to `http://localhost:4000` (see its own README for the local
+dev flow), so pointing the bundled browser demo at a Fly deployment instead needs one thing: open
+`examples/live-story/index.html?base=https://<your-app-name>.fly.dev` rather than the bare file —
+the `?base=` query param overrides which server the page talks to, no editing required. Riptide's
+CORS policy allows any origin (see `RiptideWeb.Endpoint`), so this works even opening the HTML file
+directly from disk (a `file://` origin).
+
 ### Verified
 
-Setup → deploy → seed → verify (health check, `PATCH` a line, confirm it via `GET` and over SSE) →
-complete teardown (`fly apps destroy <app> --yes`), run 3 times end-to-end with no manual
-intervention between runs, 2026-08-27.
+Setup → deploy → seed → verify (health check, `PATCH` a line, confirm it via `GET` and over SSE,
+data survives a machine restart) → complete teardown (`fly apps destroy <app> --yes`), run
+end-to-end with no manual intervention between runs, 2026-08-27 and re-verified 2026-08-28
+(HOSTNAME pinning + browser demo `?base=` override added after the 2026-08-28 run surfaced both).
 
 ## Performance
 

--- a/examples/live-story/README.md
+++ b/examples/live-story/README.md
@@ -20,6 +20,11 @@ second browser) to watch lines you add in one appear live in the other.
 
 Leave the `iex` session running — it's your live server. Stop it with Ctrl-C (twice) when done.
 
+Talking to a server somewhere other than `localhost:4000` (e.g. a Fly.io deployment — see the root
+README's "Running on Fly.io" section)? Open `index.html?base=https://your-server-host` instead of
+the bare file — `app.js` reads the `base` query param and defaults to `http://localhost:4000` only
+when it's absent.
+
 ## What to look at
 
 - Type a line and submit it — watch it appear on every open tab immediately.

--- a/examples/live-story/app.js
+++ b/examples/live-story/app.js
@@ -1,4 +1,7 @@
-const BASE_URL = "http://localhost:4000";
+// Defaults to local dev; override via a `?base=` query param (no trailing
+// slash) to point this static page at any other running Riptide instance —
+// e.g. a Fly.io deployment — without editing this file.
+const BASE_URL = new URLSearchParams(window.location.search).get("base") || "http://localhost:4000";
 const TENANT_ID = "story-demo";
 const STORY_PATH = `/tenants/${TENANT_ID}/resources/the-story`;
 const STREAM_ID = `https://riptide.example/tenants/${TENANT_ID}/resources/the-story`;

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,18 @@ primary_region = "fra"
   PHX_HOST = "riptide-live-story.fly.dev"
   PORT = "4000"
   RIPTIDE_PLACEMENT_TARGET_SIZE = "1"
+  # Unlike Kubernetes (which sets a pod's HOSTNAME automatically — see
+  # Riptide.RaCluster.data_dir/0's moduledoc), Fly Machines do NOT export a
+  # HOSTNAME env var at all (confirmed live: `fly ssh console -C env` shows
+  # no HOSTNAME entry, even though the `hostname` command itself reports the
+  # machine ID) — so data_dir/0's fallback silently keys the on-disk Ra data
+  # directory off the literal string "nonode" instead. That happens to be
+  # stable today only because Fly never sets the env var; pin it explicitly
+  # instead of depending on that absence, so a future Fly platform change
+  # (e.g. auto-populating HOSTNAME with the machine ID, which DOES change
+  # across `fly deploy`) can't silently orphan this volume's data under a
+  # new directory name.
+  HOSTNAME = "riptide"
 
 [[mounts]]
   source = "riptide_data"

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -233,9 +233,13 @@ defmodule Riptide.RaCluster do
   # Stable across pod restarts/rescheduling even though Erlang distribution identity
   # (node()) is now IP-based and NOT stable — see Phase 3b design spec §1/§3.
   # Kubernetes sets a StatefulSet pod's HOSTNAME to its stable pod name (e.g.
-  # "riptide-0"); outside Kubernetes (local dev, docker-compose, tests) HOSTNAME
-  # still resolves to something stable per-container/per-host, so this doesn't
-  # regress non-clustered environments. Both `data_dir` and `wal_data_dir` are
+  # "riptide-0"). Outside Kubernetes, HOSTNAME is NOT guaranteed to be set at
+  # all — confirmed live on Fly Machines, which export no HOSTNAME env var
+  # whatsoever (unlike Docker, which does) — so single-node platforms fall
+  # through to the "nonode" default below. That default is stable only as
+  # long as the platform keeps leaving the env var unset; `fly.toml` pins
+  # `HOSTNAME` explicitly for exactly this reason rather than relying on it.
+  # Both `data_dir` and `wal_data_dir` are
   # pinned here — `:ra`'s own `default_config/0` would otherwise leave
   # `wal_data_dir` defaulted to the OLD node()-derived directory
   # (`ra_system.erl`'s `WalDataDir = application:get_env(ra, wal_data_dir,


### PR DESCRIPTION
## Summary
- Ran the README's "Running on Fly.io" instructions end-to-end against a fresh Fly app and found two real issues.
- `Riptide.RaCluster.data_dir/0` keys the on-disk Ra data directory off `HOSTNAME`, but Fly Machines export no `HOSTNAME` env var at all (confirmed live via `fly ssh console -C env`) — it silently fell through to the hardcoded `"nonode"` literal. Stable today only by accident; `fly.toml` now pins `HOSTNAME=riptide` explicitly, and the stale moduledoc comment claiming non-k8s environments always have a stable HOSTNAME is corrected.
- `examples/live-story/app.js` hardcoded `BASE_URL` to `localhost:4000`, so a working Fly deployment had no way to actually load the bundled browser demo against it without hand-editing the file. Added a `?base=` query param override (default unchanged) and documented it in both READMEs.

## Test plan
- [x] `mix compile --force --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] `mix test` — 285 tests, 0 failures
- [x] `node --check examples/live-story/app.js` + manual logic check of the `?base=` override with/without the query param
- [x] Live-verified against a real Fly deployment: health checks, PATCH/GET/SSE round-trip, and data survival across a machine restart, before this fix (confirmed the bug) — full clean re-run with the fix planned next