### PR TITLE
Support dragging nodes in the live-story graph viewer

### DIFF
--- a/examples/live-story/README.md
+++ b/examples/live-story/README.md
@@ -49,6 +49,10 @@ every predicate becomes an edge, and new nodes ease into place via a small live 
 layout as lines get submitted. It talks to the exact same SSE stream `index.html` does, so nothing
 on the server needs to change to watch it.
 
+Click and drag any node to reposition it — it's pinned to the cursor while dragging (highlighted
+with a ring so it's clear which one you've grabbed) and rejoins the live layout normally the moment
+you release it, rather than staying stuck wherever you dropped it.
+
 Unlike `index.html` (hardcoded to `story-demo`/`the-story`), `graph.html` is a general RDF graph
 viewer — point it at any tenant/resource with `?tenant=` and `?resource=` query params (both
 default to `story-demo`/`the-story` so it shows this demo out of the box), combined with the same

--- a/examples/live-story/graph.html
+++ b/examples/live-story/graph.html
@@ -309,6 +309,11 @@
       labelRenderedSizeThreshold: 2,
     });
 
+    // Node currently being dragged, if any — tickLayout() below skips the
+    // physics simulation for this one node so a drag isn't fighting the
+    // force layout's own idea of where the node belongs every frame.
+    let draggedNode = null;
+
     // No pre-built browser bundle exists for a force-directed layout
     // library that fits this project's no-build-step, plain-<script>-tag
     // approach (graphology-layout-forceatlas2 ships CommonJS/webworker
@@ -366,6 +371,17 @@
       });
 
       nodes.forEach((node) => {
+        // A dragged node's position is owned by the mouse, not the
+        // simulation — otherwise the physics step below would immediately
+        // start pulling it back from wherever the user just placed it.
+        // Zeroing its velocity (rather than leaving stale vx/vy from
+        // before the drag started) means it doesn't go flying off once
+        // released, either.
+        if (node === draggedNode) {
+          graph.mergeNodeAttributes(node, { vx: 0, vy: 0 });
+          return;
+        }
+
         const p = graph.getNodeAttributes(node);
         let vx = (p.vx + fx.get(node)) * DAMPING - p.x * CENTER_STRENGTH;
         let vy = (p.vy + fy.get(node)) * DAMPING - p.y * CENTER_STRENGTH;
@@ -381,6 +397,42 @@
       requestAnimationFrame(animate);
     }
     requestAnimationFrame(animate);
+
+    // Drag-to-reposition: Sigma is a pure renderer with no node-dragging of
+    // its own, but exposes the raw mouse events needed to build it.
+    // "moveBody" fires for every mouse/touch move over the render area
+    // (not just moves over a node), which is what lets a drag continue
+    // smoothly even if the cursor slips off the node's small hit target
+    // mid-drag. Releasing over the mouse captor's own "mouseup" (not
+    // Sigma's "upNode") matters for the same reason: dragging the cursor
+    // off the node before releasing would never fire "upNode" at all,
+    // leaving the drag stuck.
+    renderer.on("downNode", ({ node }) => {
+      draggedNode = node;
+      graph.setNodeAttribute(node, "highlighted", true);
+      container.style.cursor = "grabbing";
+    });
+
+    renderer.on("moveBody", ({ event }) => {
+      if (!draggedNode) return;
+      const pos = renderer.viewportToGraph(event);
+      graph.setNodeAttribute(draggedNode, "x", pos.x);
+      graph.setNodeAttribute(draggedNode, "y", pos.y);
+      // Without this, Sigma's default mouse captor also interprets the
+      // same drag as a camera pan, so the whole graph would scroll
+      // underneath the node you're trying to move.
+      event.preventSigmaDefault();
+      event.original.preventDefault();
+      event.original.stopPropagation();
+    });
+
+    renderer.getMouseCaptor().on("mouseup", () => {
+      if (draggedNode) {
+        graph.removeNodeAttribute(draggedNode, "highlighted");
+      }
+      draggedNode = null;
+      container.style.cursor = "default";
+    });
 
     // Identical subscribe/reconnect shape to index.html's app — fetch()
     // rather than EventSource so Last-Event-ID can be set on the very


### PR DESCRIPTION
## Summary
- `examples/live-story/graph.html` now supports click-and-drag repositioning of any node.
- Verified Sigma v3's exact mouse event API (`downNode`/`moveBody`/`mouseup`, `viewportToGraph`, `preventSigmaDefault`) against its own shipped `.d.ts` files rather than assuming from memory — Sigma dropped its UMD browser bundle in v3, so community examples for older major versions were a real risk of being subtly wrong.
- The dragged node is excluded from the physics simulation each frame (position pinned to the cursor, velocity zeroed) so the live force layout isn't fighting the drag; it rejoins the simulation normally on release. A `highlighted` attribute (first-class Sigma node property) marks the currently-grabbed node with a ring.

## Test plan
- [x] `mix compile --force --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` all clean
- [x] Live-verified against a real Fly deployment with a real headless browser: simulated an actual mouse drag (down → multi-step move → up) and confirmed the node's graph-space position changes in the drag direction, `highlighted`/cursor state track the drag correctly, and both reset cleanly on release
- [x] Screenshot-verified: highlight ring renders on the dragged node, connected edges visibly follow it during the drag