### PR TITLE
Add live-story/graph.html: real-time WebGL RDF graph viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ editing required. Riptide's CORS policy allows any origin (see
 [`RiptideWeb.Endpoint`](lib/riptide_web/endpoint.ex)), so this works even opening the HTML file
 directly from disk (a `file://` origin).
 
+[`examples/live-story/graph.html`](examples/live-story/graph.html) — a live WebGL visualization of
+`the-story`'s actual RDF graph, see [its own README section](examples/live-story/README.md#watching-it-as-a-graph)
+— takes the same `?base=` override, plus `?tenant=`/`?resource=` to point it at any resource rather
+than just this demo's.
+
 ### Verified
 
 Setup → deploy → seed → verify (health check, `PATCH` a line, confirm it via `GET` and over SSE,

--- a/examples/live-story/README.md
+++ b/examples/live-story/README.md
@@ -38,3 +38,32 @@ the bare file — the inline script reads the `base` query param and defaults to
   it to see exactly how a browser client talks to Riptide: one `PATCH` to submit a line, one
   `fetch()`-based SSE reader (not the native `EventSource` API — see the comment in
   `subscribeOnce()` for why) to receive the full history and every future line live.
+
+## Watching it as a graph
+
+`examples/live-story/graph.html` is a second, independent page — open it in a third tab alongside
+`index.html` — that renders `the-story`'s actual RDF structure live with
+[Sigma.js](https://www.sigmajs.org/) (WebGL) instead of prose: every subject and object becomes a
+node (gold for literal values like the submitted text/author, blue for IRIs — entities and types),
+every predicate becomes an edge, and new nodes ease into place via a small live force-directed
+layout as lines get submitted. It talks to the exact same SSE stream `index.html` does, so nothing
+on the server needs to change to watch it.
+
+Unlike `index.html` (hardcoded to `story-demo`/`the-story`), `graph.html` is a general RDF graph
+viewer — point it at any tenant/resource with `?tenant=` and `?resource=` query params (both
+default to `story-demo`/`the-story` so it shows this demo out of the box), combined with the same
+`?base=` override as `index.html` for a non-local server:
+
+```
+graph.html?base=https://your-server-host&tenant=story-demo&resource=the-story
+```
+
+It loads Sigma.js and its `graphology` graph library from a CDN (via `esm.sh`, not a bare
+`jsdelivr` dist file — see the comment above the imports in `graph.html` for why: graphology's own
+browser build imports Node's `events` module, which only `esm.sh` resolves for a plain
+`<script type="module">` with no bundler), so unlike `index.html` it needs real internet access to
+that CDN, not just to your Riptide server.
+
+Scoped deliberately to what `the-story` actually does: it only ever handles `:patch` *additions*
+(the only operation this demo ever sends), not `:delete`/`:replace` or patch removals — a resource
+that actually mutates or shrinks would need that handled, which is out of scope here.

--- a/examples/live-story/graph.html
+++ b/examples/live-story/graph.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>The Story So Far — live RDF graph</title>
+  <style>
+    :root {
+      --parchment: #f6ecd9;
+      --ink: #3a2e1f;
+      --gold: #b8860b;
+      --line-bg: #fffaf0;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: var(--parchment);
+      color: var(--ink);
+      font-family: Georgia, "Times New Roman", serif;
+      overflow: hidden;
+    }
+
+    header {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1;
+      padding: 1rem 1.5rem;
+      background: linear-gradient(var(--parchment) 60%, transparent);
+      pointer-events: none;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      margin: 0 0 0.25rem 0;
+    }
+
+    .subtitle {
+      font-size: 0.85rem;
+      opacity: 0.8;
+      margin: 0;
+    }
+
+    .subtitle code {
+      background: var(--line-bg);
+      padding: 0.05rem 0.3rem;
+      border-radius: 4px;
+    }
+
+    #stats {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+
+    #graph-container {
+      position: absolute;
+      inset: 0;
+    }
+
+    #status {
+      position: absolute;
+      bottom: 1rem;
+      left: 1.5rem;
+      z-index: 1;
+      font-size: 0.8rem;
+      opacity: 0.75;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>The Story So Far — live graph</h1>
+    <p class="subtitle">
+      Every subject and object in <code id="stream-id-label"></code>'s RDF graph, as it grows live.
+      Gold nodes are literal values (text/author strings); blue nodes are IRIs (entities and types).
+    </p>
+    <p id="stats"></p>
+  </header>
+
+  <div id="graph-container"></div>
+  <p id="status">connecting…</p>
+
+  <script type="module">
+    // esm.sh, not a raw jsdelivr dist file: graphology's own ESM build
+    // imports Node's built-in `events` module (`import { EventEmitter }
+    // from "events"`) as a bare specifier, which a plain browser
+    // `<script type="module">` can't resolve without a bundler or import
+    // map — confirmed live (Chromium: "Failed to resolve module specifier
+    // 'events'"). esm.sh rewrites bare specifiers like that into real,
+    // fetchable polyfill URLs automatically, so it works unmodified here
+    // with no bundler and no manual import map.
+    import Graph from "https://esm.sh/graphology@0.25.4";
+    import Sigma from "https://esm.sh/sigma@3";
+
+    // Same convention as index.html: defaults to local dev, override via
+    // query params to point this at any Riptide server/tenant/resource
+    // without editing this file. Unlike index.html (which is hardcoded to
+    // "the story"), this viewer is a general RDF graph viewer for whatever
+    // resource you point it at.
+    const params = new URLSearchParams(window.location.search);
+    const BASE_URL = params.get("base") || "http://localhost:4000";
+    const TENANT_ID = params.get("tenant") || "story-demo";
+    const RESOURCE_PATH = params.get("resource") || "the-story";
+
+    // Mirrors RiptideWeb.LDP.ResourceController.stream_id_for/2 exactly —
+    // stream_id is a deterministic, reversible string, not looked up from
+    // anywhere, so deriving it client-side here is the same thing the
+    // server itself does.
+    const STREAM_ID_PREFIX = "https://riptide.example/tenants/";
+    const RESOURCES_SEGMENT = "/resources/";
+    const STREAM_ID = `${STREAM_ID_PREFIX}${TENANT_ID}${RESOURCES_SEGMENT}${RESOURCE_PATH}`;
+
+    document.getElementById("stream-id-label").textContent = `${TENANT_ID}/${RESOURCE_PATH}`;
+    document.title = `${TENANT_ID}/${RESOURCE_PATH} — live RDF graph`;
+
+    const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+    // Same escaping scheme as index.html's inline script — mirrors
+    // Riptide's own Turtle string escaping exactly (see that file's
+    // escapeTurtleLiteral comment for the full rationale). Needed here to
+    // decode literal values back out of the wire format.
+    function unescapeTurtleLiteral(value) {
+      return value.replace(/\\"\\"\\"/g, '"""').replace(/\\\\/g, "\\");
+    }
+
+    function unescapeShortTurtleLiteral(value) {
+      return value.replace(/\\(.)/g, (_, ch) => {
+        switch (ch) {
+          case "n": return "\n";
+          case "r": return "\r";
+          case "t": return "\t";
+          case "b": return "\b";
+          case "f": return "\f";
+          case '"': return '"';
+          case "\\": return "\\";
+          default: return ch;
+        }
+      });
+    }
+
+    // A small hand-rolled parser for exactly the Turtle subset
+    // Riptide.RDF.TurtleCodec emits (confirmed by inspecting real server
+    // output): `@prefix` lines, then one or more `<subject>` blocks of
+    // `;`-separated `predicate object` pairs terminated by `.`, using full
+    // `<IRI>`s (or the `a` shorthand for rdf:type) and short- or
+    // triple-quoted string literals. No blank nodes, collections, or
+    // nested structures — narrow enough that a full Turtle/N3 library
+    // would be overkill, matching this project's existing preference for
+    // small hand-rolled parsing over new dependencies (see index.html's
+    // own extractLiteral). A naive split on `;`/`.` would break on a
+    // submitted line containing those characters inside a literal, so this
+    // walks the string character-by-character and only treats them as
+    // separators outside of a string.
+    function parseTurtleTriples(turtle) {
+      const body = turtle.replace(/^@prefix[^\n]*\n?/gm, "");
+      const triples = [];
+      let i = 0;
+      const n = body.length;
+
+      function skipWhitespace() {
+        while (i < n && /\s/.test(body[i])) i++;
+      }
+
+      function readTerm() {
+        skipWhitespace();
+        if (body[i] === "<") {
+          const end = body.indexOf(">", i);
+          const iri = body.slice(i + 1, end);
+          i = end + 1;
+          return { type: "iri", value: iri };
+        }
+        if (body.startsWith('"""', i)) {
+          const end = body.indexOf('"""', i + 3);
+          const raw = body.slice(i + 3, end);
+          i = end + 3;
+          return { type: "literal", value: unescapeTurtleLiteral(raw) };
+        }
+        if (body[i] === '"') {
+          let j = i + 1;
+          while (j < n) {
+            if (body[j] === "\\") { j += 2; continue; }
+            if (body[j] === '"') break;
+            j++;
+          }
+          const raw = body.slice(i + 1, j);
+          i = j + 1;
+          return { type: "literal", value: unescapeShortTurtleLiteral(raw) };
+        }
+        if (body[i] === "a" && /[\s]/.test(body[i + 1] || " ")) {
+          i += 1;
+          return { type: "iri", value: RDF_TYPE };
+        }
+        throw new Error(`Unexpected Turtle token at offset ${i}: ${JSON.stringify(body.slice(i, i + 20))}`);
+      }
+
+      while (true) {
+        skipWhitespace();
+        if (i >= n) break;
+        const subject = readTerm();
+        let terminator = ";";
+        while (terminator === ";") {
+          const predicate = readTerm();
+          const object = readTerm();
+          triples.push({ subject: subject.value, predicate: predicate.value, object });
+          skipWhitespace();
+          terminator = body[i];
+          i += 1;
+        }
+      }
+
+      return triples;
+    }
+
+    const KNOWN_PREFIXES = [
+      ["http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdf:"],
+      ["http://www.w3.org/2000/01/rdf-schema#", "rdfs:"],
+      ["http://www.w3.org/2001/XMLSchema#", "xsd:"],
+      ["http://schema.org/", "schema:"],
+    ];
+
+    function shortenIri(iri) {
+      for (const [full, short] of KNOWN_PREFIXES) {
+        if (iri.startsWith(full)) return short + iri.slice(full.length);
+      }
+      if (iri.startsWith("urn:uuid:")) return "urn:uuid:" + iri.slice(9, 17) + "…";
+      return iri;
+    }
+
+    function truncate(text, max) {
+      return text.length > max ? text.slice(0, max) + "…" : text;
+    }
+
+    const graph = new Graph();
+
+    // Literal RDF terms have no identity of their own beyond their value,
+    // datatype, and language tag (real RDF semantics — two occurrences of
+    // the same literal string genuinely are the same term). Deduping
+    // literal nodes per (predicate, value) — rather than per-triple —
+    // means e.g. every line from the same guest author collapses onto one
+    // shared author node, visibly clustering lines by author instead of
+    // drawing a disconnected author leaf per line. Scoped per-predicate
+    // (not fully global) so an unrelated predicate whose value happens to
+    // match text elsewhere can't accidentally merge into it.
+    function literalNodeId(predicate, value) {
+      return `lit:${predicate}|${value}`;
+    }
+
+    function ensureNode(id, label, kind) {
+      if (graph.hasNode(id)) return;
+      const neighbors = graph.nodes();
+      let x, y;
+      if (neighbors.length > 0) {
+        // Spawn new nodes near a random existing one rather than at a fixed
+        // origin, so the graph grows outward instead of piling up at (0,0)
+        // before the layout has a chance to spread it out.
+        const near = graph.getNodeAttributes(neighbors[Math.floor(Math.random() * neighbors.length)]);
+        x = near.x + (Math.random() - 0.5) * 40;
+        y = near.y + (Math.random() - 0.5) * 40;
+      } else {
+        x = (Math.random() - 0.5) * 20;
+        y = (Math.random() - 0.5) * 20;
+      }
+
+      graph.addNode(id, {
+        label,
+        x, y, vx: 0, vy: 0,
+        size: kind === "literal" ? 6 : 8,
+        color: kind === "literal" ? "#b8860b" : "#2b6cb0",
+      });
+    }
+
+    function addTriple({ subject, predicate, object }) {
+      ensureNode(subject, shortenIri(subject), "iri");
+
+      const objectId = object.type === "iri" ? object.value : literalNodeId(predicate, object.value);
+      const objectLabel = object.type === "iri" ? shortenIri(object.value) : truncate(object.value, 40);
+      ensureNode(objectId, objectLabel, object.type);
+
+      const edgeId = `${subject}|${predicate}|${objectId}`;
+      if (!graph.hasEdge(edgeId)) {
+        graph.addEdgeWithKey(edgeId, subject, objectId, { label: shortenIri(predicate) });
+      }
+
+      updateStats();
+    }
+
+    function updateStats() {
+      document.getElementById("stats").textContent =
+        `${graph.order} nodes, ${graph.size} edges`;
+    }
+
+    const container = document.getElementById("graph-container");
+    const renderer = new Sigma(graph, container, {
+      renderEdgeLabels: true,
+      labelColor: { color: "#3a2e1f" },
+      edgeLabelColor: { color: "#3a2e1f" },
+      // Sigma's default (6) hides labels for nodes below that rendered
+      // pixel size, which at this demo's node sizes hid every literal
+      // node's label — exactly the text this viewer exists to show.
+      // Lowered rather than removed entirely, so a much larger/denser
+      // graph than this demo still degrades to hiding labels instead of
+      // becoming unreadable clutter.
+      labelRenderedSizeThreshold: 2,
+    });
+
+    // No pre-built browser bundle exists for a force-directed layout
+    // library that fits this project's no-build-step, plain-<script>-tag
+    // approach (graphology-layout-forceatlas2 ships CommonJS/webworker
+    // builds only, no UMD/ESM browser dist) — and Sigma itself is a pure
+    // renderer with no layout of its own, so *some* layout is required
+    // regardless. A small hand-rolled force simulation (mutual repulsion +
+    // spring edges + light centering, classic Fruchterman-Reingold/
+    // spring-embedder shape) is well within what this demo needs: at most
+    // a few hundred nodes, run continuously so newly-added nodes always
+    // ease into place rather than needing a separate "re-layout" trigger.
+    const REPULSION = 400;
+    const SPRING_LENGTH = 50;
+    const SPRING_STRENGTH = 0.02;
+    const CENTER_STRENGTH = 0.003;
+    const DAMPING = 0.85;
+
+    function tickLayout() {
+      const nodes = graph.nodes();
+      const fx = new Map(nodes.map((n) => [n, 0]));
+      const fy = new Map(nodes.map((n) => [n, 0]));
+
+      for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        const pa = graph.getNodeAttributes(a);
+        for (let j = i + 1; j < nodes.length; j++) {
+          const b = nodes[j];
+          const pb = graph.getNodeAttributes(b);
+          const dx = pa.x - pb.x;
+          const dy = pa.y - pb.y;
+          const distSq = dx * dx + dy * dy || 0.01;
+          const force = REPULSION / distSq;
+          const dist = Math.sqrt(distSq);
+          const ux = dx / dist;
+          const uy = dy / dist;
+          fx.set(a, fx.get(a) + ux * force);
+          fy.set(a, fy.get(a) + uy * force);
+          fx.set(b, fx.get(b) - ux * force);
+          fy.set(b, fy.get(b) - uy * force);
+        }
+      }
+
+      graph.forEachEdge((_edge, _attrs, source, target) => {
+        const ps = graph.getNodeAttributes(source);
+        const pt = graph.getNodeAttributes(target);
+        const dx = pt.x - ps.x;
+        const dy = pt.y - ps.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+        const force = (dist - SPRING_LENGTH) * SPRING_STRENGTH;
+        const ux = dx / dist;
+        const uy = dy / dist;
+        fx.set(source, fx.get(source) + ux * force);
+        fy.set(source, fy.get(source) + uy * force);
+        fx.set(target, fx.get(target) - ux * force);
+        fy.set(target, fy.get(target) - uy * force);
+      });
+
+      nodes.forEach((node) => {
+        const p = graph.getNodeAttributes(node);
+        let vx = (p.vx + fx.get(node)) * DAMPING - p.x * CENTER_STRENGTH;
+        let vy = (p.vy + fy.get(node)) * DAMPING - p.y * CENTER_STRENGTH;
+        graph.mergeNodeAttributes(node, { x: p.x + vx, y: p.y + vy, vx, vy });
+      });
+    }
+
+    function animate() {
+      if (graph.order > 0) {
+        tickLayout();
+        renderer.refresh();
+      }
+      requestAnimationFrame(animate);
+    }
+    requestAnimationFrame(animate);
+
+    // Identical subscribe/reconnect shape to index.html's app — fetch()
+    // rather than EventSource so Last-Event-ID can be set on the very
+    // first connection (see index.html's own comment on this), reconnect
+    // loop on any transport error.
+    let lastSequence = 0;
+    const statusEl = document.getElementById("status");
+
+    function handleSseEvent(rawEvent) {
+      const dataLines = [];
+      for (const line of rawEvent.split("\n")) {
+        if (line.startsWith("id: ")) {
+          lastSequence = parseInt(line.slice(4), 10);
+        } else if (line.startsWith("data: ")) {
+          dataLines.push(line.slice(6));
+        }
+      }
+      if (dataLines.length === 0) return;
+
+      const turtle = dataLines.join("\n");
+      // Scoped to this demo's own usage: the-story only ever grows via
+      // :patch additions, never :delete/:replace or patch removals, so
+      // this viewer only ever adds triples — it doesn't attempt to remove
+      // nodes/edges for those other operations. A resource that actually
+      // mutates or shrinks would need that handled; out of scope here.
+      for (const triple of parseTurtleTriples(turtle)) {
+        addTriple(triple);
+      }
+    }
+
+    async function subscribeOnce() {
+      const response = await fetch(
+        `${BASE_URL}/streams/${encodeURIComponent(STREAM_ID)}/subscribe`,
+        { headers: { "Last-Event-ID": String(lastSequence) } }
+      );
+
+      if (response.status === 409) {
+        statusEl.textContent = "cursor fell out of retention window — resetting";
+        lastSequence = 0;
+        return;
+      }
+      if (!response.ok) {
+        throw new Error(`subscribe failed: ${response.status}`);
+      }
+
+      statusEl.textContent = `watching ${STREAM_ID}`;
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        let boundary;
+        while ((boundary = buffer.indexOf("\n\n")) !== -1) {
+          handleSseEvent(buffer.slice(0, boundary));
+          buffer = buffer.slice(boundary + 2);
+        }
+      }
+    }
+
+    async function subscribeForever() {
+      while (true) {
+        try {
+          await subscribeOnce();
+        } catch (err) {
+          statusEl.textContent = "connection lost, reconnecting in 1s…";
+          console.error("SSE connection lost, reconnecting in 1s", err);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    subscribeForever();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New example page, `examples/live-story/graph.html`, opened in its own tab alongside `index.html`: renders `the-story`'s actual RDF triples live as a WebGL node-link graph (Sigma.js + graphology) instead of prose.
- Generic, not hardcoded: `?tenant=`/`?resource=` query params (default to `story-demo`/`the-story`) point it at any resource, combined with the same `?base=` override `index.html` uses.
- Hand-rolled Turtle triple parser scoped to exactly what `Riptide.RDF.TurtleCodec` emits (no blank nodes/collections/nested structures) — consistent with this project's existing preference for small hand-rolled parsing over a full Turtle library dependency.
- Literal object nodes dedupe per `(predicate, value)` rather than per-triple (true RDF literal identity), so e.g. every line from the same guest author clusters onto one shared author node.
- Hand-rolled a small continuous force-directed layout: Sigma has no built-in layout, and graphology's own force-directed layout package ships no browser-usable bundle without a bundler.
- Loads Sigma/graphology via `esm.sh` rather than a raw jsdelivr dist file — confirmed live that graphology's ESM build imports Node's `events` module as a bare specifier, which a plain `<script type="module">` can't resolve; `esm.sh` rewrites that into a real fetchable polyfill URL.
- Scoped to what `the-story` actually does: additions-only, no `:delete`/`:replace`/removals handling (documented as out of scope in both code comments and the README).

## Test plan
- [x] `mix compile --force --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` all clean (no Elixir touched, confirming nothing else drifted)
- [x] Live-verified against a real Fly deployment with a real headless browser (Playwright): initial backlog renders correctly on load
- [x] Submitted a new line via PATCH mid-session and confirmed the graph picks it up live with exactly the right new node/edge counts (+3 nodes/+2 edges for a text+author-only addition)
- [x] Screenshot-verified: literal text labels are visible, and the shared `schema:CreativeWork` type node correctly clusters multiple lines' `rdf:type` edges into one hub
- [x] Zero browser console errors after switching from jsdelivr to esm.sh imports