### PR TITLE
docs: bring Sub-project 6 spec (derivation/execution layer) onto main, fourth revision

### DIFF
--- a/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
+++ b/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
@@ -1,12 +1,13 @@
 # Derivation and Execution Layer — Architecture Design
 
-**Status:** Draft, third revision — a currency pass against Riptide's actual
-current state and external facts this document depends on, not new design
-work. This is one architecture spec defining a single new top-level
-Riptide sub-project, **Sub-project 6**, decomposed into phases 6a–6i, the
-same way Riptide's own sub-projects 3, 4, and 5 are already decomposed.
-Each phase gets its own implementation plan (`writing-plans`) when work on
-it starts. See §11 for the itemized changelog across all three revisions.
+**Status:** Draft, fourth revision — resolving three of §10's open
+decisions (Tenant name, governance, deployability) and a dedicated
+research pass on formal versioning/supersedes theory (§8.7.1). This is
+one architecture spec defining a single new top-level Riptide sub-project,
+**Sub-project 6**, decomposed into phases 6a–6i, the same way Riptide's
+own sub-projects 3, 4, and 5 are already decomposed. Each phase gets its
+own implementation plan (`writing-plans`) when work on it starts. See §11
+for the itemized changelog across all four revisions.
 
 ## 1. Motivation and vision
 
@@ -36,10 +37,12 @@ the gap once, and the bridge gets built incrementally from real use — never
 front-loaded. Not three separate design choices; one discipline, applied
 consistently.
 
-**What's settled about deployment, and what isn't.** Settled: this layer
-shares Riptide's Fact store, Rule representation, and Signature/Dialect
-definitions as one substrate. Not settled: whether the engine runs in the
-same OS process as Riptide's existing LDP surface — genuinely open, §10.
+**Deployment — resolved this revision.** This layer shares Riptide's Fact
+store, Rule representation, and Signature/Dialect definitions as one
+substrate, **and runs in the same OS process as Riptide's existing LDP
+surface** — one deployable, not a companion service. No separate
+scheduling, no separate deploy pipeline, no second thing to keep
+available.
 
 ## 2. Scope
 
@@ -51,10 +54,13 @@ same OS process as Riptide's existing LDP surface — genuinely open, §10.
 this work, not something this spec reconciles with.
 
 **Explicitly still open** (§10 for the full list): concurrent-effectful-
-execution coordination; whether this engine is a separate deployable from
-Riptide's LDP surface; formal versioning/supersedes theory for rules;
-the final Tenant name; automated detection of ontology overlap (out of
-scope *by design*, §6.5).
+execution coordination (confirmed this revision as real design work owed
+here, not a literature gap to close by more research); the bisimilar-
+term-graph constraint question; formal versioning/supersedes theory for
+rules; large object (blob) storage (§3.3, new this revision); whether
+long-running/daemon-shaped Capabilities need a second dimension beyond
+StabilityClass (§4, new this revision); automated detection of ontology
+overlap (out of scope *by design*, §6.5).
 
 ## 3. Core concepts — facts and rules
 
@@ -63,18 +69,21 @@ scope *by design*, §6.5).
 - **Fact** — an atomic RDF(-star) assertion in the EDB. Carries
   *TransactionTime* (from Riptide's sequence number) and optionally a
   *ValidTime* interval (RDF-star-annotated, §8.4). Produced by one **Event**.
-- **Tenant** *(name TBD — shortlist: Polity, Enclave, Civitas, Demesne)* —
+- **Tenant** *(name settled this revision — "Tenant" itself, no rename)* —
   an isolated administrative/institutional space. Facts, Rules,
   CatalogEntries, and Capabilities are all tenant-partitioned. A Capability
   grant in one Tenant is never exercisable by a Rule in another; this
   composes with Riptide's shipped Phase 4c ACP authorization (default-deny,
   container-level inheritance, deny-overrides-allow, tenant-root bootstrap
   claim — confirmed accurate against the shipped design, `PROGRESS.md`
-  §4), not a parallel system. **Current note**: this ACP/auth surface is
-  under active security-audit remediation in a sibling branch as of this
-  writing (observed directly, not yet its own committed spec) — Sub-project
-  6b's integration point should target whatever that lands as, not a frozen
-  snapshot of the original Phase 4a–4d design.
+  §4), not a parallel system. **Current note, updated this revision**: the
+  security-audit remediation flagged as in-progress on a sibling branch in
+  the prior revision has since landed on `main` (three parts: auth/authz,
+  Ra error handling, resource limits, and observability; dual-leader
+  repair fencing; closing the SSE/WS `Authz.evaluate` placement-down gap —
+  merged via PR #32) — as regular commits, not its own committed design
+  spec. Sub-project 6b's integration point should target this now-current
+  ACP surface directly.
 - **A Tenant's vocabulary is observed, not declared.** No separate
   "ontology preference" object. Whichever Signature a Tenant's own Facts
   happen to already use *is* their working vocabulary for that area. A
@@ -112,6 +121,47 @@ scope *by design*, §6.5).
     Templates) is inexpressible — caught by tracing a real scenario (§9)
     through the model, not by re-reading the document.
 
+### 3.3 Large objects (blobs) — new this revision, not yet researched
+
+**The problem, stated plainly.** Every Fact today is a small RDF triple,
+replicated through a per-stream Ra (Raft) cluster's consensus log. A
+multi-MB/GB blob (a PDF a Capability extracted a page from, a submitted
+tax form, an uploaded file) does not belong directly in that log — every
+replica would need to push the full blob through consensus on every
+write, and Ra's own snapshots would grow with it. This needs solving
+without introducing an external blob-storage service (S3-shaped or
+otherwise) as a second system operators must run and keep available
+alongside Riptide, and without blobs feeling bolted-on rather than a
+first-class Riptide concept.
+
+**A candidate direction (my own synthesis this revision — not yet
+independently verified the way the rest of this document's claims are,
+flagged honestly as such):** split identity from bytes, the same way this
+whole document already treats every other layer (§1's organizing idea).
+A blob is content-addressed (hashed) and immutable once written; a Fact
+references it by hash (e.g. as an IRI like `<urn:riptide-blob:sha256:...>`),
+making a blob just another kind of Term any Rule or Fact can point at —
+this is what "feels native" rather than bolted-on. Because the *bytes*
+are immutable, replicating them doesn't need consensus at all (unlike a
+Fact, which needs strict ordering) — only a small piece of metadata does
+("which nodes currently hold chunk `sha256:...`"), which is exactly the
+shape of thing Riptide's existing Fact/Ra machinery already handles well.
+Actual bytes could then transfer directly between Riptide nodes
+(peer-to-peer, outside consensus) rather than through any per-write
+replication path. This is structurally the same split Git itself makes —
+content-addressed, immutable object store versus a small, consistency-
+needing ref/commit layer — and this document already leans on git
+precedent elsewhere (§6's DedupGate `Merge`, §8.7's TerminusDB/Fluree
+grounding), so reusing it here would be consistent, not a new borrowed
+idea.
+
+**Explicitly not resolved by the above:** chunking scheme, garbage
+collection of unreferenced blobs, how many replicas a blob needs versus
+a Fact's own replica count, and — unverified — whether this candidate
+direction survives contact with real research the way every other claim
+in this document has. Added to §10 as an open question rather than locked
+in.
+
 ## 4. Capability, NativeTemplate, Template
 
 - **Capability** — an explicit, tenant-scoped, grantable permission. Two
@@ -130,6 +180,20 @@ scope *by design*, §6.5).
   - Backed by WASI Preview 2 (no ambient authority, no subprocess spawning
     by design) plus WASIX where subprocess spawning is specifically
     granted (§8.3).
+  - **A real gap, not yet designed, surfaced this revision by a universality
+    check.** "File a tax return," "extract page 2 of a PDF," and "serve
+    this web page over HTTP" should all be expressible as Capabilities —
+    that's the whole point of the model's generality, not a feature to add
+    later. The first two are one-shot: invoke, get a discrete Outcome,
+    done — exactly what `(Rule, Bindings, EDB-state) → Outcome` (§5)
+    already models. "Serve this page" is not: it's a long-running,
+    continuously-listening process serving arbitrarily many requests over
+    its lifetime, closer in shape to something Riptide already knows how
+    to run and supervise (`Riptide.Stream.StreamServer` and friends) than
+    to a discrete Interpretation. Whether this becomes a second
+    Capability dimension (e.g. `Ephemeral` vs `Persistent`, alongside
+    StabilityClass) or something else entirely is genuinely open — noted
+    in §10, not designed here.
 - **NativeTemplate** — a Rule whose Body is exactly one capability-reference
   literal. The base case, backed by a real, capability-scoped WASI
   component. Sequencing note: Sub-project 6b (§7) builds the WASI execution
@@ -323,6 +387,65 @@ before 6c actually depends on it rather than assuming continued dormancy.
 check; graph three-way merge is still weaker than git's (§6's DedupGate
 `Merge` rule) regardless of either project's activity level.
 
+**8.7.1 Formal supersedes theory — real anchors found this revision, no
+exact fit.** A dedicated research pass (four angles, 20 primary sources,
+25 claims adversarially verified) found two genuine formal theories in
+this space, and closed off one dead end:
+
+- **AGM/Katsuno-Mendelzon logic-program-update theory is real, peer-reviewed,
+  and still actively cited (2007–2023)** — Delgrande/Peppas/Woltran (LPNMR
+  2013) rephrase the AGM postulates for logic programs with SE-model-based
+  semantic revision operators and representation theorems by program class;
+  Slota & Leite (TPLP 2014) adapt Katsuno-Mendelzon's postulates to
+  answer-set-program *update* specifically, with a constructive
+  representation theorem. This is the closest existing formalism to "what
+  does it mean to update a rule set given a new rule" found anywhere in
+  this research. **But it comes with a proven limitation, not just a
+  caveat**: Slota & Leite's Theorem 31 proves any SE-model/KM-based ASP
+  update operator satisfying syntax-independence cannot simultaneously
+  satisfy both the *support* and *fact update* properties — a real
+  adequacy ceiling on this branch of theory, to design around rather than
+  discover the hard way.
+- **Description-logic conservative-extension/inseparability theory was
+  directly extended in 2022 to existential rules (TGDs)** — Jung, Lutz &
+  Marcinkowski (KR 2022) give two independent formal criteria (conjunctive-
+  query-answer preservation; chase-homomorphism preservation) for whether
+  one TGD set safely extends another, the closest syntactic match to
+  Datalog-style rules found. Decidable only for restricted fragments
+  (e.g. frontier-one TGDs) — undecidable in general (linear/guarded TGDs).
+  This formalizes *safe extension without changing prior entailments*, not
+  a directional generalize/refine "supersedes" relation — a real, useful,
+  but different question than the one this spec actually has.
+- **Patch theory (categorical and homotopical/HoTT formalizations of
+  Darcs) is a confirmed non-fit, not an unexplored option.** Every formal
+  object and worked example across four primary sources is generic
+  text/structured data (lines, integers, boolean lists) — zero mentions of
+  rules, logic programs, ontologies, or knowledge bases anywhere in the
+  primary literature. Its only notion of combining changes (merge as
+  categorical pushout) is symmetric, not the directional relation needed
+  here. Should not be revisited as a lead without new information.
+- **No rigorous, non-conventional theory of breaking-vs-compatible
+  schema/rule change was found** — a genuine gap in what this pass
+  surfaced, not proof none exists; it may hide under different
+  terminology (view update problem, schema mapping evolution, Horn/rule
+  theory revision) a future pass should search directly.
+- **The most promising unexplored angle, surfaced by this research but not
+  itself researched yet:** anti-unification's own literature (Plotkin's
+  least-general-generalization, Inductive Logic Programming's
+  generalization/specialization lattices under θ-subsumption) may connect
+  *directly* to a formal subsumption ordering between rules — closer to
+  this spec's actual mechanism (§5's Generalization) than either DL/TGD or
+  AGM/KM, and not covered by any of the four angles this pass researched.
+  Worth its own dedicated pass before concluding no exact fit exists
+  anywhere.
+
+Net: no single existing formalism directly answers "rule B (refined)
+supersedes rule A (generalized)" — the pragmatic git/TerminusDB-style
+model stays the adopted approach, but AGM/KM update theory and TGD
+conservative-extension are now real candidate anchors to build a more
+rigorous foundation on later, and ILP's own generalization-lattice
+literature is the most promising unexplored lead.
+
 **8.8 Parallelism.** Soufflé compiles `par...endpar` to OpenMP-annotated
 C++ implementing semi-naive evaluation, backed by a concurrent B-tree and
 Brie (a concurrent trie). Adoptable for QueryInterpretation.
@@ -374,23 +497,71 @@ example caught.
 
 ## 10. Open questions
 
-- OpenFASTER-Standard public governance status for this work.
-- Whether this engine is operationally a separate deployable from
-  Riptide's LDP surface.
+**Resolved this revision** (kept here, struck through, rather than
+deleted silently — see §11's changelog for the full reasoning):
+- ~~Final Tenant name~~ — resolved: **"Tenant"**, no rename.
+- ~~OpenFASTER-Standard public governance status~~ — resolved:
+  **Riptide-internal for now**, not public/OpenFASTER-Standard governance.
+- ~~Whether this engine is a separate deployable from Riptide's LDP
+  surface~~ — resolved: **same OS process**, one deployable (§1).
+
+**Still open:**
 - Concurrent-effectful-execution coordination (6d-ii's actual subject
-  matter).
+  matter) — confirmed this revision as real design work owed directly by
+  this project, not a literature gap a further research pass would close.
 - Whether the Rule/workflow-graph representation can be constrained to the
   bisimilar-term-graph fragment, or whether DedupGate must arbitrate a
   finite set of incomparable generalizations (§8.2).
-- Formal versioning/supersedes theory for declarative rules — none found;
-  pragmatic git/TerminusDB model adopted instead.
-- Final Tenant name.
+- Formal versioning/supersedes theory for declarative rules — real
+  candidate anchors found this revision (AGM/KM logic-program update, TGD
+  conservative-extension), neither an exact fit; ILP's generalization-
+  lattice literature is the most promising unresearched lead (§8.7.1).
 - `linkml-datalog`'s dormancy — re-check again immediately before 6c
   depends on it, not just at spec-writing time (§8.6).
+- **New this revision:** large object (blob) storage — a candidate
+  content-addressed direction sketched but not researched (§3.3).
+- **New this revision:** whether long-running/daemon-shaped Capabilities
+  (e.g. "serve this over HTTP") need a second Capability dimension beyond
+  StabilityClass, surfaced by a universality check but not designed (§4).
 
 ## 11. Changelog
 
-**This revision (third) — a currency pass, not new design work:**
+**This revision (fourth) — resolving open decisions plus new research:**
+- Resolved three of §10's open decisions: Tenant name (**"Tenant"**, no
+  rename — Polity/Civitas/Demesne shortlist dropped), governance
+  (**Riptide-internal for now**, not OpenFASTER-Standard public
+  governance), and deployability (**same OS process** as Riptide's
+  existing LDP surface, confirmed as one deployable, §1).
+- Confirmed concurrent-effectful-execution coordination (6d-ii) as real
+  design work this project owes directly, not a literature gap — no
+  change to its treatment as an open question, but the framing is now
+  explicit rather than ambiguous between "unresearched" and "unresolvable
+  by research."
+- Added §8.7.1: a dedicated four-angle research pass on formal
+  versioning/supersedes theory for declarative rules. Found two genuine
+  candidate anchors (AGM/Katsuno-Mendelzon logic-program-update theory;
+  description-logic conservative-extension theory extended to existential
+  rules/TGDs in 2022) — neither an exact fit for this spec's directional
+  "rule B supersedes rule A" need. Confirmed patch theory (Darcs,
+  categorical and homotopical) as a closed non-fit, not an unexplored
+  option. Surfaced ILP's own generalization-lattice literature
+  (anti-unification's own home field) as the most promising unresearched
+  lead — closer to this spec's actual mechanism than either anchor found.
+- Added §3.3: large object (blob) storage as a new open concern, with a
+  candidate content-addressed direction sketched (git's own object-store/
+  ref-layer split, reused rather than invented) — explicitly not yet
+  researched the way the rest of this document's claims are.
+- Added to §4: a universality check (does "serve this web page," not just
+  "file a tax return," fit the Capability model?) surfaced a real gap —
+  the current model implicitly assumes one-shot Interpretations, and a
+  long-running/daemon-shaped Capability doesn't fit that shape. Noted as
+  open, not designed.
+- Updated §3.1's currency note: the security-audit remediation flagged as
+  in-progress in the prior revision has since landed on `main` (PR #32) —
+  Sub-project 6b's integration point is no longer targeting a moving
+  target.
+
+**Third revision — a currency pass, not new design work:**
 - Restructured all phase numbering from independent "Sub-project 1–9" into
   a single **Sub-project 6** with phases 6a–6i, avoiding a real collision
   with Riptide's own `PROGRESS.md` table (its sub-projects 1–5, confirmed

--- a/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
+++ b/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
@@ -1,498 +1,529 @@
 # Derivation and Execution Layer — Architecture Design
 
-**Status:** Draft, revised after an independent cold review and a targeted
-re-verification pass against primary sources. This is an architecture spec
-covering the full vision and a phased roadmap — not a single implementation
-plan. Each phase gets its own implementation plan (`writing-plans`) when work
-on it starts.
-
-**Revision note:** this replaces an earlier draft of the same spec. The
-revision fixed two factual errors (§4.1, §4.2), one internally contradictory
-concept (§3.4's Generalization), one concept whose stated definition didn't
-actually support its own use (§3.2/§3.3), an overclaimed invariant (§3.5's
-Generalization Fidelity law), a real security gap (Capability was never
-tenant-scoped), and a roadmap that hid its riskiest problem inside a step
-labeled "pure wiring." All of this came from treating the first draft as
-something to stress-test, not something to defend — see §9 for the itemized
-before/after.
+**Status:** Draft, second substantive revision. This is one architecture spec
+defining several sub-projects (§7) — each gets its own implementation plan
+(`writing-plans`) when work on it starts. This revision adds the public
+Pattern Hub and ontology Crosswalk mechanism, corrects a mis-scoped
+institution-theoretic claim caught by dedicated verification, closes a real
+consistency gap between observing external state and the fidelity
+requirement, and folds `administration-commons` in as superseded rather than
+something to reconcile with — see §10 for the itemized changelog.
 
 ## 1. Motivation and vision
 
-Riptide today is an event-sourced fact store (StreamLD's reference
-implementation): an append-only, per-resource log of RDF facts, with one
-hardcoded derivation (replay a stream's events in order to compute current
-state). This spec adds the layer that's structurally missing: a general
-**derivation and execution engine**, so that "answer a question about the
-facts" and "cause an effect in the world" become two interpretations of the
-same declarative object, evaluated by one engine, instead of bespoke
-application code per feature.
+Riptide today is an event-sourced fact store: an append-only, per-resource
+log of RDF facts, with one hardcoded derivation. This spec adds the layer
+that's structurally missing: a general **derivation and execution engine**,
+so that "answer a question about the facts" and "cause an effect in the
+world" become two interpretations of the same declarative object, evaluated
+by one engine.
 
 The organizing idea: **the atomic unit should have a stable identity, and
-everything else — labels, presentations, procedures — should be a *view*
-derived from that identity, never the identity itself.** Riptide's event log
-already does this for facts. This spec extends the same discipline to
-*rules*.
+everything else should be a *view* derived from that identity, never the
+identity itself.** This spec extends that discipline from facts to rules,
+and — new in this revision — to the *vocabularies rules are expressed in*,
+which is what §6 (Pattern Hub) and §6.5 (Crosswalks) are for. The same
+underlying instinct shows up a third time there: when no existing bridge
+covers something (no matching prior Trace, no matching CatalogEntry, no
+matching Crosswalk), a human/direct-origination step fills the gap once, and
+the bridge gets built incrementally from real use — never front-loaded.
+That's not three separate design choices; it's one discipline, applied
+consistently, which is itself evidence the design is coherent rather than a
+pile of individually-plausible ideas.
 
-**What that does and doesn't settle about deployment.** It settles that this
-layer shares Riptide's Fact store, Rule representation, and Signature/Dialect
-definitions as one substrate — no second store, no parallel schema, nothing
-that needs reconciling with Riptide's own facts. It does **not**, by itself,
-settle whether the derivation/execution engine must run in the same OS
-process or release as Riptide's existing LDP surface. That's a real,
-separate engineering question — particularly once §3.3's Capability grants
-are in the picture, which expand the trusted computing base from "evaluates
-RDF queries" to "executes arbitrary sandboxed code." Kept open in §8, not
-asserted here.
+**What's settled about deployment, and what isn't.** Settled: this layer
+shares Riptide's Fact store, Rule representation, and Signature/Dialect
+definitions as one substrate. Not settled, and not asserted here: whether
+the engine runs in the same OS process as Riptide's existing LDP surface —
+genuinely open, see §9.
 
-## 2. Scope and explicit non-goals
+## 2. Scope
 
-**In scope:** the conceptual object model (§3), the grounding for each design
-decision (§4), a worked example (§5), and the phased build order (§7),
-including the concrete, ready-to-plan scope of Phase 1 (§7.1).
+**In scope:** the object model (§3–6), the grounding for each decision (§8),
+two worked examples (§9), and the sub-project breakdown (§7).
 
-**Explicitly out of scope** — flagged as open, not silently assumed:
-- Whether this layer becomes a public `OpenFASTER-Standard` module or stays
-  Riptide-internal.
-- Formal theory for coordinating **concurrent effectful** rule executions
-  (two templates racing on the same Kubernetes namespace). Neither the saga
-  pattern nor CRDTs were found to establish this — CRDT convergence is about
-  merging *data*, not arbitrating *irreversible effects*. This is real,
-  currently-unsolved design surface, not deferred paperwork (see §7, Phase
-  4b).
-- Whether the engine is a separate deployable from Riptide's LDP surface
-  (§1).
-- Detailed UI design — reuse `graphsheet`'s SHACL-driven pattern for the
-  review/discovery/monitoring surfaces this layer needs; screens aren't
-  designed here.
-- The final human-facing name for a Riptide tenant. Shortlist: **Polity**,
-  Enclave, Civitas, Demesne. This document uses **Tenant** as a placeholder.
-- Observability and testing strategy for the engine itself, beyond what
-  §4.9 requires as a precondition for later phases — Riptide's own
-  PROGRESS.md already treats observability (sub-project 5) and
-  schema-versioning risk as first-class, ongoing concerns; this layer
-  should be planned against that existing discipline when Phase 2 starts,
-  not invent a separate one here.
+**`administration-commons` note.** An earlier local project used the term
+"pattern" for a similar idea and sketched its own kernel (content-addressed
+store, Merkle log, WASI executor). It's superseded by this work, not
+something this spec reconciles with — noted here once so a future reader
+finding that repo isn't confused about which is current.
 
-## 3. Core concepts (the T-box)
+**Explicitly still open** (§9 for the full list): concurrent-effectful-
+execution coordination; whether this engine is a separate deployable from
+Riptide's LDP surface; formal versioning/supersedes theory for rules (a
+pragmatic git-like model is adopted instead); the final Tenant name; and,
+new in this revision, automated detection of ontology overlap (deliberately
+out of scope *by design*, not by gap — see §6.5).
+
+## 3. Core concepts — facts and rules
 
 ### 3.1 Fact, Event, Tenant
 
-- **Fact** — an atomic RDF(-star) assertion in the EDB. Carries a
-  *TransactionTime* (free, from Riptide's sequence number) and optionally a
-  *ValidTime* interval, RDF-star-annotated (§4.4). Produced by one **Event**.
-- **Tenant** *(name TBD, §2)* — an isolated administrative/institutional
-  space. **Facts, Rules, CatalogEntries, and Capabilities are all
-  tenant-partitioned** — Capability is added to this list in this revision;
-  its absence in the first draft was a real gap (§9, item 6). A Capability
-  grant issued inside one Tenant must never be exercisable by a Rule running
-  in another. This has to compose with Riptide's already-shipped Phase 4c
-  ACP-based authorization, not duplicate it — Capability is *scoped by* the
-  existing tenant/grant model, not a second, parallel permission system.
+- **Fact** — an atomic RDF(-star) assertion in the EDB. Carries
+  *TransactionTime* (from Riptide's sequence number) and optionally a
+  *ValidTime* interval (RDF-star-annotated, §8.4). Produced by one **Event**.
+- **Tenant** *(name TBD — shortlist: Polity, Enclave, Civitas, Demesne)* —
+  an isolated administrative/institutional space. Facts, Rules,
+  CatalogEntries, and Capabilities are all tenant-partitioned. A Capability
+  grant in one Tenant is never exercisable by a Rule in another; this
+  composes with Riptide's existing Phase 4c ACP authorization, not a
+  parallel system.
+- **A Tenant's vocabulary is observed, not declared.** No separate
+  "ontology preference" object. Whichever Signature a Tenant's own Facts
+  happen to already use *is* their working vocabulary for that area — it
+  falls out of usage. A brand-new Tenant installing its first Pattern simply
+  adopts that Pattern's native Signature; there's nothing to translate yet.
+  This removes a concept ("domain area," "ontology preference") that isn't
+  actually needed once Crosswalk resolution (§6.5) is field-level, not
+  whole-ontology: two Signatures with zero overlapping predicates simply
+  coexist, and Crosswalk resolution only engages where fields genuinely
+  overlap.
 
 ### 3.2 Signature, Dialect, Rule
 
-- **Signature** — the typed interface of a Rule: its parameters, and which
-  predicates it reads/produces. Reuses DOL's `Sign` precisely.
+- **Signature** — a Rule's typed interface: its parameters and which
+  predicates it reads/produces. Institution-theoretically, this is DOL's
+  `Sign`, reused precisely — an arrow in one institution's `Sign` category
+  (confirmed against Goguen & Burstall's own definition; see §8.1).
 - **Dialect** — which concrete rule language a Rule is expressed in. Two
-  candidate targets are being tracked, not one: **SPARQL-RL** and **SHACL
-  1.2 Rules** are both live W3C Working Drafts on the Recommendation track
-  as of this writing, developed in parallel by the Data Shapes Working
-  Group — the first draft of this spec incorrectly described SPARQL-RL as
-  SHACL 1.2 Rules' successor; that relationship isn't documented anywhere
-  and both documents are actively progressing. Track both; adopt whichever
-  reaches sufficient maturity/tooling support first, or both if they serve
-  different needs. Reference engine for actual evaluation: Soufflé's
-  extended Datalog.
+  candidates tracked in parallel, not one succeeding the other: **SPARQL-RL**
+  and **SHACL 1.2 Rules**, both live W3C Working Drafts on the
+  Recommendation track, developed in parallel by the Data Shapes Working
+  Group. Reference evaluation engine: Soufflé's extended Datalog.
 - **Rule** — a declarative IDB definition over a Signature: given a Body,
-  conclude a Head. A Body is a conjunction of literals over two kinds:
-  ordinary **Fact-pattern literals** (matched against the EDB, as in
-  classical Datalog) and, where applicable, a distinguished
-  **capability-reference literal** — a reference to a Capability that
-  ExecuteInterpretation may invoke. This second literal kind is what closes
-  the gap the first draft left open: NativeTemplate's capability-invoking
-  behavior is now part of Rule's own definition, not asserted about Rule
-  from the outside. QueryInterpretation treats a capability-reference
-  literal as inert (unevaluable, contributing nothing to derived facts);
-  ExecuteInterpretation is what actually invokes it.
+  conclude a Head. A Body is a conjunction of three literal kinds:
+  - **Fact-pattern literals** — matched against the EDB, classical Datalog.
+  - **Capability-reference literals** — a reference to a Capability (§4)
+    that ExecuteInterpretation may invoke.
+  - **Rule-reference literals** — a call to another Rule, with argument
+    bindings. **Added in this revision, closing a real bug**: the previous
+    version of this document restricted Body to the first two kinds, which
+    made Rule composability — a Template calling other Templates, the whole
+    point of the design — inexpressible. Caught by tracing a real scenario
+    through the model (§9), not by re-reading the document.
 
-### 3.3 Capability, NativeTemplate, Template
+## 4. Capability, NativeTemplate, Template
 
-- **Capability** — an explicit, tenant-scoped, grantable permission (spawn a
-  process, read a path, reach a host). Backed by WASI Preview 2 (no ambient
-  authority, no subprocess spawning by design) plus WASIX where subprocess
-  spawning is specifically granted (§4.3). Composes with Riptide's Phase 4c
-  ACP model per §3.1 — not a parallel system.
+- **Capability** — an explicit, tenant-scoped, grantable permission. Split
+  into two kinds, **new in this revision**, because collapsing them created
+  a real inconsistency (§8.5, §9):
+  - **EffectCapability** — changes something in the world (deploy a
+    service). Fidelity replay-testing (§5) actually re-invokes it,
+    sandboxed, and compares against the recorded Trace.
+  - **ObserveCapability** — reads external state and asserts the result as
+    new Facts, changing nothing external (check whether a filing already
+    exists). Fidelity replay-testing does *not* re-invoke the real external
+    system — the world isn't expected to be frozen between runs. It replays
+    the response recorded in Provenance instead, and checks that downstream
+    Rule logic behaves consistently given that recorded response. This
+    means an ObserveCapability's Provenance must record the actual observed
+    data, not just which capability was called with which parameters.
+  - Both kinds carry a **StabilityClass** — `documented` (a stable, versioned
+    public interface) or `undocumented` (a reverse-engineered or otherwise
+    unversioned interface, liable to silent breakage). This doesn't solve
+    fragility; it makes it visible and queryable. Discovery (§6) uses it as
+    a ranking input alongside recency/specificity when multiple
+    CatalogEntries could satisfy the same Task — this is not a new
+    selection mechanism, it's one more input to the mechanism §6 already
+    has.
+  - Backed by WASI Preview 2 (no ambient authority, no subprocess spawning
+    by design) plus WASIX where subprocess spawning is specifically
+    granted (§8.3).
 - **NativeTemplate** — a Rule whose Body is exactly one capability-reference
-  literal and nothing else: the base case, backed by a real,
-  capability-scoped WASI component. **Sequencing note, fixing a real
-  ordering ambiguity in the first draft:** Phase 2 (§7) builds the
-  capability-scoped WASI *execution substrate* standalone, with no Rule
-  representation involved at all — it does not yet produce NativeTemplate
-  instances, because NativeTemplate is a Rule, and Rule's own representation
-  isn't built until Phase 3. Phase 4 is what wraps the Phase 2 substrate as
-  actual NativeTemplate Rule instances. "NativeTemplate is the base case of
-  Rule" describes the finished system, not the build order.
+  literal. The base case, backed by a real, capability-scoped WASI
+  component. Sequencing note: Sub-project 2 (§7) builds the WASI execution
+  substrate standalone, with no Rule representation involved — it doesn't
+  produce NativeTemplate instances yet, since NativeTemplate is a Rule and
+  Rule's representation isn't built until Sub-project 3. Sub-project 4 is
+  what wraps Sub-project 2's substrate as actual NativeTemplate instances.
 - **Template** — `Template ⊑ Rule ⊓ (∃ a reachable step whose
-  ExecuteInterpretation invokes a Capability)`. This *is* a structural
-  predicate (graph reachability over the Rule's own Body/composition
-  structure) — the first draft's claim that Template membership involves
-  "no structural difference" from Rule was imprecise and is dropped here.
-  The real point, stated correctly: Template is not a *separate primitive*
-  requiring its own representation — it's a checkable property of the one
-  Rule representation everything already shares.
+  ExecuteInterpretation invokes a Capability)`. A structural (graph-
+  reachability) predicate over the one Rule representation everything
+  shares — not a separate primitive.
 
-### 3.4 Trace, Generalization, Provenance
+## 5. Trace, Generalization, Interpretation, Provenance
 
-- **Trace ⊑ Rule.** Revised from the first draft, which typed Trace as an
-  unrelated primitive and then couldn't consistently type Generalization
-  around it (§9, item 2). A Trace is simply a Rule whose Signature has no
-  free parameters — every value is already ground, from one concrete run
-  (a Rule's ExecuteInterpretation with specific bindings, or an ad hoc
-  LLMFallback episode). This makes Trace a degenerate case of Rule, not a
-  different kind of thing.
+- **Trace ⊑ Rule** — a Rule whose Signature has no free parameters; every
+  value already ground, from one concrete run.
 - **Generalization — uniformly `Rule × Rule → Rule`.** Anti-unification
-  (Plotkin 1970) computes the least-general-generalization of any two Rules
-  — whether both are ground (two Traces), one is ground and one already has
-  free parameters (a new Trace against an existing candidate), or neither is
-  ground (DedupGate anti-unifying a candidate against a CatalogEntry). One
-  operation, one type signature, used identically everywhere it appears in
-  §3.6's pipeline. Always accompanied by the substitutions recovering each
-  input and by mandatory **Provenance** — the dependency edge back to what
-  was generalized, which is what keeps a generalized Rule from becoming an
+  (Plotkin 1970) computes the least-general-generalization of any two
+  Rules, whether both ground, one ground and one not, or neither. One
+  operation, one type signature, used identically wherever it appears in
+  §6's pipeline. Always accompanied by the recovering substitutions and by
+  mandatory **Provenance**.
+- **Admission consequence**: a Rule generalized from only one Trace (still
+  ground, zero free parameters) is not admissible anywhere — a
+  zero-parameter "template" isn't reusable. Admission (§6) requires at
+  least one real Generalization step.
+- **Interpretation** — `(Rule, Bindings, EDB-state) → Outcome`. At least
+  **QueryInterpretation** (pure, Outcome ⊑ new Facts, capability-reference
+  literals inert) and **ExecuteInterpretation** (capability-reference
+  literals actually invoked; Outcome may include both effects and, for
+  ObserveCapability steps, newly-observed Facts — the same shape
+  QueryInterpretation produces, just externally sourced). More modes
+  expected later (dry-run, cost-estimate, explain/audit). Algebraic
+  effects/handler theory is the closest established formalism for this
+  shape; neither it nor tagless-final is a proof this specific design is
+  correct — real inspiration, not borrowed authority (re-verified in an
+  earlier pass of this process, not this revision's final one).
+- **Generalization Fidelity — an engineering requirement, not an inherited
+  proof.** Anti-unification proves syntactic recoverability of term
+  structure, not semantic reproduction of real-world effects. The actual
+  requirement: for a Generalization `g` from Traces `t₁, t₂` with
+  substitutions `σ₁, σ₂`, `ExecuteInterpretation(g, σᵢ)` should reproduce
+  `tᵢ`'s effects, verified by sandboxed replay-testing — with the kind-
+  specific replay semantics from §4 (EffectCapability re-invoked and
+  compared; ObserveCapability replayed from its recorded response, never
+  re-queried live). Capabilities that can't be safely replay-tested at all
+  (destructive, non-idempotent) may need to stay ungeneralized, or require
+  the human reviewer (§6) to certify fidelity manually. Real engineering,
+  scoped to Sub-project 5, not resolved here.
+- **Provenance** — the dependency edge back to what a Rule was generalized
+  or installed from (§6.5). What keeps a derived Rule from becoming an
   ungoverned second source of truth.
-- **Consequence for admission, stated explicitly because the first draft
-  left it implicit and inconsistent:** a Rule generalized from only one
-  Trace (i.e., still ground, zero free parameters) is not admissible as a
-  CatalogEntry — a zero-parameter "template" isn't reusable by definition.
-  DedupGate's `Admit` path requires at least one real Generalization step
-  (at least two distinct Traces or an existing Rule contributing to it).
-  Single, unrepeated Traces stay Traces; they don't get promoted to the
-  catalog on their own.
 
-### 3.5 Interpretation
+## 6. Catalog, DedupGate, Discovery, Task, LLMFallback, Pattern
 
-A function `(Rule, Bindings, EDB-state) → Outcome`. At least two disjoint
-kinds — **QueryInterpretation** (pure, Outcome ⊑ new Facts, treats
-capability-reference literals as inert) and **ExecuteInterpretation** (the
-same Rule, but capability-reference literals are actually invoked) — with
-more expected later (dry-run, cost-estimate, explain/audit). Algebraic
-effects/handler theory (Plotkin & Power; Plotkin & Pretnar) is the closest
-established formalism for this shape, and tagless-final the closest
-established technique for adding interpreters without touching existing code
-— both real, well-grounded inspiration, neither a proof this specific design
-is correct. (These two citations were re-verified in an earlier pass of this
-design process, not in the final re-verification pass behind this revision —
-carried forward, not re-checked here.)
+**Catalog is parameterized by scope: `Tenant` or `Hub`.** This is new in
+this revision and replaces an earlier, unresolved question about whether
+the public hub needed its own separate curation mechanism — it doesn't. One
+mechanism, two scopes:
 
-**On the Generalization Fidelity requirement — reframed, not just renamed,
-from the first draft's "law."** The first draft asserted, as if it followed
-from anti-unification's proven properties, that
-`ExecuteInterpretation(g, σ₁)` must reproduce a source Trace's effects
-exactly. That doesn't follow from anything cited: Plotkin's proof is about
-syntactic recoverability of term structure via substitution, not about
-semantic reproduction of real-world, potentially non-idempotent effects.
-Asserting it as inherited rigor was the exact overclaiming failure mode this
-document is otherwise careful to avoid, applied to itself.
-
-The honest version: **fidelity is a requirement this system has to be
-engineered to satisfy, not a property that falls out of the math for free.**
-Concretely, it needs:
-- A defined notion of what "reproduce effects" means per Capability — some
-  effects are naturally idempotent (a `kubectl apply` of the same manifest),
-  many are not (anything that appends, increments, or has external
-  side-state).
-- A replay-testing mechanism — running `ExecuteInterpretation(g, σᵢ)` in a
-  sandboxed/simulated mode and comparing against the recorded Trace it was
-  generalized from — as an actual test oracle for DedupGate's `Merge`
-  decisions, not an assumption they satisfy automatically.
-- Explicit handling for Capabilities that can't be safely replay-tested at
-  all (destructive, non-idempotent operations) — these may need to stay
-  ungeneralized, or require the human review step (§3.6) to certify fidelity
-  manually rather than mechanically.
-
-This is real, non-trivial engineering scoped to Phase 5 (§7), not resolved
-here.
-
-### 3.6 DedupGate, CatalogEntry, Discovery, Task, LLMFallback
-
-- **DedupGate** — anti-unifies a freshly-generalized candidate against the
-  Catalog and yields `Reject`, `Merge`, or `Admit`. Both `Admit` and `Merge`
-  require human review before the result is live — `Admit` because that's
-  `scratch-command-bar`'s and administration-commons' existing precedent
-  (review before any commons entry, not scoped to merges); `Merge`
-  additionally because graph three-way merge is provably weaker than git's
-  line-based merge: RDF's unordered-set structure lets adds/removes combine
-  mechanically without ever raising a syntactic conflict, which can silently
-  produce a semantically wrong result (Quit Store and Touch Merge's academic
-  treatment of exactly this failure mode; re-verified in an earlier pass of
-  this process, not the final one). `Reject` skips review — nothing changes.
+- **DedupGate** — anti-unifies a freshly-generalized candidate against its
+  Catalog (whichever scope) and yields `Reject`, `Merge`, or `Admit`. Both
+  `Admit` and `Merge` require human review before the result is live —
+  `Admit` because review-before-entry is the working precedent this whole
+  process already established (`scratch-command-bar`'s propose/review
+  loop); `Merge` additionally because graph three-way merge is provably
+  weaker than git's — RDF's unordered-set structure lets adds/removes
+  combine mechanically without ever raising a syntactic conflict, silently
+  producing a semantically wrong result. `Reject` skips review.
 - **CatalogEntry** — `⊑ Rule`, admitted or merged by DedupGate, subject to
-  §3.4's admission consequence (no zero-parameter entries). Carries a
-  Description for Discovery.
-- **Discovery** — search over CatalogEntry only. Two sub-capabilities with
-  different readiness timelines (§7): exact/keyword lookup by name (viable
+  §5's admission consequence.
+- **Pattern is not a separate type.** It's the name for a CatalogEntry at
+  **Hub** scope — a published, human-validated, publicly-installable unit.
+  Everything else about it (Signature, Dialect, Body, Provenance) is
+  ordinary CatalogEntry structure. Reusing "Pattern" as a name (not a new
+  formal type) matters for a concrete reason: this generalizes to *any*
+  computer-doable action — "extract page 2 of this PDF" is as much a
+  Pattern as a tax-form submission is — and giving it a second, narrower
+  formal type would misrepresent that scope.
+- **Discovery** — search over CatalogEntry (either scope). Two
+  sub-capabilities with different readiness: exact/keyword lookup (viable
   as soon as any CatalogEntry exists) and hybrid keyword+embedding
-  progressive disclosure (only useful once there's a catalog large enough to
-  need it). Conflict resolution when multiple entries match: recency first,
-  specificity as tiebreaker (CLIPS's LEX strategy; re-verified in an earlier
-  pass, not the final one).
-- **Task** — the entry point. Triggers Discovery; a confident match invokes
-  that CatalogEntry's ExecuteInterpretation directly; no match triggers
-  **LLMFallback**, whose resulting Trace feeds Generalization → DedupGate →
-  possibly a new CatalogEntry, subject to the admission consequence above.
+  progressive disclosure (once the catalog is large). Conflict resolution
+  when multiple entries match: recency, then StabilityClass (§4), then
+  specificity as final tiebreaker — extending, not replacing, CLIPS's LEX
+  precedent (recency before specificity) with the one new ranking input
+  this revision added.
+- **Task** — the entry point. Triggers Discovery against the Tenant's own
+  Catalog; a confident match invokes that CatalogEntry directly; no match
+  triggers **LLMFallback**, whose resulting Trace feeds Generalization →
+  DedupGate (Tenant scope) → possibly a new local CatalogEntry.
+- **Install** — `CatalogEntry(Hub) × Tenant → CatalogEntry(Tenant)`, the
+  operation for adopting a public Pattern (§6.5 covers the mechanism in
+  full). Its result goes through the same DedupGate as any other candidate
+  entering the Tenant's local Catalog — review scope is narrower than a
+  fresh `Admit` (confirming the specific field bindings are correct for
+  this Tenant, not re-reviewing content the Hub already curated), but it's
+  the same gate, not a separate mechanism.
 
-## 4. Grounding
+### 6.5 Crosswalk — corrected from an earlier draft's overreach
 
-**4.1 Rule dialects — corrected.** Institution theory covers Horn Clause
-Logic as a genuine sub-institution of first-order logic (Diaconescu 2006,
-re-verified against the primary source in this revision's final pass) —
-that's real and precise. What's *not* established, and wasn't hedged
-carefully enough in the first draft: Soufflé's extended Datalog (aggregation,
-stratified negation) and both SPARQL-RL and SHACL 1.2 Rules go beyond pure
-Horn Clause Logic. The institution-theoretic grounding for Dialect covers the
-Horn-clause *core* of what these dialects express, not their full extent —
-stated honestly here, matching the hedging discipline §4.2 already applied
-to the anti-unification/institution-theory question. Soufflé's hard
-requirement that user-defined functors stay pure and reentrant (re-verified
-against Soufflé's own docs in this revision's final pass — a genuine "must,"
-execution guarantees void otherwise) remains real, independent validation
-that effects belong in a separate interpreter, never a live call inside the
-pure evaluator.
+Installing a Hub Pattern against a Tenant whose own vocabulary differs
+requires translating some of the Pattern's Signature fields. What that
+translation actually *is*, formally, was mis-scoped in an earlier version
+of this document and has now been checked properly rather than asserted:
 
-**4.2 Anti-unification — corrected, with a real design consequence.**
-Plotkin/Reynolds (1970) is correctly the source for flat first-order
-syntactic anti-unification, proven unitary (a unique lgg always exists).
-It is **not** the source for term-graph anti-unification, and the first
-draft's citation was wrong. The actual term-graph result (Baumgartner,
-Kutsia, Levy & Villaret, FSCD 2018) proves the *general* term-graph case is
-only **finitary** — a finite, minimal, but not necessarily singleton set of
-incomparable generalizations can exist. Unitarity (one unique lgg) is proven
-only for the narrower special case of **bisimilar term-graphs**.
+- **When the Pattern and the Tenant's existing vocabulary share a Dialect**
+  (both SPARQL-RL, say), the correct formal tool is a **signature
+  morphism** — an arrow within one institution's `Sign` category. This is
+  established, textbook institution theory (confirmed against Goguen &
+  Burstall's own definition), and it is *already in this document's own
+  vocabulary* — it's the same kind of thing Signature itself already is.
+  No new borrowed machinery needed. If a signature morphism's soundness
+  needs checking, the literature's own vocabulary for that is model-
+  conservativeness / Mod-strictness / Sen-maximality — not the
+  sublogic/embedding/faithful/exact scale, which is documented specifically
+  for the next case, not this one.
+- **When the Pattern and the Tenant's vocabulary are in *different*
+  Dialects** (one SPARQL-RL, one SHACL 1.2 Rules), the correct tool is a
+  full **comorphism** — categorically heavier (a functor between the two
+  Dialects' `Sign` categories plus natural transformations translating
+  their sentences and models), and *this* is where the
+  sublogic/embedding/faithful/(weakly) exact fidelity scale actually
+  applies, per DOL's own worked practice.
+- **An earlier draft of this document proposed modeling all Crosswalks as
+  comorphisms and borrowing that fidelity scale universally. Checked
+  directly against the primary institution-theory literature: that's
+  wrong** for the (more common) same-Dialect case, and the correction
+  matters — it's the difference between reaching for machinery that's
+  already sitting in this document (a signature morphism, essentially a
+  second Signature with a translation) versus machinery that's
+  categorically heavier and was never actually needed for most Crosswalks.
+- **The human-facing representation, regardless of which formal case
+  applies, is SSSOM** — `exact_match`/`close_match`/`broad_match`/
+  `narrow_match`/`related_match`, each with a curator's confidence. This is
+  the right layer for the actual working mechanism, and it composes
+  cleanly with the formal distinction above rather than competing with it:
+  SSSOM's own specification is explicit that these are practical,
+  curatorial judgments calibrated to "fitness for purpose," *not* claims of
+  model-theoretic equivalence — checked directly against SSSOM's own paper,
+  which discusses DOL by name in its related work and never once invokes
+  institution theory, confirming the two are genuinely separate layers, not
+  one dressed as the other. A human curating an `exact_match` is making a
+  practical judgment call, available for later, optional strengthening
+  into a formally-checked signature morphism or comorphism if anyone
+  wants that — never a prerequisite for using the mapping.
+- **Detection of overlap is human-only, by design, for now** — not a gap to
+  fill later with automated ontology-alignment matching, a deliberate
+  scoping decision. A curator proposes a Crosswalk entry (an SSSOM mapping
+  row); it goes through the same Hub-scope DedupGate as any other Hub
+  content.
+- **Crosswalks are Hub-scope content** (a mapping between two named
+  standards is a general, reusable fact, not tenant-specific); which
+  vocabulary a given Tenant has actually settled into, per §3.1, is the one
+  genuinely tenant-local fact.
+- **Installation with partial coverage** — the actual mechanism, precisely:
+  for each field in the Pattern's Signature, look up an existing Crosswalk
+  entry against the Tenant's own established vocabulary. Matched fields
+  bind through the Crosswalk. **Unmatched fields — no Crosswalk entry
+  exists yet — the Tenant is prompted to supply those Facts directly**, in
+  the Pattern's own native vocabulary, since there's nothing to translate
+  from. This is recorded as manually-originated Provenance, not a
+  translation. Crosswalks grow incrementally from real installation
+  friction — the same anti-Xanadu discipline ("the graph should grow from
+  real transactions, not an a priori exhaustive ontology") already applied
+  to Traces (§5) and Tasks (§6), applied a third time here. For a Pattern
+  with a thin, largely-uncontested Signature (page-extraction-shaped
+  actions), this degrades to zero friction — most fields hit exact matches,
+  nothing left to fill in by hand. It only gets elaborate where a domain
+  genuinely has competing standards, which is a property of the domain, not
+  a cost the mechanism imposes uniformly.
 
-This has a real consequence the first draft's overclaim was hiding: **the
-Rule representation needs to be restricted to the bisimilar-graph fragment
-specifically**, not just "the term-graph fragment" generally, if DedupGate is
-to assume a single canonical generalization rather than needing to arbitrate
-among several incomparable ones. Whether the workflow-graph shape this
-system needs (typed steps, branch/loop/call) can be constrained to stay
-inside that narrower fragment, or whether DedupGate genuinely needs to
-handle a finite set of candidates and let human review pick among them, is
-now an explicit open question (§8) rather than a settled fact. Minimizing
-generalization variables remains NP-complete in the closest scalable
-formalism (Yernaux & Vanhoof 2022, unordered goals — re-verified precisely
-in this revision's final pass, confirmed as NP-complete, a stronger result
-than the "NP-hard" the first draft stated) — accept a bounded/greedy
-generalization regardless of which fragment is chosen.
+## 7. Sub-projects
 
-**4.3 Execution kernel.** WASI Preview 2 excludes fork/exec/subprocess
+Each of these becomes its own spec → plan → implementation cycle when work
+on it starts; this document defines their scope and dependencies, not their
+detailed plans.
+
+1. **Bitemporal fact shape.** RDF-star `validFrom`/`validTo`, a defined
+   OWL-Time Allen-relation subset, ValidTime defaulting to TransactionTime.
+   Applies to Riptide's existing LDP write path. Depends on nothing but
+   Riptide as it exists today. Detailed scope: §9.1... *(unchanged from the
+   prior revision; kept minimal here since it's already fully specified and
+   nothing in this revision touches it)*. Deferred to Sub-project 3+:
+   making ValidTime queryable/joinable in rule logic.
+2. **Execution substrate.** WASI component execution, WASIX capability
+   grant, **tenant-scoped and split into EffectCapability/ObserveCapability
+   from the start** (§4) — new requirement in this revision. Must produce
+   the integration point with Riptide's Phase 4c ACP model as an exit
+   criterion, not a follow-up. Tested with no Rule representation involved.
+3. **Pure derivation engine.** Cross-stream joins, recursion, aggregation,
+   query interpretation only. Depends on Sub-project 1.
+4. **Wiring**, split by risk:
+   - **4a — mechanical wiring.** Execute interpreter, real NativeTemplate
+     instances, `call_template` against a small hand-authored set. Low
+     risk.
+   - **4b — concurrent-effects design spike.** No established theory
+     answers coordinating concurrent ExecuteInterpretations over
+     overlapping, irreversible resources (checked: neither sagas nor CRDTs
+     establish this). Real, open design work, not a checklist item inside
+     4a.
+5. **Generalization and DedupGate**, including replay-testing fidelity with
+   the kind-specific (Effect vs. Observe) semantics from §4. Depends on 4a.
+6. **LLM fallback loop.** OAuth ported to Elixir by hand (no ecosystem to
+   lean on — `lambdaclass/datalog` dead, `fogfish/datalog` real but
+   dormant since 2019). Needs Sub-project 5's gate to have somewhere to put
+   its output.
+7. **Discovery**, split by readiness:
+   - **7a — exact/keyword lookup**, viable as soon as any CatalogEntry
+     exists (as early as Sub-project 5) — a real walking skeleton well
+     before the rest of the roadmap ships.
+   - **7b — hybrid keyword+embedding progressive disclosure**, deferred
+     until the catalog is large enough to need it.
+8. **Pattern Hub.** **New in this revision.** Stand up Hub-scope Catalog
+   (§6) as a distinct, publicly-reachable deployment of the same DedupGate
+   mechanism Sub-project 5 already builds — genuinely low new-mechanism
+   risk, since it reuses rather than duplicates. Depends on Sub-project 5.
+9. **Ontology Crosswalks and Installation.** **New in this revision.**
+   SSSOM-shaped Hub-scope Crosswalk content, the Install operation (§6.5),
+   and the human-curation workflow for proposing Crosswalk entries. Depends
+   on Sub-project 8. The signature-morphism/comorphism distinction (§6.5)
+   only needs to inform how Crosswalk correctness is *reasoned about* when
+   questioned — the day-to-day mechanism is SSSOM curation plus DedupGate,
+   which Sub-project 8 already provides.
+
+**Ongoing, not sequential:** LinkML authoring applied to each new schema as
+created (§8.6).
+
+## 8. Grounding
+
+**8.1 Rule dialects.** Institution theory covers Horn Clause Logic as a
+genuine sub-institution of first-order logic (Diaconescu 2006). Soufflé's
+extended Datalog and both target Dialects go beyond pure Horn Clause Logic —
+the institution-theoretic grounding covers their Horn-clause core, not
+their full extent; stated honestly rather than left implicit. Soufflé's
+hard requirement that user-defined functors stay pure and reentrant remains
+real, independent validation that effects belong in a separate interpreter.
+
+**8.2 Anti-unification.** Plotkin/Reynolds (1970): flat first-order
+syntactic anti-unification, proven unitary. Term-graph anti-unification is
+a *different* result (Baumgartner, Kutsia, Levy & Villaret, FSCD 2018),
+proving the general case only **finitary** (a finite, possibly-plural set
+of incomparable generalizations), with unitarity proven only for the
+narrower bisimilar-term-graph case. Open question this creates, unresolved:
+whether the Rule/workflow-graph representation can be constrained to that
+narrower fragment, or whether DedupGate genuinely needs to arbitrate among
+several incomparable candidates. Minimizing generalization variables is
+NP-complete in the closest scalable formalism (Yernaux & Vanhoof 2022) —
+accept bounded/greedy generalization regardless.
+
+**8.3 Execution kernel.** WASI Preview 2 excludes fork/exec/subprocess
 spawning by design; WASIX is the separate superset restoring it. Kernel
-primitive: "execute a capability-scoped WASM component," subprocess
-spawning one optional grantable Capability among others. (Re-verified in an
-earlier pass, not this revision's final one.)
+primitive: execute a capability-scoped WASM component; subprocess spawning
+one optional grantable capability among others.
 
-**4.4 Bitemporal facts.** Datomic is unitemporal; XTDB's two-axis model
+**8.4 Bitemporal facts.** Datomic is unitemporal; XTDB's two-axis model
 (system transaction-time, user-assigned valid-time) is the target shape,
 via RDF-star + OWL-Time. Valid-time must be duplicated into ordinary
-queryable fact form for the derivation layer to reason over it — XTDB's
-indexing alone only controls which document version a query sees. (Re-verified
-in an earlier pass, not this revision's final one.)
+queryable fact form for the derivation layer to reason over it.
 
-**4.5 Versioning.** TerminusDB and Fluree implement git's model over graph
-data; graph three-way merge is weaker than git's (see §3.6). (Re-verified in
-an earlier pass, not this revision's final one — maintenance-status claims
-about both projects specifically should be treated as time-sensitive and
-worth a fresh check before Phase 6 planning starts, not assumed current
-indefinitely.)
+**8.5 Capability kinds — new grounding this revision.** The
+EffectCapability/ObserveCapability split wasn't researched against external
+literature; it fell directly out of tracing a real scenario (§9.2) through
+the model and finding that "replay this to check fidelity" means two
+different things depending on whether the capability changes the world or
+just reads it — re-querying a live external system during a fidelity check
+would fail spuriously whenever that system's real state has simply moved on
+since the original Trace, which isn't a fidelity failure at all. This is
+this document's own synthesis, not a citation, and is presented as such.
 
-**4.6 Parallelism — fully re-confirmed in this revision's final pass, with
-more precision than the first draft had.** Soufflé compiles `par...endpar`
-blocks to OpenMP-annotated C++ (GCC's OpenMP runtime, threads pinned to
-cores) implementing semi-naive evaluation — not runtime interpretation.
-Backed by two purpose-built concurrent structures: a concurrent B-tree
-(optimistic fine-grained locking extending seqlocks, plus a traversal-reuse
-"hints" mechanism) and Brie, a concurrent trie hybridizing trie/B-tree design
-with lock-free insertion. This is the adoptable answer for
-QueryInterpretation. ExecuteInterpretation concurrency has no equivalent
-answer and stays explicitly open (§2, §7 Phase 4b).
+**8.6 Authoring.** LinkML adopted for Sub-project 3's rule schema and
+Sub-project 8/9's Pattern and Crosswalk schemas specifically —
+`linkml-datalog` (real, alpha, dormant since Feb 2024 at last check, worth
+a fresh liveness check before depending on it) already demonstrates
+"author in LinkML, generate a working Soufflé Datalog program" as a working
+pattern, not a hypothesis.
 
-**4.7 Conflict resolution.** CLIPS's LEX strategy: recency checked before
-specificity, specificity only the final tiebreaker. (Re-verified in an
-earlier pass, not this revision's final one.)
+**8.7 Versioning.** TerminusDB and Fluree implement git's model over graph
+data; graph three-way merge is weaker than git's (§6's DedupGate `Merge`
+rule). Maintenance-status claims about both projects are time-sensitive and
+worth a fresh check before Sub-project 6 planning.
 
-**4.8 Authoring.** LinkML isn't a replacement for StreamLD's shipped SHACL
-schemas — a safely-deferrable representation choice. Adopted now for the
-*new* Phase 3 rule schema specifically: `linkml-datalog` (real, alpha,
-dormant since Feb 2024 as of the last check) already demonstrates "author in
-LinkML, generate a working Soufflé Datalog program" as a working pattern.
-(Re-verified in an earlier pass, not this revision's final one — worth a
-fresh liveness check before depending on it in Phase 3 planning, given how
-long "dormant since Feb 2024" has now been true.)
+**8.8 Parallelism.** Soufflé compiles `par...endpar` to OpenMP-annotated
+C++ implementing semi-naive evaluation, backed by a concurrent B-tree and
+Brie (a concurrent trie). Adoptable for QueryInterpretation.
+ExecuteInterpretation concurrency has no equivalent answer (§7, Sub-project
+4b).
 
-**4.9 Human review, UI, and repo integration.** External research on
+**8.9 Signature morphisms vs. comorphisms — the correction driving §6.5.**
+Confirmed directly against Goguen & Burstall's own definitions and
+follow-on literature (Diaconescu; the 2-institutions literature): a
+signature morphism is an arrow within one institution's `Sign` category — a
+translation within one Dialect. A comorphism is a categorically heavier
+triple (a functor between two institutions' `Sign` categories, plus natural
+transformations translating their sentences and models) — needed only when
+crossing between genuinely different Dialects. The
+sublogic/embedding/faithful/(weakly) exact fidelity scale is documented
+specifically for comorphisms; same-institution signature-morphism quality
+uses different, unrelated vocabulary (model-conservativeness,
+Mod-strictness, Sen-maximality) in the literature that actually works
+within one institution. SSSOM's own specification frames its match
+predicates as practical/curatorial ("fitness for purpose," explicitly not
+correctness), and no citable work connects SSSOM/SKOS mappings to
+institution-theoretic morphisms of either kind — confirmed by a direct
+search of SSSOM's own paper, which discusses DOL by name in its related
+work without ever invoking institution theory.
+
+**8.10 Conflict resolution.** CLIPS's LEX strategy: recency checked before
+specificity, specificity the final tiebreaker. StabilityClass (§4) is a new
+ranking input this revision adds ahead of specificity, not documented CLIPS
+behavior — this document's own extension, stated as such.
+
+**8.11 Human review, UI, repo integration.** External research on
 review-gate placement and generic-shape-driven UI came back empty twice —
-treated as a real signal, not bad luck. Uses local precedent instead:
-`scratch-command-bar`'s working propose/review loop, administration-commons'
-stated review principle, `graphsheet`'s shipped SHACL-driven UI. **Added in
-this revision:** this layer is not yet reflected in Riptide's own
-PROGRESS.md sub-project table, which the repo treats as the canonical
-current-status reference — that should happen no later than Phase 2 start,
-not as an afterthought once the whole roadmap is further along.
+a real signal, not bad luck. Local precedent used instead:
+`scratch-command-bar`'s propose/review loop, `graphsheet`'s shipped
+SHACL-driven UI. This layer should be reflected in Riptide's own
+PROGRESS.md sub-project table no later than Sub-project 2's start.
 
-**4.10 Elixir OAuth.** No Elixir Datalog ecosystem to lean on
-(`lambdaclass/datalog` dead stub; `fogfish/datalog` real, dormant since
-2019). OAuth needs hand-porting to Elixir, the same scoped cost
-`sovereign-ops` already identified for its own agent loop. (Re-verified in
-an earlier pass, not this revision's final one.)
+## 9. Worked examples
 
-## 5. Worked example
+**9.1 — the clean case (unchanged from the prior revision).** Task "deploy
+the billing service" → no CatalogEntry match → LLMFallback produces a
+ground Trace → not admitted alone (§5) → weeks later, a second, similar
+Task's Trace anti-unifies against the first, producing a genuinely
+parameterized candidate → DedupGate `Admit` with human review, including
+sandboxed-replay fidelity evidence → becomes CatalogEntry
+`deploy-service-to-prod` → a third occurrence hits Discovery's exact lookup
+directly, zero LLM calls.
 
-Added in this revision — the first draft had none, and the cold review
-correctly flagged that as a real source of the ambiguities it found.
+**9.2 — the case that found real gaps: a German tax filing, walked through
+deliberately, not as a domain this spec builds.** A fresh Tenant, Task
+"file my tax return." Discovery finds nothing (empty Catalog). LLMFallback
+doesn't decompose this into one Trace — it needs, in order:
 
-1. **Task**: "deploy the billing service." Discovery finds no matching
-   CatalogEntry (first time this kind of task has occurred). LLMFallback
-   runs: the LLM issues concrete tool calls, producing a ground
-   **Trace** — a zero-parameter Rule whose Body is a specific sequence of
-   capability-reference literals with concrete arguments
-   (`kubectl(apply, "billing.yaml", "prod")`, `kubectl(rollout-status,
-   "billing", "prod")`).
-2. Per §3.4's admission consequence, this single Trace is **not** admitted —
-   it's stored as a Trace with Provenance pointing at nothing (it's the
-   first occurrence), and the Task completes by running it directly under
-   ExecuteInterpretation.
-3. **Weeks later**, a second Task: "deploy the auth service." Discovery again
-   finds no CatalogEntry, but this time a Trace-similarity check (a cheap
-   prefilter, not full anti-unification, over the stored Trace log) surfaces
-   the billing-deploy Trace as a candidate. LLMFallback's new Trace and the
-   old Trace go through **Generalization**: anti-unification finds they
-   agree on `kubectl(apply, ?, "prod")` and `kubectl(rollout-status, ?,
-   "prod")`, diverging only on the manifest/service name — producing a
-   genuinely parameterized Rule with one free parameter, plus the
-   substitutions recovering each original Trace.
-4. This candidate goes to **DedupGate**. The Catalog is empty, so there's
-   nothing to anti-unify against for dedup purposes — it's a novel,
-   admissible candidate (it has a real parameter, satisfying §3.4). Per §3.6,
-   `Admit` requires human review regardless: a reviewer sees the proposed
-   Rule, its Description, and — per §3.5's fidelity requirement — evidence
-   from a sandboxed replay that specializing it back to each original Trace's
-   bindings reproduces each original run.
-5. Reviewer approves. It becomes a **CatalogEntry**: `deploy-service-to-prod`,
-   one parameter (`service`).
-6. **Third occurrence**: Task "deploy the auth service" (again, or a
-   different service) now hits Discovery's exact/keyword lookup, finds the
-   CatalogEntry directly, and runs `ExecuteInterpretation` with the bound
-   parameter — zero LLM calls.
+1. **An ObserveCapability check**: has this year's filing already been
+   submitted? Queries the external tax authority, asserts the answer as a
+   new Fact with its own ValidTime (per §8.4, distinct from when Riptide
+   learned it). This Fact's Provenance records the actual response, so a
+   later fidelity replay of any Rule built from this Trace replays that
+   recorded answer rather than re-querying — the real external system
+   isn't expected to still say the same thing days or months later, and
+   that's not a fidelity failure (§4, §8.5).
+2. **Gathering the actual facts to file** — no existing Signature in this
+   ecosystem covers personal income tax; the Tenant supplies them via the
+   same extraction-and-review loop `scratch-command-bar` already uses. This
+   is real content-layer work this spec doesn't provide, correctly out of
+   scope (§2) — but the example is worth keeping precisely because it shows
+   *how much* has to exist before "file my tax return" can complete on a
+   fresh instance, which the simpler §9.1 example doesn't reveal.
+3. **An EffectCapability submission.** Two independently-viable
+   implementations exist in principle for the same real-world outcome — a
+   documented official interface and a reverse-engineered one — exactly
+   the shape Discovery's own multi-match resolution (§6) already handles:
+   eligibility differences show up as Signature preconditions (a documented
+   path's CatalogEntry requires a Fact this Tenant may or may not have),
+   and StabilityClass (§4) correctly ranks the documented path over the
+   reverse-engineered one when both apply. No new mechanism needed —
+   genuine validation that §6's existing machinery covers this, not a gap.
+4. Composability (§3.2's rule-reference literals, fixed in this revision)
+   is what lets a `file-annual-return` Rule call a `submit-return` Rule
+   that calls a lower-level submission NativeTemplate — the bug this
+   example caught when it was still missing.
 
-## 6. Diagram
+Nothing about German tax law is proposed as part of this spec's own
+deliverables; this example exists to stress-test the object model against
+something with real regulatory weight, external system fragility, and
+composability requirements a purely infrastructural example wouldn't
+surface.
 
-```
-  Content / domain           (lattice, MiKaDiv, KaFE — unaffected)
-  Extraction / population    (scratch-command-bar's pattern — LLMFallback + review)
-  ── new in this spec, abstraction layers — NOT call order; see §5 for call order ──
-  Discovery
-  Anti-unification / DedupGate
-  Interpretation             (Query / Execute)
-  Rule (IDB)                 (SPARQL-RL / SHACL 1.2 Rules-targeted, Soufflé-referenced)
-  ── existing, unchanged ───────────────────────────────────────
-  Execution kernel           (WASI + WASIX capability, tenant-scoped)
-  Fact / Event (EDB)         (Riptide today, extended with valid-time)
-```
+## 10. Changelog
 
-## 7. Phased build order
+**This revision (second):**
+- Rule's Body gained a rule-reference literal kind — composability was
+  inexpressible without it, caught by §9.2.
+- Capability split into EffectCapability/ObserveCapability with distinct
+  fidelity-replay semantics — caught by the same trace.
+- StabilityClass added, feeding Discovery's existing conflict resolution.
+- Catalog generalized to Tenant/Hub scope; Pattern defined as a name for
+  Hub-scope CatalogEntry, not a new type.
+- Crosswalk mechanism added: SSSOM as the working representation;
+  signature morphisms for same-Dialect translation (corrected from an
+  earlier, wrong instinct to model all of this as comorphisms); comorphisms
+  reserved for genuinely cross-Dialect translation, with the
+  sublogic/embedding/faithful/exact scale now correctly scoped to that case
+  only.
+- Sub-projects 8 and 9 added; the whole document restructured as one spec
+  defining many sub-projects rather than a single phased roadmap.
+- `administration-commons` reframed as superseded, not something to
+  reconcile with.
 
-1. **Bitemporal fact shape.** Changes what a fact looks like; must land
-   before anything reads/writes facts downstream. Depends on nothing but
-   Riptide as it exists today. Scope detailed in §7.1.
-2. **Execution substrate in isolation.** WASI component execution, the
-   WASIX capability grant, **tenant-scoped from the start** (§3.1) — tested
-   with no Rule representation involved. This phase must also produce the
-   integration point with Riptide's Phase 4c ACP model; shipping a
-   capability-grant mechanism that doesn't yet compose with existing
-   authorization is not acceptable exit criteria for this phase. Add this
-   layer's own entry to PROGRESS.md's sub-project table here, not later
-   (§4.9).
-3. **Pure derivation engine.** Cross-stream joins, recursion, aggregation,
-   query interpretation only. Depends on Phase 1.
-4. **Wiring — split into two sub-phases, correcting the first draft's single
-   "pure wiring" phase that actually hid its hardest problem.**
-   - **4a — mechanical wiring.** Connect Phase 2's substrate and Phase 3's
-     engine: add the execute interpreter, NativeTemplate instances become
-     real (§3.3), `call_template` works for the first time against a small,
-     hand-authored set of NativeTemplates. Genuinely low-risk, no open
-     research questions.
-   - **4b — concurrent-effects design spike.** The problem named in §2 and
-     §4.6: no established theory answers how two concurrent
-     ExecuteInterpretations should be coordinated when they touch
-     overlapping, irreversible resources. This is real, open design work,
-     scoped and staffed as such — not a checklist item inside 4a.
-5. **Anti-unification: Generalization and DedupGate**, including the
-   replay-testing fidelity mechanism from §3.5. Depends on 4a.
-6. **LLM fallback loop.** Last among the "core" phases — needs 5's gate to
-   have somewhere to put its output.
-7. **Discovery — split by readiness, correcting the first draft's
-   single-phase, catalog-must-already-be-large framing.**
-   - **7a — exact/keyword lookup.** Viable as soon as any CatalogEntry
-     exists (as early as Phase 5), giving a real, working walking skeleton
-     (§5's example, end to end) well before the full roadmap ships — the
-     first draft had no demonstrable milestone before the very last phase.
-   - **7b — hybrid keyword+embedding progressive disclosure.** Deferred
-     until the catalog is large enough to need it.
-
-**Ongoing, not sequential:** LinkML authoring (§4.8) applied to each new
-schema as created.
-
-### 7.1 Phase 1 — ready to plan
-
-- RDF-star `validFrom`/`validTo` annotation convention on individual facts.
-- A defined OWL-Time Allen-relation subset for interval comparisons.
-- ValidTime defaults to TransactionTime when unspecified (XTDB's default).
-- Applies to all new writes in Riptide's existing LDP write path — no new
-  engine, no behavior change beyond the annotation.
-- Deferred to Phase 3+: making ValidTime queryable/joinable in rule logic.
-
-## 8. Open questions
-
-- OpenFASTER-Standard public governance status.
-- Whether this engine is operationally a separate deployable from Riptide's
-  LDP surface, given Capability grants expand the trusted computing base
-  (§1) — genuinely unresolved, not just undecided by omission.
-- Concurrent-effectful-execution coordination — no established answer;
-  Phase 4b's actual subject matter, not a footnote.
-- Whether the Rule/workflow-graph representation can be constrained to the
-  bisimilar-term-graph fragment where anti-unification is proven unitary, or
-  whether DedupGate must handle a finite set of incomparable generalizations
-  (§4.2) — newly surfaced by this revision, not resolved.
-- Formal versioning/supersedes theory for declarative rules — none found;
-  pragmatic git/TerminusDB model adopted instead.
-- Final Tenant name.
-- Fresh liveness checks needed before depending on them operationally:
-  `linkml-datalog` (dormant since Feb 2024 at last check) and
-  TerminusDB/Fluree's current maintenance status (§4.5, §4.8).
-
-## 9. What changed in this revision, and why
-
-For anyone comparing against the first draft: this is not a copyedit.
-- §3.2/§3.3/§3.4: Rule's definition now actually accommodates
-  NativeTemplate; Trace is now `⊑ Rule` instead of an incompatible sibling
-  type; Generalization has one consistent type signature (`Rule × Rule →
-  Rule`) instead of three incompatible ones used in different places.
-- §3.5: the Generalization Fidelity "law" is reframed from an inherited
-  proof to an engineering requirement this system has to earn, with a
-  concrete mechanism (replay-testing) instead of an assumption.
-- §4.1: SPARQL-RL is no longer described as succeeding SHACL 1.2 Rules —
-  they're two parallel, currently-live drafts. Institution-theoretic
-  grounding for Dialect is now scoped to the Horn-clause core, not the full
-  extent of the actual target dialects.
-- §4.2: anti-unification's term-graph unitarity claim is correctly
-  attributed (Baumgartner et al. 2018, not Plotkin/Reynolds) and correctly
-  scoped (finitary in general, unitary only for bisimilar graphs) — with a
-  real, newly-surfaced open question this creates for DedupGate.
-- §3.1: Capability is now tenant-scoped and required to compose with
-  Riptide's existing ACP model — a real security gap in the first draft.
-- §7: Phase 4 is split into a genuinely-low-risk wiring step and an
-  honestly-scoped open-research step, instead of one phase mischaracterized
-  as both. Phase 7 is split so a real walking skeleton exists many phases
-  before the end of the roadmap, instead of no working demonstration until
-  everything ships.
-- §5 (worked example) and §1's deployment-scope narrowing are new; both were
-  gaps a cold reader flagged, not refinements of something already there.
+**Prior revision:** fixed Rule's definition to accommodate NativeTemplate,
+made Trace `⊑ Rule` with one consistent Generalization type signature,
+reframed the Generalization Fidelity requirement from an inherited proof to
+an engineering obligation, corrected the SPARQL-RL/SHACL 1.2 Rules
+relationship, corrected the term-graph anti-unification citation and scope,
+added tenant-scoping to Capability, split the wiring phase by risk, and
+added a walking-skeleton milestone before the end of the roadmap.

--- a/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
+++ b/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
@@ -1,313 +1,498 @@
 # Derivation and Execution Layer — Architecture Design
 
-**Status:** Draft, pending review. This is an architecture spec covering the full
-vision and a phased roadmap — not a single implementation plan. Each phase below
-gets its own implementation plan (via the `writing-plans` process) when work on it
-starts, per the usual decomposition discipline for a project too large for one plan.
+**Status:** Draft, revised after an independent cold review and a targeted
+re-verification pass against primary sources. This is an architecture spec
+covering the full vision and a phased roadmap — not a single implementation
+plan. Each phase gets its own implementation plan (`writing-plans`) when work
+on it starts.
+
+**Revision note:** this replaces an earlier draft of the same spec. The
+revision fixed two factual errors (§4.1, §4.2), one internally contradictory
+concept (§3.4's Generalization), one concept whose stated definition didn't
+actually support its own use (§3.2/§3.3), an overclaimed invariant (§3.5's
+Generalization Fidelity law), a real security gap (Capability was never
+tenant-scoped), and a roadmap that hid its riskiest problem inside a step
+labeled "pure wiring." All of this came from treating the first draft as
+something to stress-test, not something to defend — see §9 for the itemized
+before/after.
 
 ## 1. Motivation and vision
 
-Riptide today is an event-sourced fact store (StreamLD's reference implementation):
-an append-only, per-resource log of RDF facts, with one hardcoded derivation (replay
-a stream's events in order to compute current state). This spec adds the layer that
-was structurally missing: a general **derivation and execution engine**, so that
-"answer a question about the facts" and "cause an effect in the world" become two
-interpretations of the same declarative object, evaluated by one engine, rather than
-bespoke application code per feature.
+Riptide today is an event-sourced fact store (StreamLD's reference
+implementation): an append-only, per-resource log of RDF facts, with one
+hardcoded derivation (replay a stream's events in order to compute current
+state). This spec adds the layer that's structurally missing: a general
+**derivation and execution engine**, so that "answer a question about the
+facts" and "cause an effect in the world" become two interpretations of the
+same declarative object, evaluated by one engine, instead of bespoke
+application code per feature.
 
-The organizing idea, carried through every layer of this design: **the atomic unit
-should have a stable identity, and everything else — labels, presentations,
-procedures — should be a *view* derived from that identity, never the identity
-itself.** Riptide's event log already does this for facts (an IRI, never a label,
-is what anything actually references). This spec extends the same discipline to
-*rules* and *capabilities*, so the whole system stays one substrate that things are
-derived from, not several substrates that need reconciling.
+The organizing idea: **the atomic unit should have a stable identity, and
+everything else — labels, presentations, procedures — should be a *view*
+derived from that identity, never the identity itself.** Riptide's event log
+already does this for facts. This spec extends the same discipline to
+*rules*.
 
-This is why the work in this document lives inside Riptide rather than as a
-separate service: once "querying" and "doing" are understood as the same kind of
-operation (two interpretations of one rule, evaluated by one engine — see §3.5),
-there is no natural seam to split into two systems. A separate service calling
-Riptide over an API would reintroduce exactly the two-sources-of-truth problem this
-design exists to avoid.
+**What that does and doesn't settle about deployment.** It settles that this
+layer shares Riptide's Fact store, Rule representation, and Signature/Dialect
+definitions as one substrate — no second store, no parallel schema, nothing
+that needs reconciling with Riptide's own facts. It does **not**, by itself,
+settle whether the derivation/execution engine must run in the same OS
+process or release as Riptide's existing LDP surface. That's a real,
+separate engineering question — particularly once §3.3's Capability grants
+are in the picture, which expand the trusted computing base from "evaluates
+RDF queries" to "executes arbitrary sandboxed code." Kept open in §8, not
+asserted here.
 
 ## 2. Scope and explicit non-goals
 
-**In scope:** the conceptual object model (the T-box, §3), the phased build order
-(§6), and the concrete, ready-to-plan scope of Phase 1 (§7).
+**In scope:** the conceptual object model (§3), the grounding for each design
+decision (§4), a worked example (§5), and the phased build order (§7),
+including the concrete, ready-to-plan scope of Phase 1 (§7.1).
 
-**Explicitly out of scope for this document** — flagged as open, not silently
-assumed:
-- Whether this layer ever becomes a public `OpenFASTER-Standard` module (like
-  StreamLD itself) or stays Riptide-internal. Nothing in the roadmap forces this
-  decision before there's something substantial enough to be worth standardizing.
-- Formal theory for coordinating **concurrent effectful** rule executions (e.g. two
-  templates racing on the same Kubernetes namespace). Research specifically
-  checked whether the saga pattern or CRDTs answer this and found neither
-  established for this case — CRDT convergence theory is about merging *data*, not
-  arbitrating *irreversible real-world effects*. This needs its own design spike
-  when Phase 4 is reached, not a borrowed citation.
-- Detailed UI design. `graphsheet` already solves generic-UI-from-shape for SHACL
-  data in this same ecosystem; the review/discovery/monitoring surfaces this layer
-  needs should reuse that pattern rather than be designed from scratch, but the
-  actual screens are not designed here.
-- The final human-facing name for a Riptide tenant. Shortlist from brainstorming:
-  **Polity**, Enclave, Civitas, Demesne. This document uses **Tenant** as a
-  placeholder term throughout; find-and-replace once decided.
+**Explicitly out of scope** — flagged as open, not silently assumed:
+- Whether this layer becomes a public `OpenFASTER-Standard` module or stays
+  Riptide-internal.
+- Formal theory for coordinating **concurrent effectful** rule executions
+  (two templates racing on the same Kubernetes namespace). Neither the saga
+  pattern nor CRDTs were found to establish this — CRDT convergence is about
+  merging *data*, not arbitrating *irreversible effects*. This is real,
+  currently-unsolved design surface, not deferred paperwork (see §7, Phase
+  4b).
+- Whether the engine is a separate deployable from Riptide's LDP surface
+  (§1).
+- Detailed UI design — reuse `graphsheet`'s SHACL-driven pattern for the
+  review/discovery/monitoring surfaces this layer needs; screens aren't
+  designed here.
+- The final human-facing name for a Riptide tenant. Shortlist: **Polity**,
+  Enclave, Civitas, Demesne. This document uses **Tenant** as a placeholder.
+- Observability and testing strategy for the engine itself, beyond what
+  §4.9 requires as a precondition for later phases — Riptide's own
+  PROGRESS.md already treats observability (sub-project 5) and
+  schema-versioning risk as first-class, ongoing concerns; this layer
+  should be planned against that existing discipline when Phase 2 starts,
+  not invent a separate one here.
 
 ## 3. Core concepts (the T-box)
 
-Every concrete technology choice in §4 is an instance of one of these concepts.
-This section is deliberately technology-agnostic.
-
 ### 3.1 Fact, Event, Tenant
 
-- **Fact** — an atomic RDF(-star) assertion in the EDB. Carries a *TransactionTime*
-  (free, from Riptide's existing per-stream sequence number) and optionally a
-  *ValidTime* interval, RDF-star-annotated (see §4.4). Produced by exactly one
-  **Event** (an append to a stream).
-- **Tenant** *(name TBD, see §2)* — an isolated administrative/institutional space.
-  Facts, Rules, and CatalogEntries are partitioned by Tenant. A person may hold
-  exactly one "institutional" Tenant plus any number of private Tenants (the
-  long-term ambition motivating the naming question) — this spec does not design
-  the multi-tenancy mechanics themselves, which are Riptide's existing phase-4a
-  work; it only adds Tenant as a T-box concept that Facts and Rules are scoped by.
+- **Fact** — an atomic RDF(-star) assertion in the EDB. Carries a
+  *TransactionTime* (free, from Riptide's sequence number) and optionally a
+  *ValidTime* interval, RDF-star-annotated (§4.4). Produced by one **Event**.
+- **Tenant** *(name TBD, §2)* — an isolated administrative/institutional
+  space. **Facts, Rules, CatalogEntries, and Capabilities are all
+  tenant-partitioned** — Capability is added to this list in this revision;
+  its absence in the first draft was a real gap (§9, item 6). A Capability
+  grant issued inside one Tenant must never be exercisable by a Rule running
+  in another. This has to compose with Riptide's already-shipped Phase 4c
+  ACP-based authorization, not duplicate it — Capability is *scoped by* the
+  existing tenant/grant model, not a second, parallel permission system.
 
 ### 3.2 Signature, Dialect, Rule
 
 - **Signature** — the typed interface of a Rule: its parameters, and which
-  predicates it reads/produces. This is the one piece of literal
-  institution-theoretic vocabulary reused here — precisely, not by analogy,
-  matching DOL's `Sign`.
-- **Dialect** — which concrete rule language a Rule is expressed in (target:
-  SPARQL-RL; reference engine: Soufflé's extended Datalog). This is where real
-  heterogeneity lives, and it is the part institution theory actually, rigorously
-  covers (Horn Clause Logic as a sub-institution of first-order logic).
-- **Rule** — a declarative IDB definition over a Signature: given a Body (a
-  pattern over Facts, possibly self-referential), conclude a Head.
+  predicates it reads/produces. Reuses DOL's `Sign` precisely.
+- **Dialect** — which concrete rule language a Rule is expressed in. Two
+  candidate targets are being tracked, not one: **SPARQL-RL** and **SHACL
+  1.2 Rules** are both live W3C Working Drafts on the Recommendation track
+  as of this writing, developed in parallel by the Data Shapes Working
+  Group — the first draft of this spec incorrectly described SPARQL-RL as
+  SHACL 1.2 Rules' successor; that relationship isn't documented anywhere
+  and both documents are actively progressing. Track both; adopt whichever
+  reaches sufficient maturity/tooling support first, or both if they serve
+  different needs. Reference engine for actual evaluation: Soufflé's
+  extended Datalog.
+- **Rule** — a declarative IDB definition over a Signature: given a Body,
+  conclude a Head. A Body is a conjunction of literals over two kinds:
+  ordinary **Fact-pattern literals** (matched against the EDB, as in
+  classical Datalog) and, where applicable, a distinguished
+  **capability-reference literal** — a reference to a Capability that
+  ExecuteInterpretation may invoke. This second literal kind is what closes
+  the gap the first draft left open: NativeTemplate's capability-invoking
+  behavior is now part of Rule's own definition, not asserted about Rule
+  from the outside. QueryInterpretation treats a capability-reference
+  literal as inert (unevaluable, contributing nothing to derived facts);
+  ExecuteInterpretation is what actually invokes it.
 
 ### 3.3 Capability, NativeTemplate, Template
 
-- **Capability** — an explicit, grantable permission (spawn a process, read a
-  path, reach a host) that only a NativeTemplate consumes. Backed by WASI
-  Preview 2 (no ambient authority, no subprocess spawning by design) plus WASIX
-  where subprocess spawning is specifically granted (see §4.3).
-- **NativeTemplate** — a Rule with no further Body — the base case, backed by a
-  real, capability-scoped WASI component. The bootstrapping kernel.
-- **Template** — precisely: `Template ⊑ Rule ⊓ (∃ a reachable step whose
-  ExecuteInterpretation invokes a Capability)`. Not a separate primitive from
-  Rule — a Rule becomes a Template exactly when it does something, not by any
-  structural difference.
+- **Capability** — an explicit, tenant-scoped, grantable permission (spawn a
+  process, read a path, reach a host). Backed by WASI Preview 2 (no ambient
+  authority, no subprocess spawning by design) plus WASIX where subprocess
+  spawning is specifically granted (§4.3). Composes with Riptide's Phase 4c
+  ACP model per §3.1 — not a parallel system.
+- **NativeTemplate** — a Rule whose Body is exactly one capability-reference
+  literal and nothing else: the base case, backed by a real,
+  capability-scoped WASI component. **Sequencing note, fixing a real
+  ordering ambiguity in the first draft:** Phase 2 (§7) builds the
+  capability-scoped WASI *execution substrate* standalone, with no Rule
+  representation involved at all — it does not yet produce NativeTemplate
+  instances, because NativeTemplate is a Rule, and Rule's own representation
+  isn't built until Phase 3. Phase 4 is what wraps the Phase 2 substrate as
+  actual NativeTemplate Rule instances. "NativeTemplate is the base case of
+  Rule" describes the finished system, not the build order.
+- **Template** — `Template ⊑ Rule ⊓ (∃ a reachable step whose
+  ExecuteInterpretation invokes a Capability)`. This *is* a structural
+  predicate (graph reachability over the Rule's own Body/composition
+  structure) — the first draft's claim that Template membership involves
+  "no structural difference" from Rule was imprecise and is dropped here.
+  The real point, stated correctly: Template is not a *separate primitive*
+  requiring its own representation — it's a checkable property of the one
+  Rule representation everything already shares.
 
 ### 3.4 Trace, Generalization, Provenance
 
-- **Trace** — a record of one concrete run: a Rule's ExecuteInterpretation with
-  specific bindings, or an ad hoc LLMFallback episode.
-- **Generalization** — `Trace × Trace → Rule`, computed via anti-unification
-  (Plotkin 1970): the least-general-generalization of two concrete instances,
-  always accompanied by the substitutions that recover each original and by
-  mandatory **Provenance** recording what it was generalized from.
-- **Provenance** is what keeps a generalized Rule from becoming an ungoverned,
-  independently-asserted second source of truth — the same discipline a
-  materialized view needs: a dependency edge back to what it was derived from.
+- **Trace ⊑ Rule.** Revised from the first draft, which typed Trace as an
+  unrelated primitive and then couldn't consistently type Generalization
+  around it (§9, item 2). A Trace is simply a Rule whose Signature has no
+  free parameters — every value is already ground, from one concrete run
+  (a Rule's ExecuteInterpretation with specific bindings, or an ad hoc
+  LLMFallback episode). This makes Trace a degenerate case of Rule, not a
+  different kind of thing.
+- **Generalization — uniformly `Rule × Rule → Rule`.** Anti-unification
+  (Plotkin 1970) computes the least-general-generalization of any two Rules
+  — whether both are ground (two Traces), one is ground and one already has
+  free parameters (a new Trace against an existing candidate), or neither is
+  ground (DedupGate anti-unifying a candidate against a CatalogEntry). One
+  operation, one type signature, used identically everywhere it appears in
+  §3.6's pipeline. Always accompanied by the substitutions recovering each
+  input and by mandatory **Provenance** — the dependency edge back to what
+  was generalized, which is what keeps a generalized Rule from becoming an
+  ungoverned second source of truth.
+- **Consequence for admission, stated explicitly because the first draft
+  left it implicit and inconsistent:** a Rule generalized from only one
+  Trace (i.e., still ground, zero free parameters) is not admissible as a
+  CatalogEntry — a zero-parameter "template" isn't reusable by definition.
+  DedupGate's `Admit` path requires at least one real Generalization step
+  (at least two distinct Traces or an existing Rule contributing to it).
+  Single, unrepeated Traces stay Traces; they don't get promoted to the
+  catalog on their own.
 
 ### 3.5 Interpretation
 
-A function `(Rule, Bindings, EDB-state) → Outcome`. At least two disjoint kinds:
-- **QueryInterpretation** — pure, Outcome ⊑ new Facts, no side effects. Classical
-  Datalog derivation.
-- **ExecuteInterpretation** — the same Rule, but a designated step may invoke a
-  Capability.
-
-More modes (dry-run/simulate, cost-estimate, explain/audit) are expected later —
-this is deliberately an open, extensible set, not a hardcoded pair. Algebraic
+A function `(Rule, Bindings, EDB-state) → Outcome`. At least two disjoint
+kinds — **QueryInterpretation** (pure, Outcome ⊑ new Facts, treats
+capability-reference literals as inert) and **ExecuteInterpretation** (the
+same Rule, but capability-reference literals are actually invoked) — with
+more expected later (dry-run, cost-estimate, explain/audit). Algebraic
 effects/handler theory (Plotkin & Power; Plotkin & Pretnar) is the closest
-rigorously-established formalism for "one program, many interpretations," and
-tagless-final is the closest established technique for adding new interpreters
-without touching existing code (the expression problem) — both are real,
-well-grounded inspirations for this concept, and neither is a proof that this
-system's specific design is correct. That distinction is intentional and should
-stay explicit in any future writing about this layer, not get smoothed over.
+established formalism for this shape, and tagless-final the closest
+established technique for adding interpreters without touching existing code
+— both real, well-grounded inspiration, neither a proof this specific design
+is correct. (These two citations were re-verified in an earlier pass of this
+design process, not in the final re-verification pass behind this revision —
+carried forward, not re-checked here.)
 
-**The Generalization Fidelity law** — the one cross-cutting invariant, earned by
-this design rather than inherited from elsewhere: for any Generalization
-producing Rule `g` from Traces `t₁, t₂` with substitutions `σ₁, σ₂`,
-`ExecuteInterpretation(g, σ₁)` must reproduce `t₁`'s effects exactly, and
-likewise for `t₂`. Generalizing and specializing back must commute with actually
-running the thing. This is the concrete, checkable property any test suite for
-the DedupGate (§3.6) must verify before trusting a merge.
+**On the Generalization Fidelity requirement — reframed, not just renamed,
+from the first draft's "law."** The first draft asserted, as if it followed
+from anti-unification's proven properties, that
+`ExecuteInterpretation(g, σ₁)` must reproduce a source Trace's effects
+exactly. That doesn't follow from anything cited: Plotkin's proof is about
+syntactic recoverability of term structure via substitution, not about
+semantic reproduction of real-world, potentially non-idempotent effects.
+Asserting it as inherited rigor was the exact overclaiming failure mode this
+document is otherwise careful to avoid, applied to itself.
+
+The honest version: **fidelity is a requirement this system has to be
+engineered to satisfy, not a property that falls out of the math for free.**
+Concretely, it needs:
+- A defined notion of what "reproduce effects" means per Capability — some
+  effects are naturally idempotent (a `kubectl apply` of the same manifest),
+  many are not (anything that appends, increments, or has external
+  side-state).
+- A replay-testing mechanism — running `ExecuteInterpretation(g, σᵢ)` in a
+  sandboxed/simulated mode and comparing against the recorded Trace it was
+  generalized from — as an actual test oracle for DedupGate's `Merge`
+  decisions, not an assumption they satisfy automatically.
+- Explicit handling for Capabilities that can't be safely replay-tested at
+  all (destructive, non-idempotent operations) — these may need to stay
+  ungeneralized, or require the human review step (§3.6) to certify fidelity
+  manually rather than mechanically.
+
+This is real, non-trivial engineering scoped to Phase 5 (§7), not resolved
+here.
 
 ### 3.6 DedupGate, CatalogEntry, Discovery, Task, LLMFallback
 
-- **DedupGate** — takes a freshly-generalized candidate Rule, anti-unifies it
-  against the existing Catalog, and yields `Reject`, `Merge`, or `Admit`. Both
-  `Admit` and `Merge` require human review before the result becomes a live
-  CatalogEntry — `Admit`, because that's `scratch-command-bar`'s and
-  administration-commons' existing precedent (mandatory review before commons
-  entry, full stop, not scoped to merges only); `Merge` additionally because
-  of §4.6's finding on graph merge specifically — it is not safe to
-  auto-resolve, the same way TerminusDB/Fluree's real merge strategies flag
-  rather than silently combine overlapping subgraphs. Only `Reject` skips
-  review, since nothing changes.
-- **CatalogEntry** — `⊑ Rule`, admitted or merged by DedupGate. Carries a
-  Description for Discovery's retrieval.
-- **Discovery** — search over CatalogEntry only (progressive disclosure, hybrid
-  keyword+embedding), never over un-admitted Rules. Conflict resolution when
-  multiple entries match: recency first, specificity as tiebreaker, per the
-  CLIPS LEX precedent (§4.7) — not specificity-first, which was the more
-  intuitive but unverified assumption going in.
-- **Task** — the entry point. Triggers Discovery; a confident match invokes that
-  CatalogEntry's ExecuteInterpretation directly (zero LLM calls); no match
-  triggers **LLMFallback**, whose resulting Trace feeds Generalization →
-  DedupGate → possibly a new CatalogEntry.
+- **DedupGate** — anti-unifies a freshly-generalized candidate against the
+  Catalog and yields `Reject`, `Merge`, or `Admit`. Both `Admit` and `Merge`
+  require human review before the result is live — `Admit` because that's
+  `scratch-command-bar`'s and administration-commons' existing precedent
+  (review before any commons entry, not scoped to merges); `Merge`
+  additionally because graph three-way merge is provably weaker than git's
+  line-based merge: RDF's unordered-set structure lets adds/removes combine
+  mechanically without ever raising a syntactic conflict, which can silently
+  produce a semantically wrong result (Quit Store and Touch Merge's academic
+  treatment of exactly this failure mode; re-verified in an earlier pass of
+  this process, not the final one). `Reject` skips review — nothing changes.
+- **CatalogEntry** — `⊑ Rule`, admitted or merged by DedupGate, subject to
+  §3.4's admission consequence (no zero-parameter entries). Carries a
+  Description for Discovery.
+- **Discovery** — search over CatalogEntry only. Two sub-capabilities with
+  different readiness timelines (§7): exact/keyword lookup by name (viable
+  as soon as any CatalogEntry exists) and hybrid keyword+embedding
+  progressive disclosure (only useful once there's a catalog large enough to
+  need it). Conflict resolution when multiple entries match: recency first,
+  specificity as tiebreaker (CLIPS's LEX strategy; re-verified in an earlier
+  pass, not the final one).
+- **Task** — the entry point. Triggers Discovery; a confident match invokes
+  that CatalogEntry's ExecuteInterpretation directly; no match triggers
+  **LLMFallback**, whose resulting Trace feeds Generalization → DedupGate →
+  possibly a new CatalogEntry, subject to the admission consequence above.
 
-## 4. Grounding — what's established vs. what's this design's own synthesis
+## 4. Grounding
 
-Condensed from the research this spec is built on; kept here so the rationale
-travels with the design rather than living only in conversation history.
+**4.1 Rule dialects — corrected.** Institution theory covers Horn Clause
+Logic as a genuine sub-institution of first-order logic (Diaconescu 2006,
+re-verified against the primary source in this revision's final pass) —
+that's real and precise. What's *not* established, and wasn't hedged
+carefully enough in the first draft: Soufflé's extended Datalog (aggregation,
+stratified negation) and both SPARQL-RL and SHACL 1.2 Rules go beyond pure
+Horn Clause Logic. The institution-theoretic grounding for Dialect covers the
+Horn-clause *core* of what these dialects express, not their full extent —
+stated honestly here, matching the hedging discipline §4.2 already applied
+to the anti-unification/institution-theory question. Soufflé's hard
+requirement that user-defined functors stay pure and reentrant (re-verified
+against Soufflé's own docs in this revision's final pass — a genuine "must,"
+execution guarantees void otherwise) remains real, independent validation
+that effects belong in a separate interpreter, never a live call inside the
+pure evaluator.
 
-**4.1 Rule dialects.** Institution theory legitimately covers this axis (HCL as a
-sub-institution of FOL, Diaconescu 2006). SPARQL-RL (the W3C's emerging successor
-to what would have been "SHACL 1.2 Rules") is the target dialect to track. Soufflé
-is the reference engine — and its hard requirement that foreign functors stay pure
-is independent, real-world validation that effects must be a *separate
-interpreter*, never a live call inside the pure evaluator.
+**4.2 Anti-unification — corrected, with a real design consequence.**
+Plotkin/Reynolds (1970) is correctly the source for flat first-order
+syntactic anti-unification, proven unitary (a unique lgg always exists).
+It is **not** the source for term-graph anti-unification, and the first
+draft's citation was wrong. The actual term-graph result (Baumgartner,
+Kutsia, Levy & Villaret, FSCD 2018) proves the *general* term-graph case is
+only **finitary** — a finite, minimal, but not necessarily singleton set of
+incomparable generalizations can exist. Unitarity (one unique lgg) is proven
+only for the narrower special case of **bisimilar term-graphs**.
 
-**4.2 Anti-unification.** Plotkin/Reynolds 1970. Proven "unitary" (a unique
-least-general-generalization always exists) in the term-graph fragment — this is
-why the Rule representation must stay inside that fragment, not drift into
-unrestricted higher-order structure, where the guarantee provably collapses.
-Minimizing the number of generalization variables is NP-hard in the closest
-scalable formalism (Yernaux & Vanhoof 2022) — accept a bounded/greedy
-generalization, not a promised-minimal one. No established literature connects
-anti-unification to institution theory or to rule-specificity ordering — both
-would be novel contributions of this design, not citations.
+This has a real consequence the first draft's overclaim was hiding: **the
+Rule representation needs to be restricted to the bisimilar-graph fragment
+specifically**, not just "the term-graph fragment" generally, if DedupGate is
+to assume a single canonical generalization rather than needing to arbitrate
+among several incomparable ones. Whether the workflow-graph shape this
+system needs (typed steps, branch/loop/call) can be constrained to stay
+inside that narrower fragment, or whether DedupGate genuinely needs to
+handle a finite set of candidates and let human review pick among them, is
+now an explicit open question (§8) rather than a settled fact. Minimizing
+generalization variables remains NP-complete in the closest scalable
+formalism (Yernaux & Vanhoof 2022, unordered goals — re-verified precisely
+in this revision's final pass, confirmed as NP-complete, a stronger result
+than the "NP-hard" the first draft stated) — accept a bounded/greedy
+generalization regardless of which fragment is chosen.
 
-**4.3 Execution kernel.** WASI Preview 2 deliberately excludes fork/exec/subprocess
-spawning (security-by-default). WASIX is the real, separate superset that restores
-it. The kernel's one true primitive is "execute a capability-scoped WASM
-component"; subprocess spawning is one optional, explicitly-granted capability
-among others — present on this box (so `git`/`kubectl`/`terraform` keep working
-unmodified), absent by default anywhere that shouldn't need it.
+**4.3 Execution kernel.** WASI Preview 2 excludes fork/exec/subprocess
+spawning by design; WASIX is the separate superset restoring it. Kernel
+primitive: "execute a capability-scoped WASM component," subprocess
+spawning one optional grantable Capability among others. (Re-verified in an
+earlier pass, not this revision's final one.)
 
-**4.4 Bitemporal facts.** Datomic is unitemporal (transaction-time only) — not a
-positive precedent, despite earlier treatment as one. XTDB's two-axis model
-(system-assigned transaction-time, user-assigned valid-time defaulting to
-transaction-time) is the target shape, encoded via RDF-star annotations using
-OWL-Time's Allen-relation vocabulary for interval comparisons. Important limit:
-valid-time must be duplicated into ordinary queryable fact form for the
-derivation layer to reason over it — XTDB's own bitemporal indexing only
-controls *which document version* a query sees, it doesn't make valid-time a
-first-class joinable relation for free.
+**4.4 Bitemporal facts.** Datomic is unitemporal; XTDB's two-axis model
+(system transaction-time, user-assigned valid-time) is the target shape,
+via RDF-star + OWL-Time. Valid-time must be duplicated into ordinary
+queryable fact form for the derivation layer to reason over it — XTDB's
+indexing alone only controls which document version a query sees. (Re-verified
+in an earlier pass, not this revision's final one.)
 
-**4.5 Versioning.** TerminusDB and Fluree are real, current, git-modeled graph
-databases. Graph three-way merge is provably weaker than git's text merge (RDF's
-unordered-set structure lets adds/removes combine mechanically without ever
-raising a syntactic conflict, which can silently produce a semantically wrong
-result) — hence §3.6's rule that `Merge` always requires human review.
+**4.5 Versioning.** TerminusDB and Fluree implement git's model over graph
+data; graph three-way merge is weaker than git's (see §3.6). (Re-verified in
+an earlier pass, not this revision's final one — maintenance-status claims
+about both projects specifically should be treated as time-sensitive and
+worth a fresh check before Phase 6 planning starts, not assumed current
+indefinitely.)
 
-**4.6 Parallelism.** Soufflé's mechanism is real and specific: compile-time
-`par...endpar` blocks lowered to OpenMP-annotated C++, backed by purpose-built
-concurrent data structures (a concurrent B-tree, a concurrent trie called
-"Brie"). This is the adoptable answer for QueryInterpretation. ExecuteInterpretation
-concurrency (§2) has no equivalent answer and is explicitly open.
+**4.6 Parallelism — fully re-confirmed in this revision's final pass, with
+more precision than the first draft had.** Soufflé compiles `par...endpar`
+blocks to OpenMP-annotated C++ (GCC's OpenMP runtime, threads pinned to
+cores) implementing semi-naive evaluation — not runtime interpretation.
+Backed by two purpose-built concurrent structures: a concurrent B-tree
+(optimistic fine-grained locking extending seqlocks, plus a traversal-reuse
+"hints" mechanism) and Brie, a concurrent trie hybridizing trie/B-tree design
+with lock-free insertion. This is the adoptable answer for
+QueryInterpretation. ExecuteInterpretation concurrency has no equivalent
+answer and stays explicitly open (§2, §7 Phase 4b).
 
-**4.7 Conflict resolution.** CLIPS's LEX strategy checks recency before
-specificity, specificity only as the final tiebreaker — informs Discovery's
-ordering (§3.6).
+**4.7 Conflict resolution.** CLIPS's LEX strategy: recency checked before
+specificity, specificity only the final tiebreaker. (Re-verified in an
+earlier pass, not this revision's final one.)
 
-**4.8 Authoring.** LinkML is not a replacement for StreamLD's already-shipped
-SHACL schemas (a safely-deferrable representation choice, since generated SHACL
-is equivalent to hand-written SHACL). It *is* adopted now for the **new** Phase 3
-rule/template schema specifically, because `linkml-datalog` (real, if alpha and
-dormant since Feb 2024) already demonstrates "author in LinkML, generate a
-working Soufflé Datalog program" as a working pattern, not a hypothesis.
+**4.8 Authoring.** LinkML isn't a replacement for StreamLD's shipped SHACL
+schemas — a safely-deferrable representation choice. Adopted now for the
+*new* Phase 3 rule schema specifically: `linkml-datalog` (real, alpha,
+dormant since Feb 2024 as of the last check) already demonstrates "author in
+LinkML, generate a working Soufflé Datalog program" as a working pattern.
+(Re-verified in an earlier pass, not this revision's final one — worth a
+fresh liveness check before depending on it in Phase 3 planning, given how
+long "dormant since Feb 2024" has now been true.)
 
-**4.9 Human review and UI.** External research on review-gate placement and
-generic-shape-driven UI came back with zero verified coverage across two
-independent attempts — treated as a real signal, not bad luck, that these are
-softer practice questions than the rest of this document's grounding. This spec
-uses local precedent instead: `scratch-command-bar`'s working propose/review
-loop and administration-commons' stated principle for *where* human review
-sits (before commons entry), and `graphsheet`'s shipped SHACL-driven UI for
-*how* review/discovery/monitoring surfaces should be built.
+**4.9 Human review, UI, and repo integration.** External research on
+review-gate placement and generic-shape-driven UI came back empty twice —
+treated as a real signal, not bad luck. Uses local precedent instead:
+`scratch-command-bar`'s working propose/review loop, administration-commons'
+stated review principle, `graphsheet`'s shipped SHACL-driven UI. **Added in
+this revision:** this layer is not yet reflected in Riptide's own
+PROGRESS.md sub-project table, which the repo treats as the canonical
+current-status reference — that should happen no later than Phase 2 start,
+not as an afterthought once the whole roadmap is further along.
 
-**4.10 Elixir OAuth.** No existing LinkML-Elixir or general Elixir Datalog
-ecosystem to lean on (`lambdaclass/datalog` is a dead stub; `fogfish/datalog`
-is real but dormant since 2019 — worth studying, not a dependency to trust
-blindly). The Claude subscription OAuth flow needs porting by hand to Elixir,
-the same real, scoped cost `sovereign-ops` already identified for its own
-agent loop — not a new unknown.
+**4.10 Elixir OAuth.** No Elixir Datalog ecosystem to lean on
+(`lambdaclass/datalog` dead stub; `fogfish/datalog` real, dormant since
+2019). OAuth needs hand-porting to Elixir, the same scoped cost
+`sovereign-ops` already identified for its own agent loop. (Re-verified in
+an earlier pass, not this revision's final one.)
 
-## 5. Diagram (informal — one substrate, six layers, only two of them new)
+## 5. Worked example
+
+Added in this revision — the first draft had none, and the cold review
+correctly flagged that as a real source of the ambiguities it found.
+
+1. **Task**: "deploy the billing service." Discovery finds no matching
+   CatalogEntry (first time this kind of task has occurred). LLMFallback
+   runs: the LLM issues concrete tool calls, producing a ground
+   **Trace** — a zero-parameter Rule whose Body is a specific sequence of
+   capability-reference literals with concrete arguments
+   (`kubectl(apply, "billing.yaml", "prod")`, `kubectl(rollout-status,
+   "billing", "prod")`).
+2. Per §3.4's admission consequence, this single Trace is **not** admitted —
+   it's stored as a Trace with Provenance pointing at nothing (it's the
+   first occurrence), and the Task completes by running it directly under
+   ExecuteInterpretation.
+3. **Weeks later**, a second Task: "deploy the auth service." Discovery again
+   finds no CatalogEntry, but this time a Trace-similarity check (a cheap
+   prefilter, not full anti-unification, over the stored Trace log) surfaces
+   the billing-deploy Trace as a candidate. LLMFallback's new Trace and the
+   old Trace go through **Generalization**: anti-unification finds they
+   agree on `kubectl(apply, ?, "prod")` and `kubectl(rollout-status, ?,
+   "prod")`, diverging only on the manifest/service name — producing a
+   genuinely parameterized Rule with one free parameter, plus the
+   substitutions recovering each original Trace.
+4. This candidate goes to **DedupGate**. The Catalog is empty, so there's
+   nothing to anti-unify against for dedup purposes — it's a novel,
+   admissible candidate (it has a real parameter, satisfying §3.4). Per §3.6,
+   `Admit` requires human review regardless: a reviewer sees the proposed
+   Rule, its Description, and — per §3.5's fidelity requirement — evidence
+   from a sandboxed replay that specializing it back to each original Trace's
+   bindings reproduces each original run.
+5. Reviewer approves. It becomes a **CatalogEntry**: `deploy-service-to-prod`,
+   one parameter (`service`).
+6. **Third occurrence**: Task "deploy the auth service" (again, or a
+   different service) now hits Discovery's exact/keyword lookup, finds the
+   CatalogEntry directly, and runs `ExecuteInterpretation` with the bound
+   parameter — zero LLM calls.
+
+## 6. Diagram
 
 ```
-  Content / domain           (lattice, MiKaDiv, KaFE — unaffected by this spec)
+  Content / domain           (lattice, MiKaDiv, KaFE — unaffected)
   Extraction / population    (scratch-command-bar's pattern — LLMFallback + review)
-  ── new in this spec ──────────────────────────────────────────
-  Discovery                  (§3.6 — catalog search)
-  Anti-unification / DedupGate (§3.4, §3.6 — generalize, dedup, human-reviewed merge)
-  Interpretation             (§3.5 — Query / Execute, algebraic-effects-inspired)
-  Rule (IDB)                 (§3.2 — SPARQL-RL-targeted, Soufflé-referenced)
+  ── new in this spec, abstraction layers — NOT call order; see §5 for call order ──
+  Discovery
+  Anti-unification / DedupGate
+  Interpretation             (Query / Execute)
+  Rule (IDB)                 (SPARQL-RL / SHACL 1.2 Rules-targeted, Soufflé-referenced)
   ── existing, unchanged ───────────────────────────────────────
-  Execution kernel           (§4.3 — WASI + WASIX capability)
-  Fact / Event (EDB)         (Riptide today, extended with valid-time — §4.4)
+  Execution kernel           (WASI + WASIX capability, tenant-scoped)
+  Fact / Event (EDB)         (Riptide today, extended with valid-time)
 ```
 
-## 6. Phased build order
+## 7. Phased build order
 
-Each phase exists because the next one needs it, not because it's a natural
-checklist item — see the dependency reasoning, not just the sequence.
+1. **Bitemporal fact shape.** Changes what a fact looks like; must land
+   before anything reads/writes facts downstream. Depends on nothing but
+   Riptide as it exists today. Scope detailed in §7.1.
+2. **Execution substrate in isolation.** WASI component execution, the
+   WASIX capability grant, **tenant-scoped from the start** (§3.1) — tested
+   with no Rule representation involved. This phase must also produce the
+   integration point with Riptide's Phase 4c ACP model; shipping a
+   capability-grant mechanism that doesn't yet compose with existing
+   authorization is not acceptable exit criteria for this phase. Add this
+   layer's own entry to PROGRESS.md's sub-project table here, not later
+   (§4.9).
+3. **Pure derivation engine.** Cross-stream joins, recursion, aggregation,
+   query interpretation only. Depends on Phase 1.
+4. **Wiring — split into two sub-phases, correcting the first draft's single
+   "pure wiring" phase that actually hid its hardest problem.**
+   - **4a — mechanical wiring.** Connect Phase 2's substrate and Phase 3's
+     engine: add the execute interpreter, NativeTemplate instances become
+     real (§3.3), `call_template` works for the first time against a small,
+     hand-authored set of NativeTemplates. Genuinely low-risk, no open
+     research questions.
+   - **4b — concurrent-effects design spike.** The problem named in §2 and
+     §4.6: no established theory answers how two concurrent
+     ExecuteInterpretations should be coordinated when they touch
+     overlapping, irreversible resources. This is real, open design work,
+     scoped and staffed as such — not a checklist item inside 4a.
+5. **Anti-unification: Generalization and DedupGate**, including the
+   replay-testing fidelity mechanism from §3.5. Depends on 4a.
+6. **LLM fallback loop.** Last among the "core" phases — needs 5's gate to
+   have somewhere to put its output.
+7. **Discovery — split by readiness, correcting the first draft's
+   single-phase, catalog-must-already-be-large framing.**
+   - **7a — exact/keyword lookup.** Viable as soon as any CatalogEntry
+     exists (as early as Phase 5), giving a real, working walking skeleton
+     (§5's example, end to end) well before the full roadmap ships — the
+     first draft had no demonstrable milestone before the very last phase.
+   - **7b — hybrid keyword+embedding progressive disclosure.** Deferred
+     until the catalog is large enough to need it.
 
-1. **Bitemporal fact shape** (§7, detailed below). First because it changes what a
-   fact *looks like* — every later phase reads/writes facts, so retrofitting this
-   after Rules exist means touching everything downstream. Depends on nothing but
-   Riptide as it exists today.
-2. **Execution kernel in isolation.** WASI component execution, the WASIX
-   capability grant, the native/leaf template set — tested with no rule language
-   involved at all. Independent of Phase 3; only needs to exist before Phase 4.
-3. **Pure derivation engine.** Cross-stream joins, recursion, aggregation, moving
-   toward SPARQL-RL syntax, evaluated with the query interpreter only — no effects.
-   Isolated from Phase 2 so derivation bugs and effect bugs are never tangled
-   together. Depends on Phase 1 (needs the final fact shape).
-4. **Wire Phases 2 and 3 together.** Add the execute interpreter; `call_template`
-   becomes real for the first time. Pure wiring, no new logic — but this is also
-   where §2's concurrent-effects question has to actually get answered, not
-   deferred further.
-5. **Anti-unification: generalization and the DedupGate.** Only meaningful once
-   real rules exist in the engine's own representation (Phase 4).
-6. **LLM fallback loop.** Deliberately last among the "core" phases — the escape
-   hatch for the unknown, with somewhere coherent (Phase 5's gate) to put its
-   output. Starting here, as originally conceived, would have meant a harness with
-   nowhere for its distillations to land.
-7. **Discovery.** Only relevant once Phases 4–6 have produced a catalog worth
-   searching.
+**Ongoing, not sequential:** LinkML authoring (§4.8) applied to each new
+schema as created.
 
-**Ongoing, not sequential:** LinkML authoring (§4.8) applied to each new schema as
-it's created (Phase 1's bitemporal envelope, Phase 3/4's rule schema).
+### 7.1 Phase 1 — ready to plan
 
-## 7. Phase 1 — ready to plan
+- RDF-star `validFrom`/`validTo` annotation convention on individual facts.
+- A defined OWL-Time Allen-relation subset for interval comparisons.
+- ValidTime defaults to TransactionTime when unspecified (XTDB's default).
+- Applies to all new writes in Riptide's existing LDP write path — no new
+  engine, no behavior change beyond the annotation.
+- Deferred to Phase 3+: making ValidTime queryable/joinable in rule logic.
 
-Concrete, bounded scope for the first implementation plan:
+## 8. Open questions
 
-- Define the RDF-star `validFrom`/`validTo` annotation convention for individual
-  facts (quoted-triple syntax, per §4.4).
-- Adopt a defined subset of OWL-Time's Allen-relation vocabulary for interval
-  comparisons (before/after/meets/overlaps/during/starts/finishes/equals, at
-  minimum).
-- ValidTime defaults to TransactionTime when unspecified, matching XTDB's
-  documented default.
-- This becomes the fact-writing convention for all new writes going forward, in
-  Riptide's existing LDP write path — no new engine, no new derivation, no
-  behavior change beyond the added annotation.
-- Explicitly deferred to Phase 3+: making ValidTime queryable/joinable inside
-  rule logic. Phase 1 only establishes that the field exists on facts.
+- OpenFASTER-Standard public governance status.
+- Whether this engine is operationally a separate deployable from Riptide's
+  LDP surface, given Capability grants expand the trusted computing base
+  (§1) — genuinely unresolved, not just undecided by omission.
+- Concurrent-effectful-execution coordination — no established answer;
+  Phase 4b's actual subject matter, not a footnote.
+- Whether the Rule/workflow-graph representation can be constrained to the
+  bisimilar-term-graph fragment where anti-unification is proven unitary, or
+  whether DedupGate must handle a finite set of incomparable generalizations
+  (§4.2) — newly surfaced by this revision, not resolved.
+- Formal versioning/supersedes theory for declarative rules — none found;
+  pragmatic git/TerminusDB model adopted instead.
+- Final Tenant name.
+- Fresh liveness checks needed before depending on them operationally:
+  `linkml-datalog` (dormant since Feb 2024 at last check) and
+  TerminusDB/Fluree's current maintenance status (§4.5, §4.8).
 
-## 8. Open questions (tracked, not blocking)
+## 9. What changed in this revision, and why
 
-- OpenFASTER-Standard public governance status for this layer (§2).
-- Concurrent-effectful-execution coordination theory — no established saga/CRDT
-  answer found; needs a dedicated design spike at Phase 4 (§2, §4.6).
-- Formal versioning/supersedes theory for declarative rules — adopted the
-  pragmatic git/TerminusDB model instead of a formal criterion, since none was
-  found (§4.5).
-- Final Tenant name (§2).
+For anyone comparing against the first draft: this is not a copyedit.
+- §3.2/§3.3/§3.4: Rule's definition now actually accommodates
+  NativeTemplate; Trace is now `⊑ Rule` instead of an incompatible sibling
+  type; Generalization has one consistent type signature (`Rule × Rule →
+  Rule`) instead of three incompatible ones used in different places.
+- §3.5: the Generalization Fidelity "law" is reframed from an inherited
+  proof to an engineering requirement this system has to earn, with a
+  concrete mechanism (replay-testing) instead of an assumption.
+- §4.1: SPARQL-RL is no longer described as succeeding SHACL 1.2 Rules —
+  they're two parallel, currently-live drafts. Institution-theoretic
+  grounding for Dialect is now scoped to the Horn-clause core, not the full
+  extent of the actual target dialects.
+- §4.2: anti-unification's term-graph unitarity claim is correctly
+  attributed (Baumgartner et al. 2018, not Plotkin/Reynolds) and correctly
+  scoped (finitary in general, unitary only for bisimilar graphs) — with a
+  real, newly-surfaced open question this creates for DedupGate.
+- §3.1: Capability is now tenant-scoped and required to compose with
+  Riptide's existing ACP model — a real security gap in the first draft.
+- §7: Phase 4 is split into a genuinely-low-risk wiring step and an
+  honestly-scoped open-research step, instead of one phase mischaracterized
+  as both. Phase 7 is split so a real walking skeleton exists many phases
+  before the end of the roadmap, instead of no working demonstration until
+  everything ships.
+- §5 (worked example) and §1's deployment-scope narrowing are new; both were
+  gaps a cold reader flagged, not refinements of something already there.

--- a/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
+++ b/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
@@ -1,15 +1,22 @@
 # Derivation and Execution Layer — Architecture Design
 
-**Status:** Draft, second substantive revision. This is one architecture spec
-defining several sub-projects (§7) — each gets its own implementation plan
-(`writing-plans`) when work on it starts. This revision adds the public
-Pattern Hub and ontology Crosswalk mechanism, corrects a mis-scoped
-institution-theoretic claim caught by dedicated verification, closes a real
-consistency gap between observing external state and the fidelity
-requirement, and folds `administration-commons` in as superseded rather than
-something to reconcile with — see §10 for the itemized changelog.
+**Status:** Draft, third revision — a currency pass against Riptide's actual
+current state and external facts this document depends on, not new design
+work. This is one architecture spec defining a single new top-level
+Riptide sub-project, **Sub-project 6**, decomposed into phases 6a–6i, the
+same way Riptide's own sub-projects 3, 4, and 5 are already decomposed.
+Each phase gets its own implementation plan (`writing-plans`) when work on
+it starts. See §11 for the itemized changelog across all three revisions.
 
 ## 1. Motivation and vision
+
+**Riptide's production-readiness roadmap (its own sub-projects 1–5:
+persistence, Docker/CI, clustering/HA, security/multi-tenancy,
+observability) is complete as of today**, per `PROGRESS.md`. This spec's
+work is the first thing built on top of that now-stable foundation, not a
+parallel effort competing with an unfinished one — worth stating plainly,
+since most of this document was drafted while that roadmap was still
+in flight.
 
 Riptide today is an event-sourced fact store: an append-only, per-resource
 log of RDF facts, with one hardcoded derivation. This spec adds the layer
@@ -21,39 +28,33 @@ by one engine.
 The organizing idea: **the atomic unit should have a stable identity, and
 everything else should be a *view* derived from that identity, never the
 identity itself.** This spec extends that discipline from facts to rules,
-and — new in this revision — to the *vocabularies rules are expressed in*,
-which is what §6 (Pattern Hub) and §6.5 (Crosswalks) are for. The same
-underlying instinct shows up a third time there: when no existing bridge
-covers something (no matching prior Trace, no matching CatalogEntry, no
-matching Crosswalk), a human/direct-origination step fills the gap once, and
-the bridge gets built incrementally from real use — never front-loaded.
-That's not three separate design choices; it's one discipline, applied
-consistently, which is itself evidence the design is coherent rather than a
-pile of individually-plausible ideas.
+and to the *vocabularies rules are expressed in* (§6, Pattern Hub; §6.5,
+Crosswalks). The same underlying instinct shows up a third time there: when
+no existing bridge covers something (no matching prior Trace, no matching
+CatalogEntry, no matching Crosswalk), a human/direct-origination step fills
+the gap once, and the bridge gets built incrementally from real use — never
+front-loaded. Not three separate design choices; one discipline, applied
+consistently.
 
 **What's settled about deployment, and what isn't.** Settled: this layer
 shares Riptide's Fact store, Rule representation, and Signature/Dialect
-definitions as one substrate. Not settled, and not asserted here: whether
-the engine runs in the same OS process as Riptide's existing LDP surface —
-genuinely open, see §9.
+definitions as one substrate. Not settled: whether the engine runs in the
+same OS process as Riptide's existing LDP surface — genuinely open, §10.
 
 ## 2. Scope
 
-**In scope:** the object model (§3–6), the grounding for each decision (§8),
-two worked examples (§9), and the sub-project breakdown (§7).
+**In scope:** the object model (§3–6), the grounding for each decision
+(§8), two worked examples (§9), and Sub-project 6's phase breakdown (§7).
 
 **`administration-commons` note.** An earlier local project used the term
-"pattern" for a similar idea and sketched its own kernel (content-addressed
-store, Merkle log, WASI executor). It's superseded by this work, not
-something this spec reconciles with — noted here once so a future reader
-finding that repo isn't confused about which is current.
+"pattern" for a similar idea and sketched its own kernel. Superseded by
+this work, not something this spec reconciles with.
 
-**Explicitly still open** (§9 for the full list): concurrent-effectful-
+**Explicitly still open** (§10 for the full list): concurrent-effectful-
 execution coordination; whether this engine is a separate deployable from
-Riptide's LDP surface; formal versioning/supersedes theory for rules (a
-pragmatic git-like model is adopted instead); the final Tenant name; and,
-new in this revision, automated detection of ontology overlap (deliberately
-out of scope *by design*, not by gap — see §6.5).
+Riptide's LDP surface; formal versioning/supersedes theory for rules;
+the final Tenant name; automated detection of ontology overlap (out of
+scope *by design*, §6.5).
 
 ## 3. Core concepts — facts and rules
 
@@ -66,80 +67,79 @@ out of scope *by design*, not by gap — see §6.5).
   an isolated administrative/institutional space. Facts, Rules,
   CatalogEntries, and Capabilities are all tenant-partitioned. A Capability
   grant in one Tenant is never exercisable by a Rule in another; this
-  composes with Riptide's existing Phase 4c ACP authorization, not a
-  parallel system.
+  composes with Riptide's shipped Phase 4c ACP authorization (default-deny,
+  container-level inheritance, deny-overrides-allow, tenant-root bootstrap
+  claim — confirmed accurate against the shipped design, `PROGRESS.md`
+  §4), not a parallel system. **Current note**: this ACP/auth surface is
+  under active security-audit remediation in a sibling branch as of this
+  writing (observed directly, not yet its own committed spec) — Sub-project
+  6b's integration point should target whatever that lands as, not a frozen
+  snapshot of the original Phase 4a–4d design.
 - **A Tenant's vocabulary is observed, not declared.** No separate
   "ontology preference" object. Whichever Signature a Tenant's own Facts
-  happen to already use *is* their working vocabulary for that area — it
-  falls out of usage. A brand-new Tenant installing its first Pattern simply
-  adopts that Pattern's native Signature; there's nothing to translate yet.
-  This removes a concept ("domain area," "ontology preference") that isn't
-  actually needed once Crosswalk resolution (§6.5) is field-level, not
-  whole-ontology: two Signatures with zero overlapping predicates simply
-  coexist, and Crosswalk resolution only engages where fields genuinely
-  overlap.
+  happen to already use *is* their working vocabulary for that area. A
+  brand-new Tenant installing its first Pattern simply adopts that
+  Pattern's native Signature. This works because Crosswalk resolution
+  (§6.5) is field-level, not whole-ontology: two Signatures with zero
+  overlapping predicates simply coexist.
 
 ### 3.2 Signature, Dialect, Rule
 
 - **Signature** — a Rule's typed interface: its parameters and which
   predicates it reads/produces. Institution-theoretically, this is DOL's
-  `Sign`, reused precisely — an arrow in one institution's `Sign` category
-  (confirmed against Goguen & Burstall's own definition; see §8.1).
-- **Dialect** — which concrete rule language a Rule is expressed in. Two
-  candidates tracked in parallel, not one succeeding the other: **SPARQL-RL**
-  and **SHACL 1.2 Rules**, both live W3C Working Drafts on the
-  Recommendation track, developed in parallel by the Data Shapes Working
-  Group. Reference evaluation engine: Soufflé's extended Datalog.
+  `Sign`, reused precisely (§8.1).
+- **Dialect — corrected this revision.** Previously described as two
+  independent, parallel W3C drafts (SPARQL-RL and SHACL 1.2 Rules). **As of
+  a direct re-check today, that's no longer accurate**: the live,
+  always-current URL for "SHACL 1.2 Rules" (`w3.org/TR/shacl12-rules/`) now
+  redirects to `w3.org/TR/sparql12-rl/` — the two appear to have been
+  consolidated by the Data Shapes Working Group into one document under the
+  SPARQL-RL name. The historical dated snapshot
+  (`w3.org/TR/2025/WD-shacl12-rules-20251209/`) is still directly reachable
+  as an archival artifact, per normal W3C practice, but is no longer the
+  current version of anything. **Target Dialect: SPARQL-RL**, tracked as
+  one document, not two — simpler than the prior revision assumed. Worth a
+  fresh check again before Sub-project 6c locks in a concrete grammar,
+  since this is a live Working Draft, not a finished Recommendation.
+  Reference evaluation engine: Soufflé's extended Datalog.
 - **Rule** — a declarative IDB definition over a Signature: given a Body,
   conclude a Head. A Body is a conjunction of three literal kinds:
   - **Fact-pattern literals** — matched against the EDB, classical Datalog.
   - **Capability-reference literals** — a reference to a Capability (§4)
     that ExecuteInterpretation may invoke.
   - **Rule-reference literals** — a call to another Rule, with argument
-    bindings. **Added in this revision, closing a real bug**: the previous
-    version of this document restricted Body to the first two kinds, which
-    made Rule composability — a Template calling other Templates, the whole
-    point of the design — inexpressible. Caught by tracing a real scenario
-    through the model (§9), not by re-reading the document.
+    bindings. Without this, Rule composability (Templates calling other
+    Templates) is inexpressible — caught by tracing a real scenario (§9)
+    through the model, not by re-reading the document.
 
 ## 4. Capability, NativeTemplate, Template
 
-- **Capability** — an explicit, tenant-scoped, grantable permission. Split
-  into two kinds, **new in this revision**, because collapsing them created
-  a real inconsistency (§8.5, §9):
-  - **EffectCapability** — changes something in the world (deploy a
-    service). Fidelity replay-testing (§5) actually re-invokes it,
-    sandboxed, and compares against the recorded Trace.
+- **Capability** — an explicit, tenant-scoped, grantable permission. Two
+  kinds:
+  - **EffectCapability** — changes something in the world. Fidelity
+    replay-testing (§5) re-invokes it, sandboxed, and compares against the
+    recorded Trace.
   - **ObserveCapability** — reads external state and asserts the result as
-    new Facts, changing nothing external (check whether a filing already
-    exists). Fidelity replay-testing does *not* re-invoke the real external
-    system — the world isn't expected to be frozen between runs. It replays
-    the response recorded in Provenance instead, and checks that downstream
-    Rule logic behaves consistently given that recorded response. This
-    means an ObserveCapability's Provenance must record the actual observed
-    data, not just which capability was called with which parameters.
-  - Both kinds carry a **StabilityClass** — `documented` (a stable, versioned
-    public interface) or `undocumented` (a reverse-engineered or otherwise
-    unversioned interface, liable to silent breakage). This doesn't solve
-    fragility; it makes it visible and queryable. Discovery (§6) uses it as
-    a ranking input alongside recency/specificity when multiple
-    CatalogEntries could satisfy the same Task — this is not a new
-    selection mechanism, it's one more input to the mechanism §6 already
-    has.
+    new Facts, changing nothing external. Fidelity replay-testing does
+    *not* re-invoke the real external system — it replays the response
+    recorded in Provenance, since the external world isn't expected to be
+    frozen between runs.
+  - Both kinds carry a **StabilityClass** — `documented` or `undocumented`
+    (reverse-engineered, liable to silent breakage). Discovery (§6) uses it
+    as a ranking input alongside recency/specificity.
   - Backed by WASI Preview 2 (no ambient authority, no subprocess spawning
     by design) plus WASIX where subprocess spawning is specifically
     granted (§8.3).
 - **NativeTemplate** — a Rule whose Body is exactly one capability-reference
   literal. The base case, backed by a real, capability-scoped WASI
-  component. Sequencing note: Sub-project 2 (§7) builds the WASI execution
+  component. Sequencing note: Sub-project 6b (§7) builds the WASI execution
   substrate standalone, with no Rule representation involved — it doesn't
-  produce NativeTemplate instances yet, since NativeTemplate is a Rule and
-  Rule's representation isn't built until Sub-project 3. Sub-project 4 is
-  what wraps Sub-project 2's substrate as actual NativeTemplate instances.
+  produce NativeTemplate instances yet, since Rule's representation isn't
+  built until 6c. 6d is what wraps 6b's substrate as actual NativeTemplate
+  instances.
 - **Template** — `Template ⊑ Rule ⊓ (∃ a reachable step whose
-  ExecuteInterpretation invokes a Capability)`. A structural (graph-
-  reachability) predicate over the one Rule representation everything
-  shares — not a separate primitive.
+  ExecuteInterpretation invokes a Capability)`. A structural predicate over
+  the one Rule representation everything shares — not a separate primitive.
 
 ## 5. Trace, Generalization, Interpretation, Provenance
 
@@ -147,212 +147,135 @@ out of scope *by design*, not by gap — see §6.5).
   value already ground, from one concrete run.
 - **Generalization — uniformly `Rule × Rule → Rule`.** Anti-unification
   (Plotkin 1970) computes the least-general-generalization of any two
-  Rules, whether both ground, one ground and one not, or neither. One
-  operation, one type signature, used identically wherever it appears in
-  §6's pipeline. Always accompanied by the recovering substitutions and by
+  Rules. Always accompanied by the recovering substitutions and by
   mandatory **Provenance**.
-- **Admission consequence**: a Rule generalized from only one Trace (still
-  ground, zero free parameters) is not admissible anywhere — a
-  zero-parameter "template" isn't reusable. Admission (§6) requires at
-  least one real Generalization step.
+- **Admission consequence**: a Rule generalized from only one Trace is not
+  admissible anywhere — a zero-parameter "template" isn't reusable.
+  Admission (§6) requires at least one real Generalization step.
 - **Interpretation** — `(Rule, Bindings, EDB-state) → Outcome`. At least
-  **QueryInterpretation** (pure, Outcome ⊑ new Facts, capability-reference
-  literals inert) and **ExecuteInterpretation** (capability-reference
-  literals actually invoked; Outcome may include both effects and, for
-  ObserveCapability steps, newly-observed Facts — the same shape
-  QueryInterpretation produces, just externally sourced). More modes
-  expected later (dry-run, cost-estimate, explain/audit). Algebraic
-  effects/handler theory is the closest established formalism for this
-  shape; neither it nor tagless-final is a proof this specific design is
-  correct — real inspiration, not borrowed authority (re-verified in an
-  earlier pass of this process, not this revision's final one).
+  **QueryInterpretation** (pure) and **ExecuteInterpretation** (capability-
+  reference literals actually invoked; Outcome may include effects and,
+  for ObserveCapability steps, newly-observed Facts). More modes expected
+  later. Algebraic effects/handler theory is the closest established
+  formalism for this shape; not a proof this specific design is correct.
 - **Generalization Fidelity — an engineering requirement, not an inherited
-  proof.** Anti-unification proves syntactic recoverability of term
-  structure, not semantic reproduction of real-world effects. The actual
-  requirement: for a Generalization `g` from Traces `t₁, t₂` with
-  substitutions `σ₁, σ₂`, `ExecuteInterpretation(g, σᵢ)` should reproduce
-  `tᵢ`'s effects, verified by sandboxed replay-testing — with the kind-
-  specific replay semantics from §4 (EffectCapability re-invoked and
-  compared; ObserveCapability replayed from its recorded response, never
-  re-queried live). Capabilities that can't be safely replay-tested at all
-  (destructive, non-idempotent) may need to stay ungeneralized, or require
-  the human reviewer (§6) to certify fidelity manually. Real engineering,
-  scoped to Sub-project 5, not resolved here.
+  proof.** For a Generalization `g` from Traces `t₁, t₂` with substitutions
+  `σ₁, σ₂`, `ExecuteInterpretation(g, σᵢ)` should reproduce `tᵢ`'s effects,
+  verified by sandboxed replay-testing with the kind-specific semantics
+  from §4. Capabilities that can't be safely replay-tested may need to
+  stay ungeneralized, or require human certification (§6). Real
+  engineering, scoped to Sub-project 6e.
 - **Provenance** — the dependency edge back to what a Rule was generalized
-  or installed from (§6.5). What keeps a derived Rule from becoming an
-  ungoverned second source of truth.
+  or installed from (§6.5).
 
 ## 6. Catalog, DedupGate, Discovery, Task, LLMFallback, Pattern
 
-**Catalog is parameterized by scope: `Tenant` or `Hub`.** This is new in
-this revision and replaces an earlier, unresolved question about whether
-the public hub needed its own separate curation mechanism — it doesn't. One
-mechanism, two scopes:
+**Catalog is parameterized by scope: `Tenant` or `Hub`.** One mechanism,
+two scopes:
 
 - **DedupGate** — anti-unifies a freshly-generalized candidate against its
-  Catalog (whichever scope) and yields `Reject`, `Merge`, or `Admit`. Both
-  `Admit` and `Merge` require human review before the result is live —
-  `Admit` because review-before-entry is the working precedent this whole
-  process already established (`scratch-command-bar`'s propose/review
-  loop); `Merge` additionally because graph three-way merge is provably
-  weaker than git's — RDF's unordered-set structure lets adds/removes
-  combine mechanically without ever raising a syntactic conflict, silently
-  producing a semantically wrong result. `Reject` skips review.
+  Catalog and yields `Reject`, `Merge`, or `Admit`. Both `Admit` and
+  `Merge` require human review before the result is live — `Admit` per
+  `scratch-command-bar`'s existing propose/review precedent; `Merge`
+  additionally because graph three-way merge is provably weaker than
+  git's. `Reject` skips review.
 - **CatalogEntry** — `⊑ Rule`, admitted or merged by DedupGate, subject to
   §5's admission consequence.
 - **Pattern is not a separate type.** It's the name for a CatalogEntry at
-  **Hub** scope — a published, human-validated, publicly-installable unit.
-  Everything else about it (Signature, Dialect, Body, Provenance) is
-  ordinary CatalogEntry structure. Reusing "Pattern" as a name (not a new
-  formal type) matters for a concrete reason: this generalizes to *any*
-  computer-doable action — "extract page 2 of this PDF" is as much a
-  Pattern as a tax-form submission is — and giving it a second, narrower
-  formal type would misrepresent that scope.
-- **Discovery** — search over CatalogEntry (either scope). Two
-  sub-capabilities with different readiness: exact/keyword lookup (viable
-  as soon as any CatalogEntry exists) and hybrid keyword+embedding
-  progressive disclosure (once the catalog is large). Conflict resolution
-  when multiple entries match: recency, then StabilityClass (§4), then
-  specificity as final tiebreaker — extending, not replacing, CLIPS's LEX
-  precedent (recency before specificity) with the one new ranking input
-  this revision added.
+  **Hub** scope — a published, human-validated, publicly-installable unit,
+  generalizing to *any* computer-doable action, not an administrative-only
+  subset.
+- **Discovery** — search over CatalogEntry (either scope). Exact/keyword
+  lookup (viable as soon as any CatalogEntry exists) and, later, hybrid
+  keyword+embedding progressive disclosure. Conflict resolution: recency,
+  then StabilityClass, then specificity as final tiebreaker.
 - **Task** — the entry point. Triggers Discovery against the Tenant's own
   Catalog; a confident match invokes that CatalogEntry directly; no match
   triggers **LLMFallback**, whose resulting Trace feeds Generalization →
   DedupGate (Tenant scope) → possibly a new local CatalogEntry.
-- **Install** — `CatalogEntry(Hub) × Tenant → CatalogEntry(Tenant)`, the
-  operation for adopting a public Pattern (§6.5 covers the mechanism in
-  full). Its result goes through the same DedupGate as any other candidate
-  entering the Tenant's local Catalog — review scope is narrower than a
-  fresh `Admit` (confirming the specific field bindings are correct for
-  this Tenant, not re-reviewing content the Hub already curated), but it's
-  the same gate, not a separate mechanism.
+- **Install** — `CatalogEntry(Hub) × Tenant → CatalogEntry(Tenant)` (§6.5),
+  going through the same DedupGate as any tenant-local candidate, with a
+  narrower review scope (confirming field bindings, not re-reviewing
+  already-curated content).
 
-### 6.5 Crosswalk — corrected from an earlier draft's overreach
+### 6.5 Crosswalk
 
-Installing a Hub Pattern against a Tenant whose own vocabulary differs
-requires translating some of the Pattern's Signature fields. What that
-translation actually *is*, formally, was mis-scoped in an earlier version
-of this document and has now been checked properly rather than asserted:
+- **Same-Dialect translation** (the common case, especially now that §3.2
+  consolidates the Dialect target to one document): a **signature
+  morphism** — an arrow within one institution's `Sign` category, already
+  this document's own vocabulary. Soundness vocabulary, if ever checked:
+  model-conservativeness / Mod-strictness / Sen-maximality.
+- **Cross-Dialect translation**: a full **comorphism** — categorically
+  heavier, and the case where the sublogic/embedding/faithful/(weakly)
+  exact fidelity scale actually applies (per DOL's own worked practice). An
+  earlier draft proposed modeling *all* Crosswalks as comorphisms; checked
+  against the primary literature, that was wrong for the same-Dialect
+  case, which is the common one.
+- **Human-facing representation, either case: SSSOM** —
+  `exact_match`/`close_match`/`broad_match`/`narrow_match`/`related_match`,
+  a curator's practical judgment ("fitness for purpose," explicitly not a
+  claim of model-theoretic equivalence, per SSSOM's own specification),
+  available for later optional strengthening into a formally-checked
+  morphism, never a prerequisite for use.
+- **Detection of overlap is human-only, by design, for now.** A curator
+  proposes a Crosswalk entry; it goes through the same Hub-scope DedupGate
+  as any other Hub content.
+- **Crosswalks are Hub-scope content**; a Tenant's actual vocabulary
+  commitment (§3.1) is the one genuinely tenant-local fact.
+- **Installation with partial coverage**: per Signature field, look up an
+  existing Crosswalk against the Tenant's established vocabulary. Matched
+  fields bind through it. **Unmatched fields — the Tenant supplies those
+  Facts directly**, in the Pattern's native vocabulary, recorded as
+  manually-originated Provenance. Crosswalks grow incrementally from real
+  installation friction, the same discipline already applied to Traces and
+  Tasks. Degrades to zero friction for thin, uncontested Signatures.
 
-- **When the Pattern and the Tenant's existing vocabulary share a Dialect**
-  (both SPARQL-RL, say), the correct formal tool is a **signature
-  morphism** — an arrow within one institution's `Sign` category. This is
-  established, textbook institution theory (confirmed against Goguen &
-  Burstall's own definition), and it is *already in this document's own
-  vocabulary* — it's the same kind of thing Signature itself already is.
-  No new borrowed machinery needed. If a signature morphism's soundness
-  needs checking, the literature's own vocabulary for that is model-
-  conservativeness / Mod-strictness / Sen-maximality — not the
-  sublogic/embedding/faithful/exact scale, which is documented specifically
-  for the next case, not this one.
-- **When the Pattern and the Tenant's vocabulary are in *different*
-  Dialects** (one SPARQL-RL, one SHACL 1.2 Rules), the correct tool is a
-  full **comorphism** — categorically heavier (a functor between the two
-  Dialects' `Sign` categories plus natural transformations translating
-  their sentences and models), and *this* is where the
-  sublogic/embedding/faithful/(weakly) exact fidelity scale actually
-  applies, per DOL's own worked practice.
-- **An earlier draft of this document proposed modeling all Crosswalks as
-  comorphisms and borrowing that fidelity scale universally. Checked
-  directly against the primary institution-theory literature: that's
-  wrong** for the (more common) same-Dialect case, and the correction
-  matters — it's the difference between reaching for machinery that's
-  already sitting in this document (a signature morphism, essentially a
-  second Signature with a translation) versus machinery that's
-  categorically heavier and was never actually needed for most Crosswalks.
-- **The human-facing representation, regardless of which formal case
-  applies, is SSSOM** — `exact_match`/`close_match`/`broad_match`/
-  `narrow_match`/`related_match`, each with a curator's confidence. This is
-  the right layer for the actual working mechanism, and it composes
-  cleanly with the formal distinction above rather than competing with it:
-  SSSOM's own specification is explicit that these are practical,
-  curatorial judgments calibrated to "fitness for purpose," *not* claims of
-  model-theoretic equivalence — checked directly against SSSOM's own paper,
-  which discusses DOL by name in its related work and never once invokes
-  institution theory, confirming the two are genuinely separate layers, not
-  one dressed as the other. A human curating an `exact_match` is making a
-  practical judgment call, available for later, optional strengthening
-  into a formally-checked signature morphism or comorphism if anyone
-  wants that — never a prerequisite for using the mapping.
-- **Detection of overlap is human-only, by design, for now** — not a gap to
-  fill later with automated ontology-alignment matching, a deliberate
-  scoping decision. A curator proposes a Crosswalk entry (an SSSOM mapping
-  row); it goes through the same Hub-scope DedupGate as any other Hub
-  content.
-- **Crosswalks are Hub-scope content** (a mapping between two named
-  standards is a general, reusable fact, not tenant-specific); which
-  vocabulary a given Tenant has actually settled into, per §3.1, is the one
-  genuinely tenant-local fact.
-- **Installation with partial coverage** — the actual mechanism, precisely:
-  for each field in the Pattern's Signature, look up an existing Crosswalk
-  entry against the Tenant's own established vocabulary. Matched fields
-  bind through the Crosswalk. **Unmatched fields — no Crosswalk entry
-  exists yet — the Tenant is prompted to supply those Facts directly**, in
-  the Pattern's own native vocabulary, since there's nothing to translate
-  from. This is recorded as manually-originated Provenance, not a
-  translation. Crosswalks grow incrementally from real installation
-  friction — the same anti-Xanadu discipline ("the graph should grow from
-  real transactions, not an a priori exhaustive ontology") already applied
-  to Traces (§5) and Tasks (§6), applied a third time here. For a Pattern
-  with a thin, largely-uncontested Signature (page-extraction-shaped
-  actions), this degrades to zero friction — most fields hit exact matches,
-  nothing left to fill in by hand. It only gets elaborate where a domain
-  genuinely has competing standards, which is a property of the domain, not
-  a cost the mechanism imposes uniformly.
+## 7. Sub-project 6: phases
 
-## 7. Sub-projects
+Riptide's own `PROGRESS.md` sub-projects (1–5) are complete; this becomes
+**Sub-project 6**, decomposed the same way sub-projects 3–5 already are.
+Each phase becomes its own spec → plan → implementation cycle.
 
-Each of these becomes its own spec → plan → implementation cycle when work
-on it starts; this document defines their scope and dependencies, not their
-detailed plans.
-
-1. **Bitemporal fact shape.** RDF-star `validFrom`/`validTo`, a defined
-   OWL-Time Allen-relation subset, ValidTime defaulting to TransactionTime.
-   Applies to Riptide's existing LDP write path. Depends on nothing but
-   Riptide as it exists today. Detailed scope: §9.1... *(unchanged from the
-   prior revision; kept minimal here since it's already fully specified and
-   nothing in this revision touches it)*. Deferred to Sub-project 3+:
-   making ValidTime queryable/joinable in rule logic.
-2. **Execution substrate.** WASI component execution, WASIX capability
-   grant, **tenant-scoped and split into EffectCapability/ObserveCapability
-   from the start** (§4) — new requirement in this revision. Must produce
-   the integration point with Riptide's Phase 4c ACP model as an exit
-   criterion, not a follow-up. Tested with no Rule representation involved.
-3. **Pure derivation engine.** Cross-stream joins, recursion, aggregation,
-   query interpretation only. Depends on Sub-project 1.
-4. **Wiring**, split by risk:
-   - **4a — mechanical wiring.** Execute interpreter, real NativeTemplate
-     instances, `call_template` against a small hand-authored set. Low
-     risk.
-   - **4b — concurrent-effects design spike.** No established theory
-     answers coordinating concurrent ExecuteInterpretations over
-     overlapping, irreversible resources (checked: neither sagas nor CRDTs
-     establish this). Real, open design work, not a checklist item inside
-     4a.
-5. **Generalization and DedupGate**, including replay-testing fidelity with
-   the kind-specific (Effect vs. Observe) semantics from §4. Depends on 4a.
-6. **LLM fallback loop.** OAuth ported to Elixir by hand (no ecosystem to
-   lean on — `lambdaclass/datalog` dead, `fogfish/datalog` real but
-   dormant since 2019). Needs Sub-project 5's gate to have somewhere to put
-   its output.
-7. **Discovery**, split by readiness:
-   - **7a — exact/keyword lookup**, viable as soon as any CatalogEntry
-     exists (as early as Sub-project 5) — a real walking skeleton well
-     before the rest of the roadmap ships.
-   - **7b — hybrid keyword+embedding progressive disclosure**, deferred
-     until the catalog is large enough to need it.
-8. **Pattern Hub.** **New in this revision.** Stand up Hub-scope Catalog
-   (§6) as a distinct, publicly-reachable deployment of the same DedupGate
-   mechanism Sub-project 5 already builds — genuinely low new-mechanism
-   risk, since it reuses rather than duplicates. Depends on Sub-project 5.
-9. **Ontology Crosswalks and Installation.** **New in this revision.**
-   SSSOM-shaped Hub-scope Crosswalk content, the Install operation (§6.5),
-   and the human-curation workflow for proposing Crosswalk entries. Depends
-   on Sub-project 8. The signature-morphism/comorphism distinction (§6.5)
-   only needs to inform how Crosswalk correctness is *reasoned about* when
-   questioned — the day-to-day mechanism is SSSOM curation plus DedupGate,
-   which Sub-project 8 already provides.
+- **6a — Bitemporal fact shape.** RDF-star `validFrom`/`validTo`, a defined
+  OWL-Time Allen-relation subset, ValidTime defaulting to TransactionTime.
+  Applies to Riptide's existing LDP write path. **Must build on the
+  already-shipped Phase 3a schema-versioning envelope** (`PROGRESS.md`
+  §3, shipped 2026-08-24) rather than treat the `Event`/`Patch` shape
+  change as a fresh, unaddressed risk — that envelope exists specifically
+  so a struct-shape change like this one doesn't break reading
+  previously-persisted data. Depends on nothing else. Deferred to 6c+:
+  making ValidTime queryable/joinable in rule logic.
+- **6b — Execution substrate.** WASI component execution, WASIX capability
+  grant, tenant-scoped and split into EffectCapability/ObserveCapability
+  from the start. Must produce the integration point with Riptide's
+  *current* ACP model (§3.1's live-audit-remediation note) as an exit
+  criterion. Tested with no Rule representation involved.
+- **6c — Pure derivation engine.** Cross-stream joins, recursion,
+  aggregation, query interpretation only. Depends on 6a.
+- **6d — Wiring**, split by risk:
+  - **6d-i — mechanical wiring.** Execute interpreter, real NativeTemplate
+    instances, `call_template` against a small hand-authored set. Low risk.
+  - **6d-ii — concurrent-effects design spike.** No established theory
+    answers coordinating concurrent ExecuteInterpretations over
+    overlapping, irreversible resources (checked: neither sagas nor CRDTs
+    establish this). Real, open design work.
+- **6e — Generalization and DedupGate**, including replay-testing fidelity
+  with the kind-specific semantics from §4. Depends on 6d-i.
+- **6f — LLM fallback loop.** OAuth ported to Elixir by hand (no ecosystem
+  to lean on — `lambdaclass/datalog` dead, `fogfish/datalog` real but
+  dormant since 2019, re-confirmed today, no change). Needs 6e's gate.
+- **6g — Discovery**, split by readiness:
+  - **6g-i — exact/keyword lookup**, viable as soon as any CatalogEntry
+    exists (as early as 6e) — a real walking skeleton well before the rest
+    of the roadmap ships.
+  - **6g-ii — hybrid keyword+embedding progressive disclosure**, deferred
+    until the catalog is large enough to need it.
+- **6h — Pattern Hub.** Stand up Hub-scope Catalog as a distinct,
+  publicly-reachable deployment of the same DedupGate mechanism 6e already
+  builds. Depends on 6e.
+- **6i — Ontology Crosswalks and Installation.** SSSOM-shaped Hub-scope
+  Crosswalk content, the Install operation, human-curation workflow.
+  Depends on 6h.
 
 **Ongoing, not sequential:** LinkML authoring applied to each new schema as
 created (§8.6).
@@ -361,169 +284,145 @@ created (§8.6).
 
 **8.1 Rule dialects.** Institution theory covers Horn Clause Logic as a
 genuine sub-institution of first-order logic (Diaconescu 2006). Soufflé's
-extended Datalog and both target Dialects go beyond pure Horn Clause Logic —
+extended Datalog and SPARQL-RL (§3.2) go beyond pure Horn Clause Logic —
 the institution-theoretic grounding covers their Horn-clause core, not
-their full extent; stated honestly rather than left implicit. Soufflé's
-hard requirement that user-defined functors stay pure and reentrant remains
-real, independent validation that effects belong in a separate interpreter.
+their full extent. Soufflé's hard requirement that user-defined functors
+stay pure and reentrant remains real, independent validation that effects
+belong in a separate interpreter.
 
 **8.2 Anti-unification.** Plotkin/Reynolds (1970): flat first-order
-syntactic anti-unification, proven unitary. Term-graph anti-unification is
-a *different* result (Baumgartner, Kutsia, Levy & Villaret, FSCD 2018),
-proving the general case only **finitary** (a finite, possibly-plural set
-of incomparable generalizations), with unitarity proven only for the
-narrower bisimilar-term-graph case. Open question this creates, unresolved:
-whether the Rule/workflow-graph representation can be constrained to that
-narrower fragment, or whether DedupGate genuinely needs to arbitrate among
-several incomparable candidates. Minimizing generalization variables is
-NP-complete in the closest scalable formalism (Yernaux & Vanhoof 2022) —
-accept bounded/greedy generalization regardless.
+syntactic anti-unification, proven unitary. Term-graph anti-unification
+(Baumgartner, Kutsia, Levy & Villaret, FSCD 2018) proves the general case
+only **finitary**, with unitarity proven only for the narrower
+bisimilar-term-graph case — open question (§10) whether the Rule
+representation can be constrained there. Minimizing generalization
+variables is NP-complete in the closest scalable formalism (Yernaux &
+Vanhoof 2022).
 
 **8.3 Execution kernel.** WASI Preview 2 excludes fork/exec/subprocess
-spawning by design; WASIX is the separate superset restoring it. Kernel
-primitive: execute a capability-scoped WASM component; subprocess spawning
-one optional grantable capability among others.
+spawning by design; WASIX is the separate superset restoring it.
 
-**8.4 Bitemporal facts.** Datomic is unitemporal; XTDB's two-axis model
-(system transaction-time, user-assigned valid-time) is the target shape,
-via RDF-star + OWL-Time. Valid-time must be duplicated into ordinary
-queryable fact form for the derivation layer to reason over it.
+**8.4 Bitemporal facts.** Datomic is unitemporal; XTDB's two-axis model is
+the target shape, via RDF-star + OWL-Time. Valid-time must be duplicated
+into ordinary queryable fact form for the derivation layer to reason over
+it.
 
-**8.5 Capability kinds — new grounding this revision.** The
-EffectCapability/ObserveCapability split wasn't researched against external
-literature; it fell directly out of tracing a real scenario (§9.2) through
-the model and finding that "replay this to check fidelity" means two
-different things depending on whether the capability changes the world or
-just reads it — re-querying a live external system during a fidelity check
-would fail spuriously whenever that system's real state has simply moved on
-since the original Trace, which isn't a fidelity failure at all. This is
-this document's own synthesis, not a citation, and is presented as such.
+**8.5 Capability kinds.** The EffectCapability/ObserveCapability split
+fell out of tracing §9.2 through the model, not external research — this
+document's own synthesis, presented as such.
 
-**8.6 Authoring.** LinkML adopted for Sub-project 3's rule schema and
-Sub-project 8/9's Pattern and Crosswalk schemas specifically —
-`linkml-datalog` (real, alpha, dormant since Feb 2024 at last check, worth
-a fresh liveness check before depending on it) already demonstrates
-"author in LinkML, generate a working Soufflé Datalog program" as a working
-pattern, not a hypothesis.
+**8.6 Authoring — liveness re-checked today.** LinkML adopted for 6c's
+rule schema and 6h/6i's Pattern and Crosswalk schemas. `linkml-datalog`:
+re-checked, still last pushed 2024-02-14, one open issue, not archived —
+dormant, unchanged from the prior check, worth another look immediately
+before 6c actually depends on it rather than assuming continued dormancy.
 
-**8.7 Versioning.** TerminusDB and Fluree implement git's model over graph
-data; graph three-way merge is weaker than git's (§6's DedupGate `Merge`
-rule). Maintenance-status claims about both projects are time-sensitive and
-worth a fresh check before Sub-project 6 planning.
+**8.7 Versioning — liveness re-checked today.** TerminusDB: last pushed
+2026-08-10 (~2.5 weeks ago), actively maintained. Fluree: last pushed
+2026-08-27 (today), very actively maintained. Both current as of this
+check; graph three-way merge is still weaker than git's (§6's DedupGate
+`Merge` rule) regardless of either project's activity level.
 
 **8.8 Parallelism.** Soufflé compiles `par...endpar` to OpenMP-annotated
 C++ implementing semi-naive evaluation, backed by a concurrent B-tree and
 Brie (a concurrent trie). Adoptable for QueryInterpretation.
-ExecuteInterpretation concurrency has no equivalent answer (§7, Sub-project
-4b).
+ExecuteInterpretation concurrency has no equivalent answer (6d-ii).
 
-**8.9 Signature morphisms vs. comorphisms — the correction driving §6.5.**
-Confirmed directly against Goguen & Burstall's own definitions and
-follow-on literature (Diaconescu; the 2-institutions literature): a
-signature morphism is an arrow within one institution's `Sign` category — a
-translation within one Dialect. A comorphism is a categorically heavier
-triple (a functor between two institutions' `Sign` categories, plus natural
-transformations translating their sentences and models) — needed only when
-crossing between genuinely different Dialects. The
-sublogic/embedding/faithful/(weakly) exact fidelity scale is documented
-specifically for comorphisms; same-institution signature-morphism quality
-uses different, unrelated vocabulary (model-conservativeness,
-Mod-strictness, Sen-maximality) in the literature that actually works
-within one institution. SSSOM's own specification frames its match
-predicates as practical/curatorial ("fitness for purpose," explicitly not
-correctness), and no citable work connects SSSOM/SKOS mappings to
-institution-theoretic morphisms of either kind — confirmed by a direct
-search of SSSOM's own paper, which discusses DOL by name in its related
-work without ever invoking institution theory.
+**8.9 Signature morphisms vs. comorphisms.** A signature morphism is an
+arrow within one institution's `Sign` category — translation within one
+Dialect. A comorphism is categorically heavier (a functor between two
+institutions' `Sign` categories plus natural transformations translating
+sentences and models) — needed only crossing Dialects. The
+sublogic/embedding/faithful/(weakly) exact scale is documented specifically
+for comorphisms; same-institution signature-morphism quality uses
+different vocabulary (model-conservativeness, Mod-strictness,
+Sen-maximality). SSSOM connects formally to neither.
 
-**8.10 Conflict resolution.** CLIPS's LEX strategy: recency checked before
-specificity, specificity the final tiebreaker. StabilityClass (§4) is a new
-ranking input this revision adds ahead of specificity, not documented CLIPS
-behavior — this document's own extension, stated as such.
+**8.10 Conflict resolution.** CLIPS's LEX strategy: recency before
+specificity, specificity the final tiebreaker. StabilityClass is this
+document's own extension to that ordering, not documented CLIPS behavior.
 
 **8.11 Human review, UI, repo integration.** External research on
-review-gate placement and generic-shape-driven UI came back empty twice —
-a real signal, not bad luck. Local precedent used instead:
-`scratch-command-bar`'s propose/review loop, `graphsheet`'s shipped
-SHACL-driven UI. This layer should be reflected in Riptide's own
-PROGRESS.md sub-project table no later than Sub-project 2's start.
+review-gate placement and generic-shape-driven UI came back empty twice.
+Local precedent used instead: `scratch-command-bar`'s propose/review loop,
+`graphsheet`'s shipped SHACL-driven UI. **This work should be added to
+Riptide's `PROGRESS.md` sub-project table as Sub-project 6 no later than
+6b's start** — concrete now that 1–5 are confirmed complete and the table
+has an obvious next row.
 
 ## 9. Worked examples
 
-**9.1 — the clean case (unchanged from the prior revision).** Task "deploy
-the billing service" → no CatalogEntry match → LLMFallback produces a
-ground Trace → not admitted alone (§5) → weeks later, a second, similar
-Task's Trace anti-unifies against the first, producing a genuinely
-parameterized candidate → DedupGate `Admit` with human review, including
-sandboxed-replay fidelity evidence → becomes CatalogEntry
-`deploy-service-to-prod` → a third occurrence hits Discovery's exact lookup
-directly, zero LLM calls.
+**9.1 — the clean case.** Task "deploy the billing service" → no
+CatalogEntry match → LLMFallback produces a ground Trace → not admitted
+alone (§5) → weeks later, a second Task's Trace anti-unifies against the
+first → DedupGate `Admit` with human review and sandboxed-replay fidelity
+evidence → CatalogEntry `deploy-service-to-prod` → a third occurrence hits
+Discovery's exact lookup directly, zero LLM calls.
 
-**9.2 — the case that found real gaps: a German tax filing, walked through
-deliberately, not as a domain this spec builds.** A fresh Tenant, Task
-"file my tax return." Discovery finds nothing (empty Catalog). LLMFallback
-doesn't decompose this into one Trace — it needs, in order:
+**9.2 — the case that found real gaps: a German tax filing**, walked
+through deliberately, not as a domain this spec builds. A fresh Tenant,
+Task "file my tax return." LLMFallback needs, in order: (1) an
+ObserveCapability check with its own ValidTime and recorded-response
+Provenance (§4, §8.5); (2) gathering facts via the same
+extraction-and-review loop `scratch-command-bar` uses — real content-layer
+work, correctly out of scope; (3) an EffectCapability submission, where
+two independently-viable implementations for the same outcome are resolved
+by §6's existing Discovery mechanism (Signature preconditions for
+eligibility, StabilityClass for trust ranking) with no new mechanism
+needed; (4) composability via rule-reference literals, the bug this
+example caught.
 
-1. **An ObserveCapability check**: has this year's filing already been
-   submitted? Queries the external tax authority, asserts the answer as a
-   new Fact with its own ValidTime (per §8.4, distinct from when Riptide
-   learned it). This Fact's Provenance records the actual response, so a
-   later fidelity replay of any Rule built from this Trace replays that
-   recorded answer rather than re-querying — the real external system
-   isn't expected to still say the same thing days or months later, and
-   that's not a fidelity failure (§4, §8.5).
-2. **Gathering the actual facts to file** — no existing Signature in this
-   ecosystem covers personal income tax; the Tenant supplies them via the
-   same extraction-and-review loop `scratch-command-bar` already uses. This
-   is real content-layer work this spec doesn't provide, correctly out of
-   scope (§2) — but the example is worth keeping precisely because it shows
-   *how much* has to exist before "file my tax return" can complete on a
-   fresh instance, which the simpler §9.1 example doesn't reveal.
-3. **An EffectCapability submission.** Two independently-viable
-   implementations exist in principle for the same real-world outcome — a
-   documented official interface and a reverse-engineered one — exactly
-   the shape Discovery's own multi-match resolution (§6) already handles:
-   eligibility differences show up as Signature preconditions (a documented
-   path's CatalogEntry requires a Fact this Tenant may or may not have),
-   and StabilityClass (§4) correctly ranks the documented path over the
-   reverse-engineered one when both apply. No new mechanism needed —
-   genuine validation that §6's existing machinery covers this, not a gap.
-4. Composability (§3.2's rule-reference literals, fixed in this revision)
-   is what lets a `file-annual-return` Rule call a `submit-return` Rule
-   that calls a lower-level submission NativeTemplate — the bug this
-   example caught when it was still missing.
+## 10. Open questions
 
-Nothing about German tax law is proposed as part of this spec's own
-deliverables; this example exists to stress-test the object model against
-something with real regulatory weight, external system fragility, and
-composability requirements a purely infrastructural example wouldn't
-surface.
+- OpenFASTER-Standard public governance status for this work.
+- Whether this engine is operationally a separate deployable from
+  Riptide's LDP surface.
+- Concurrent-effectful-execution coordination (6d-ii's actual subject
+  matter).
+- Whether the Rule/workflow-graph representation can be constrained to the
+  bisimilar-term-graph fragment, or whether DedupGate must arbitrate a
+  finite set of incomparable generalizations (§8.2).
+- Formal versioning/supersedes theory for declarative rules — none found;
+  pragmatic git/TerminusDB model adopted instead.
+- Final Tenant name.
+- `linkml-datalog`'s dormancy — re-check again immediately before 6c
+  depends on it, not just at spec-writing time (§8.6).
 
-## 10. Changelog
+## 11. Changelog
 
-**This revision (second):**
-- Rule's Body gained a rule-reference literal kind — composability was
-  inexpressible without it, caught by §9.2.
-- Capability split into EffectCapability/ObserveCapability with distinct
-  fidelity-replay semantics — caught by the same trace.
-- StabilityClass added, feeding Discovery's existing conflict resolution.
-- Catalog generalized to Tenant/Hub scope; Pattern defined as a name for
-  Hub-scope CatalogEntry, not a new type.
-- Crosswalk mechanism added: SSSOM as the working representation;
-  signature morphisms for same-Dialect translation (corrected from an
-  earlier, wrong instinct to model all of this as comorphisms); comorphisms
-  reserved for genuinely cross-Dialect translation, with the
-  sublogic/embedding/faithful/exact scale now correctly scoped to that case
-  only.
-- Sub-projects 8 and 9 added; the whole document restructured as one spec
-  defining many sub-projects rather than a single phased roadmap.
-- `administration-commons` reframed as superseded, not something to
-  reconcile with.
+**This revision (third) — a currency pass, not new design work:**
+- Restructured all phase numbering from independent "Sub-project 1–9" into
+  a single **Sub-project 6** with phases 6a–6i, avoiding a real collision
+  with Riptide's own `PROGRESS.md` table (its sub-projects 1–5, confirmed
+  complete as of today, use exactly this numbering scheme already).
+- Corrected Dialect (§3.2, §8.1): SHACL 1.2 Rules' current URL now
+  redirects to SPARQL 1.2 RL — the two W3C drafts previously tracked as
+  independent appear to have been consolidated. Target simplified to
+  SPARQL-RL alone.
+- Added the live audit-remediation caveat on Riptide's ACP/auth surface
+  (§3.1) — observed directly as in-progress, uncommitted work on a sibling
+  branch as of this writing.
+- Noted 6a's dependency on the already-shipped Phase 3a schema-versioning
+  envelope (§7), which exists specifically to handle a fact-shape change
+  like this one safely.
+- Re-verified liveness of `linkml-datalog` (unchanged, still dormant),
+  TerminusDB (active), and Fluree (very active, pushed today) against
+  their actual current state, not carried forward from an earlier check
+  (§8.6, §8.7).
+- Noted Riptide's own production-readiness roadmap (sub-projects 1–5) is
+  now complete (§1) — this work is the first thing built on a finished
+  foundation, not alongside an unfinished one.
 
-**Prior revision:** fixed Rule's definition to accommodate NativeTemplate,
+**Second revision:** added the Pattern Hub and Crosswalk mechanism, split
+Capability into Effect/Observe kinds, added rule-reference literals fixing
+a real composability bug, corrected an institution-theory overreach
+(Crosswalks are signature morphisms in the common case, not universally
+comorphisms), added StabilityClass, and reframed `administration-commons`
+as superseded.
+
+**First revision:** fixed Rule's definition to accommodate NativeTemplate,
 made Trace `⊑ Rule` with one consistent Generalization type signature,
-reframed the Generalization Fidelity requirement from an inherited proof to
-an engineering obligation, corrected the SPARQL-RL/SHACL 1.2 Rules
-relationship, corrected the term-graph anti-unification citation and scope,
+reframed Generalization Fidelity from an inherited proof to an engineering
+obligation, corrected the term-graph anti-unification citation and scope,
 added tenant-scoping to Capability, split the wiring phase by risk, and
-added a walking-skeleton milestone before the end of the roadmap.
+added a walking-skeleton milestone.

--- a/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
+++ b/docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md
@@ -1,0 +1,313 @@
+# Derivation and Execution Layer — Architecture Design
+
+**Status:** Draft, pending review. This is an architecture spec covering the full
+vision and a phased roadmap — not a single implementation plan. Each phase below
+gets its own implementation plan (via the `writing-plans` process) when work on it
+starts, per the usual decomposition discipline for a project too large for one plan.
+
+## 1. Motivation and vision
+
+Riptide today is an event-sourced fact store (StreamLD's reference implementation):
+an append-only, per-resource log of RDF facts, with one hardcoded derivation (replay
+a stream's events in order to compute current state). This spec adds the layer that
+was structurally missing: a general **derivation and execution engine**, so that
+"answer a question about the facts" and "cause an effect in the world" become two
+interpretations of the same declarative object, evaluated by one engine, rather than
+bespoke application code per feature.
+
+The organizing idea, carried through every layer of this design: **the atomic unit
+should have a stable identity, and everything else — labels, presentations,
+procedures — should be a *view* derived from that identity, never the identity
+itself.** Riptide's event log already does this for facts (an IRI, never a label,
+is what anything actually references). This spec extends the same discipline to
+*rules* and *capabilities*, so the whole system stays one substrate that things are
+derived from, not several substrates that need reconciling.
+
+This is why the work in this document lives inside Riptide rather than as a
+separate service: once "querying" and "doing" are understood as the same kind of
+operation (two interpretations of one rule, evaluated by one engine — see §3.5),
+there is no natural seam to split into two systems. A separate service calling
+Riptide over an API would reintroduce exactly the two-sources-of-truth problem this
+design exists to avoid.
+
+## 2. Scope and explicit non-goals
+
+**In scope:** the conceptual object model (the T-box, §3), the phased build order
+(§6), and the concrete, ready-to-plan scope of Phase 1 (§7).
+
+**Explicitly out of scope for this document** — flagged as open, not silently
+assumed:
+- Whether this layer ever becomes a public `OpenFASTER-Standard` module (like
+  StreamLD itself) or stays Riptide-internal. Nothing in the roadmap forces this
+  decision before there's something substantial enough to be worth standardizing.
+- Formal theory for coordinating **concurrent effectful** rule executions (e.g. two
+  templates racing on the same Kubernetes namespace). Research specifically
+  checked whether the saga pattern or CRDTs answer this and found neither
+  established for this case — CRDT convergence theory is about merging *data*, not
+  arbitrating *irreversible real-world effects*. This needs its own design spike
+  when Phase 4 is reached, not a borrowed citation.
+- Detailed UI design. `graphsheet` already solves generic-UI-from-shape for SHACL
+  data in this same ecosystem; the review/discovery/monitoring surfaces this layer
+  needs should reuse that pattern rather than be designed from scratch, but the
+  actual screens are not designed here.
+- The final human-facing name for a Riptide tenant. Shortlist from brainstorming:
+  **Polity**, Enclave, Civitas, Demesne. This document uses **Tenant** as a
+  placeholder term throughout; find-and-replace once decided.
+
+## 3. Core concepts (the T-box)
+
+Every concrete technology choice in §4 is an instance of one of these concepts.
+This section is deliberately technology-agnostic.
+
+### 3.1 Fact, Event, Tenant
+
+- **Fact** — an atomic RDF(-star) assertion in the EDB. Carries a *TransactionTime*
+  (free, from Riptide's existing per-stream sequence number) and optionally a
+  *ValidTime* interval, RDF-star-annotated (see §4.4). Produced by exactly one
+  **Event** (an append to a stream).
+- **Tenant** *(name TBD, see §2)* — an isolated administrative/institutional space.
+  Facts, Rules, and CatalogEntries are partitioned by Tenant. A person may hold
+  exactly one "institutional" Tenant plus any number of private Tenants (the
+  long-term ambition motivating the naming question) — this spec does not design
+  the multi-tenancy mechanics themselves, which are Riptide's existing phase-4a
+  work; it only adds Tenant as a T-box concept that Facts and Rules are scoped by.
+
+### 3.2 Signature, Dialect, Rule
+
+- **Signature** — the typed interface of a Rule: its parameters, and which
+  predicates it reads/produces. This is the one piece of literal
+  institution-theoretic vocabulary reused here — precisely, not by analogy,
+  matching DOL's `Sign`.
+- **Dialect** — which concrete rule language a Rule is expressed in (target:
+  SPARQL-RL; reference engine: Soufflé's extended Datalog). This is where real
+  heterogeneity lives, and it is the part institution theory actually, rigorously
+  covers (Horn Clause Logic as a sub-institution of first-order logic).
+- **Rule** — a declarative IDB definition over a Signature: given a Body (a
+  pattern over Facts, possibly self-referential), conclude a Head.
+
+### 3.3 Capability, NativeTemplate, Template
+
+- **Capability** — an explicit, grantable permission (spawn a process, read a
+  path, reach a host) that only a NativeTemplate consumes. Backed by WASI
+  Preview 2 (no ambient authority, no subprocess spawning by design) plus WASIX
+  where subprocess spawning is specifically granted (see §4.3).
+- **NativeTemplate** — a Rule with no further Body — the base case, backed by a
+  real, capability-scoped WASI component. The bootstrapping kernel.
+- **Template** — precisely: `Template ⊑ Rule ⊓ (∃ a reachable step whose
+  ExecuteInterpretation invokes a Capability)`. Not a separate primitive from
+  Rule — a Rule becomes a Template exactly when it does something, not by any
+  structural difference.
+
+### 3.4 Trace, Generalization, Provenance
+
+- **Trace** — a record of one concrete run: a Rule's ExecuteInterpretation with
+  specific bindings, or an ad hoc LLMFallback episode.
+- **Generalization** — `Trace × Trace → Rule`, computed via anti-unification
+  (Plotkin 1970): the least-general-generalization of two concrete instances,
+  always accompanied by the substitutions that recover each original and by
+  mandatory **Provenance** recording what it was generalized from.
+- **Provenance** is what keeps a generalized Rule from becoming an ungoverned,
+  independently-asserted second source of truth — the same discipline a
+  materialized view needs: a dependency edge back to what it was derived from.
+
+### 3.5 Interpretation
+
+A function `(Rule, Bindings, EDB-state) → Outcome`. At least two disjoint kinds:
+- **QueryInterpretation** — pure, Outcome ⊑ new Facts, no side effects. Classical
+  Datalog derivation.
+- **ExecuteInterpretation** — the same Rule, but a designated step may invoke a
+  Capability.
+
+More modes (dry-run/simulate, cost-estimate, explain/audit) are expected later —
+this is deliberately an open, extensible set, not a hardcoded pair. Algebraic
+effects/handler theory (Plotkin & Power; Plotkin & Pretnar) is the closest
+rigorously-established formalism for "one program, many interpretations," and
+tagless-final is the closest established technique for adding new interpreters
+without touching existing code (the expression problem) — both are real,
+well-grounded inspirations for this concept, and neither is a proof that this
+system's specific design is correct. That distinction is intentional and should
+stay explicit in any future writing about this layer, not get smoothed over.
+
+**The Generalization Fidelity law** — the one cross-cutting invariant, earned by
+this design rather than inherited from elsewhere: for any Generalization
+producing Rule `g` from Traces `t₁, t₂` with substitutions `σ₁, σ₂`,
+`ExecuteInterpretation(g, σ₁)` must reproduce `t₁`'s effects exactly, and
+likewise for `t₂`. Generalizing and specializing back must commute with actually
+running the thing. This is the concrete, checkable property any test suite for
+the DedupGate (§3.6) must verify before trusting a merge.
+
+### 3.6 DedupGate, CatalogEntry, Discovery, Task, LLMFallback
+
+- **DedupGate** — takes a freshly-generalized candidate Rule, anti-unifies it
+  against the existing Catalog, and yields `Reject`, `Merge`, or `Admit`. Both
+  `Admit` and `Merge` require human review before the result becomes a live
+  CatalogEntry — `Admit`, because that's `scratch-command-bar`'s and
+  administration-commons' existing precedent (mandatory review before commons
+  entry, full stop, not scoped to merges only); `Merge` additionally because
+  of §4.6's finding on graph merge specifically — it is not safe to
+  auto-resolve, the same way TerminusDB/Fluree's real merge strategies flag
+  rather than silently combine overlapping subgraphs. Only `Reject` skips
+  review, since nothing changes.
+- **CatalogEntry** — `⊑ Rule`, admitted or merged by DedupGate. Carries a
+  Description for Discovery's retrieval.
+- **Discovery** — search over CatalogEntry only (progressive disclosure, hybrid
+  keyword+embedding), never over un-admitted Rules. Conflict resolution when
+  multiple entries match: recency first, specificity as tiebreaker, per the
+  CLIPS LEX precedent (§4.7) — not specificity-first, which was the more
+  intuitive but unverified assumption going in.
+- **Task** — the entry point. Triggers Discovery; a confident match invokes that
+  CatalogEntry's ExecuteInterpretation directly (zero LLM calls); no match
+  triggers **LLMFallback**, whose resulting Trace feeds Generalization →
+  DedupGate → possibly a new CatalogEntry.
+
+## 4. Grounding — what's established vs. what's this design's own synthesis
+
+Condensed from the research this spec is built on; kept here so the rationale
+travels with the design rather than living only in conversation history.
+
+**4.1 Rule dialects.** Institution theory legitimately covers this axis (HCL as a
+sub-institution of FOL, Diaconescu 2006). SPARQL-RL (the W3C's emerging successor
+to what would have been "SHACL 1.2 Rules") is the target dialect to track. Soufflé
+is the reference engine — and its hard requirement that foreign functors stay pure
+is independent, real-world validation that effects must be a *separate
+interpreter*, never a live call inside the pure evaluator.
+
+**4.2 Anti-unification.** Plotkin/Reynolds 1970. Proven "unitary" (a unique
+least-general-generalization always exists) in the term-graph fragment — this is
+why the Rule representation must stay inside that fragment, not drift into
+unrestricted higher-order structure, where the guarantee provably collapses.
+Minimizing the number of generalization variables is NP-hard in the closest
+scalable formalism (Yernaux & Vanhoof 2022) — accept a bounded/greedy
+generalization, not a promised-minimal one. No established literature connects
+anti-unification to institution theory or to rule-specificity ordering — both
+would be novel contributions of this design, not citations.
+
+**4.3 Execution kernel.** WASI Preview 2 deliberately excludes fork/exec/subprocess
+spawning (security-by-default). WASIX is the real, separate superset that restores
+it. The kernel's one true primitive is "execute a capability-scoped WASM
+component"; subprocess spawning is one optional, explicitly-granted capability
+among others — present on this box (so `git`/`kubectl`/`terraform` keep working
+unmodified), absent by default anywhere that shouldn't need it.
+
+**4.4 Bitemporal facts.** Datomic is unitemporal (transaction-time only) — not a
+positive precedent, despite earlier treatment as one. XTDB's two-axis model
+(system-assigned transaction-time, user-assigned valid-time defaulting to
+transaction-time) is the target shape, encoded via RDF-star annotations using
+OWL-Time's Allen-relation vocabulary for interval comparisons. Important limit:
+valid-time must be duplicated into ordinary queryable fact form for the
+derivation layer to reason over it — XTDB's own bitemporal indexing only
+controls *which document version* a query sees, it doesn't make valid-time a
+first-class joinable relation for free.
+
+**4.5 Versioning.** TerminusDB and Fluree are real, current, git-modeled graph
+databases. Graph three-way merge is provably weaker than git's text merge (RDF's
+unordered-set structure lets adds/removes combine mechanically without ever
+raising a syntactic conflict, which can silently produce a semantically wrong
+result) — hence §3.6's rule that `Merge` always requires human review.
+
+**4.6 Parallelism.** Soufflé's mechanism is real and specific: compile-time
+`par...endpar` blocks lowered to OpenMP-annotated C++, backed by purpose-built
+concurrent data structures (a concurrent B-tree, a concurrent trie called
+"Brie"). This is the adoptable answer for QueryInterpretation. ExecuteInterpretation
+concurrency (§2) has no equivalent answer and is explicitly open.
+
+**4.7 Conflict resolution.** CLIPS's LEX strategy checks recency before
+specificity, specificity only as the final tiebreaker — informs Discovery's
+ordering (§3.6).
+
+**4.8 Authoring.** LinkML is not a replacement for StreamLD's already-shipped
+SHACL schemas (a safely-deferrable representation choice, since generated SHACL
+is equivalent to hand-written SHACL). It *is* adopted now for the **new** Phase 3
+rule/template schema specifically, because `linkml-datalog` (real, if alpha and
+dormant since Feb 2024) already demonstrates "author in LinkML, generate a
+working Soufflé Datalog program" as a working pattern, not a hypothesis.
+
+**4.9 Human review and UI.** External research on review-gate placement and
+generic-shape-driven UI came back with zero verified coverage across two
+independent attempts — treated as a real signal, not bad luck, that these are
+softer practice questions than the rest of this document's grounding. This spec
+uses local precedent instead: `scratch-command-bar`'s working propose/review
+loop and administration-commons' stated principle for *where* human review
+sits (before commons entry), and `graphsheet`'s shipped SHACL-driven UI for
+*how* review/discovery/monitoring surfaces should be built.
+
+**4.10 Elixir OAuth.** No existing LinkML-Elixir or general Elixir Datalog
+ecosystem to lean on (`lambdaclass/datalog` is a dead stub; `fogfish/datalog`
+is real but dormant since 2019 — worth studying, not a dependency to trust
+blindly). The Claude subscription OAuth flow needs porting by hand to Elixir,
+the same real, scoped cost `sovereign-ops` already identified for its own
+agent loop — not a new unknown.
+
+## 5. Diagram (informal — one substrate, six layers, only two of them new)
+
+```
+  Content / domain           (lattice, MiKaDiv, KaFE — unaffected by this spec)
+  Extraction / population    (scratch-command-bar's pattern — LLMFallback + review)
+  ── new in this spec ──────────────────────────────────────────
+  Discovery                  (§3.6 — catalog search)
+  Anti-unification / DedupGate (§3.4, §3.6 — generalize, dedup, human-reviewed merge)
+  Interpretation             (§3.5 — Query / Execute, algebraic-effects-inspired)
+  Rule (IDB)                 (§3.2 — SPARQL-RL-targeted, Soufflé-referenced)
+  ── existing, unchanged ───────────────────────────────────────
+  Execution kernel           (§4.3 — WASI + WASIX capability)
+  Fact / Event (EDB)         (Riptide today, extended with valid-time — §4.4)
+```
+
+## 6. Phased build order
+
+Each phase exists because the next one needs it, not because it's a natural
+checklist item — see the dependency reasoning, not just the sequence.
+
+1. **Bitemporal fact shape** (§7, detailed below). First because it changes what a
+   fact *looks like* — every later phase reads/writes facts, so retrofitting this
+   after Rules exist means touching everything downstream. Depends on nothing but
+   Riptide as it exists today.
+2. **Execution kernel in isolation.** WASI component execution, the WASIX
+   capability grant, the native/leaf template set — tested with no rule language
+   involved at all. Independent of Phase 3; only needs to exist before Phase 4.
+3. **Pure derivation engine.** Cross-stream joins, recursion, aggregation, moving
+   toward SPARQL-RL syntax, evaluated with the query interpreter only — no effects.
+   Isolated from Phase 2 so derivation bugs and effect bugs are never tangled
+   together. Depends on Phase 1 (needs the final fact shape).
+4. **Wire Phases 2 and 3 together.** Add the execute interpreter; `call_template`
+   becomes real for the first time. Pure wiring, no new logic — but this is also
+   where §2's concurrent-effects question has to actually get answered, not
+   deferred further.
+5. **Anti-unification: generalization and the DedupGate.** Only meaningful once
+   real rules exist in the engine's own representation (Phase 4).
+6. **LLM fallback loop.** Deliberately last among the "core" phases — the escape
+   hatch for the unknown, with somewhere coherent (Phase 5's gate) to put its
+   output. Starting here, as originally conceived, would have meant a harness with
+   nowhere for its distillations to land.
+7. **Discovery.** Only relevant once Phases 4–6 have produced a catalog worth
+   searching.
+
+**Ongoing, not sequential:** LinkML authoring (§4.8) applied to each new schema as
+it's created (Phase 1's bitemporal envelope, Phase 3/4's rule schema).
+
+## 7. Phase 1 — ready to plan
+
+Concrete, bounded scope for the first implementation plan:
+
+- Define the RDF-star `validFrom`/`validTo` annotation convention for individual
+  facts (quoted-triple syntax, per §4.4).
+- Adopt a defined subset of OWL-Time's Allen-relation vocabulary for interval
+  comparisons (before/after/meets/overlaps/during/starts/finishes/equals, at
+  minimum).
+- ValidTime defaults to TransactionTime when unspecified, matching XTDB's
+  documented default.
+- This becomes the fact-writing convention for all new writes going forward, in
+  Riptide's existing LDP write path — no new engine, no new derivation, no
+  behavior change beyond the added annotation.
+- Explicitly deferred to Phase 3+: making ValidTime queryable/joinable inside
+  rule logic. Phase 1 only establishes that the field exists on facts.
+
+## 8. Open questions (tracked, not blocking)
+
+- OpenFASTER-Standard public governance status for this layer (§2).
+- Concurrent-effectful-execution coordination theory — no established saga/CRDT
+  answer found; needs a dedicated design spike at Phase 4 (§2, §4.6).
+- Formal versioning/supersedes theory for declarative rules — adopted the
+  pragmatic git/TerminusDB model instead of a formal criterion, since none was
+  found (§4.5).
+- Final Tenant name (§2).


### PR DESCRIPTION
## Summary
- Brings the "Derivation and Execution Layer" architecture spec (Sub-project 6) forward from its original branch onto current `main` — the branch only ever touched this one file, so this is a clean merge, no conflicts with anything shipped since.
- Resolves three open decisions: Tenant name (kept as "Tenant"), governance (Riptide-internal for now), deployability (same OS process as the existing LDP surface).
- Adds §8.7.1: a dedicated research pass on formal versioning/supersedes theory for declarative rules, requested after two prior attempts came back empty. Found two real candidate anchors (AGM/KM logic-program update; DL conservative-extension extended to TGDs in 2022), confirmed patch theory as a closed non-fit, and surfaced ILP's generalization-lattice literature as the most promising unresearched lead.
- Adds two new open items, explicitly flagged as sketched-not-designed: large object/blob storage (content-addressed, reusing git's object-store/ref-layer split rather than a separate blob service or the Ra consensus log), and a Capability-model gap for long-running/daemon-shaped actions (e.g. serving a web page) versus the current one-shot-Interpretation shape.
- Updates the §3.1 currency note: the security-audit remediation flagged as in-progress in the prior revision has since landed on `main` (PR #32).

## Test plan
- [x] `mix compile --force --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` all clean (docs-only change, confirming nothing else drifted)
- [x] Verified no other file conflicts: the source branch touched only this one spec file across all four revisions