### PR TITLE
Phase 6c-i-b: Fact-pattern matching and joins

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a shipped** (Rule/Signature representation and parser) — 20 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b shipped** (Rule/Signature representation and parser; fact-pattern matching and joins) — 19 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -515,4 +515,24 @@ new persistence path. `linkml-datalog` re-checked 2026-08-28: still dormant (las
 2024-02-14) — unchanged from the design spec's prior checks.
 
 **Status**: Phase 6c-i-a shipped 2026-08-28. 20 phases remaining across the primary spine and the
+three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6c-i-b — Fact-pattern matching and joins
+
+Second link in the walking skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → ...`), following
+6c-i-a's Rule/Signature representation. **Shipped 2026-08-28** — see
+`docs/superpowers/specs/2026-08-28-phase-6c-i-b-fact-pattern-matching-design.md`.
+
+`Riptide.Derivation.Matcher.bindings/2`/`evaluate/2` evaluate the fact-pattern-only fragment of
+QueryInterpretation: joins across a Rule's Body against a caller-supplied `RDF.Graph.t()`, then
+concludes the Head. Built as a thin adapter over `RDF.Query`/`RDF.Query.BGP` (already available
+transitively via the `rdf` hex dependency, no new dependency) rather than a hand-rolled join
+algorithm. Closes a real unbounded-atom-creation risk found during design: `RDF.Query.BGP`'s
+matcher requires atom-based variables, so Body variables are translated through a small, fixed,
+compile-time-created pool of placeholder atoms rather than `String.to_atom/1` on untrusted
+variable-name text. Also enforces Datalog rule safety (every Head variable must appear in the
+Body) and rejects Bodies containing capability-reference/rule-reference literals (out of scope
+until 6b-i's WASI substrate exists).
+
+**Status**: Phase 6c-i-b shipped 2026-08-28. 19 phases remaining across the primary spine and the
 three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/matcher.ex
+++ b/lib/riptide/derivation/matcher.ex
@@ -31,15 +31,24 @@ defmodule Riptide.Derivation.Matcher do
   Body is well-formed but unsatisfiable against `graph`.
   """
   @spec bindings(Rule.t(), RDF.Graph.t()) ::
-          {:ok, [%{Var.t() => RDF.Term.t()}]} | {:error, :too_many_variables}
+          {:ok, [%{Var.t() => RDF.Term.t()}]}
+          | {:error, :too_many_variables | {:unsupported_literal, Rule.literal()}}
   def bindings(%Rule{body: body}, %RDF.Graph{} = graph) do
-    with {:ok, var_to_atom} <- assign_variable_pool(body) do
+    with :ok <- check_literal_kinds(body),
+         {:ok, var_to_atom} <- assign_variable_pool(body) do
       triple_patterns = Enum.map(body, &to_triple_pattern(&1, var_to_atom))
       bgp = %RDF.Query.BGP{triple_patterns: triple_patterns}
       {:ok, results} = RDF.Query.execute(bgp, graph)
 
       atom_to_var = Map.new(var_to_atom, fn {var, atom} -> {atom, var} end)
       {:ok, Enum.map(results, &translate_binding(&1, atom_to_var))}
+    end
+  end
+
+  defp check_literal_kinds(body) do
+    case Enum.find(body, &(not match?(%FactPattern{}, &1))) do
+      nil -> :ok
+      literal -> {:error, {:unsupported_literal, literal}}
     end
   end
 

--- a/lib/riptide/derivation/matcher.ex
+++ b/lib/riptide/derivation/matcher.ex
@@ -45,6 +45,49 @@ defmodule Riptide.Derivation.Matcher do
     end
   end
 
+  @doc """
+  Evaluates a Rule: finds every Body-satisfying binding (`bindings/2`) and
+  substitutes each into the Head to produce one concluded `RDF.Triple.t()`
+  per binding. Checks Rule safety (every Head variable must appear in the
+  Body) structurally, before any graph access.
+  """
+  @spec evaluate(Rule.t(), RDF.Graph.t()) ::
+          {:ok, [RDF.Triple.t()]}
+          | {:error,
+             :too_many_variables | {:unsupported_literal, Rule.literal()} | {:unsafe_rule, Var.t()}}
+  def evaluate(%Rule{head: head} = rule, %RDF.Graph{} = graph) do
+    with :ok <- check_safety(head, rule.body),
+         {:ok, results} <- bindings(rule, graph) do
+      {:ok, Enum.map(results, &conclude(head, &1))}
+    end
+  end
+
+  defp check_safety(%FactPattern{args: head_args}, body) do
+    body_vars =
+      body
+      |> Enum.flat_map(fn
+        %FactPattern{args: args} -> args
+        _other -> []
+      end)
+      |> Enum.filter(&match?(%Var{}, &1))
+      |> MapSet.new()
+
+    head_args
+    |> Enum.filter(&match?(%Var{}, &1))
+    |> Enum.find(&(not MapSet.member?(body_vars, &1)))
+    |> case do
+      nil -> :ok
+      unbound_var -> {:error, {:unsafe_rule, unbound_var}}
+    end
+  end
+
+  defp conclude(%FactPattern{predicate: predicate, args: [subject, object]}, binding) do
+    {substitute(subject, binding), predicate, substitute(object, binding)}
+  end
+
+  defp substitute(%Var{} = var, binding), do: Map.fetch!(binding, var)
+  defp substitute(term, _binding), do: term
+
   defp check_literal_kinds(body) do
     case Enum.find(body, &(not match?(%FactPattern{}, &1))) do
       nil -> :ok

--- a/lib/riptide/derivation/matcher.ex
+++ b/lib/riptide/derivation/matcher.ex
@@ -1,0 +1,70 @@
+defmodule Riptide.Derivation.Matcher do
+  @moduledoc """
+  Fact-pattern matching and joins — the fact-pattern-only fragment of
+  QueryInterpretation (design spec
+  `docs/superpowers/specs/2026-08-28-phase-6c-i-b-fact-pattern-matching-design.md`).
+
+  A thin adapter over `RDF.Query`/`RDF.Query.BGP`: nothing outside this
+  module ever references `RDF.Query.BGP` directly. Body variables are
+  never turned into atoms via `String.to_atom/1` on their name text —
+  `RDF.Query.BGP`'s matcher hardcodes `is_atom/1` as its internal test for
+  "this position is a variable" (`rdf` hex package's `bgp/helper.ex`,
+  `bgp/query_planner.ex`), and Rule Body text is untrusted/LLM-authorable,
+  so deriving atoms from it would reopen the same unbounded-atom-creation
+  risk this codebase has already fixed twice (design spec §4). Instead, a
+  small, fixed pool of atoms created once at compile time stands in for
+  "the Nth distinct variable in this Body" — the mapping from a Rule's
+  real `Var.t()` names to pool slots is plain local state, scoped to one
+  `bindings/2`/`evaluate/2` call, never persisted.
+  """
+
+  alias Riptide.Derivation.{Rule, Var}
+  alias Riptide.Derivation.Literal.FactPattern
+
+  @max_variables 64
+  @var_pool Enum.map(1..@max_variables, &String.to_atom("$riptide_derivation_var_#{&1}"))
+
+  @doc """
+  The raw join: finds every binding of the Body's variables that satisfies
+  every fact-pattern literal in `rule.body` against `graph` simultaneously.
+  One map per satisfying solution; `{:ok, []}` (not an error) when the
+  Body is well-formed but unsatisfiable against `graph`.
+  """
+  @spec bindings(Rule.t(), RDF.Graph.t()) ::
+          {:ok, [%{Var.t() => RDF.Term.t()}]} | {:error, :too_many_variables}
+  def bindings(%Rule{body: body}, %RDF.Graph{} = graph) do
+    with {:ok, var_to_atom} <- assign_variable_pool(body) do
+      triple_patterns = Enum.map(body, &to_triple_pattern(&1, var_to_atom))
+      bgp = %RDF.Query.BGP{triple_patterns: triple_patterns}
+      {:ok, results} = RDF.Query.execute(bgp, graph)
+
+      atom_to_var = Map.new(var_to_atom, fn {var, atom} -> {atom, var} end)
+      {:ok, Enum.map(results, &translate_binding(&1, atom_to_var))}
+    end
+  end
+
+  defp assign_variable_pool(body) do
+    vars =
+      body
+      |> Enum.flat_map(fn %FactPattern{args: args} -> args end)
+      |> Enum.filter(&match?(%Var{}, &1))
+      |> Enum.uniq()
+
+    if length(vars) > @max_variables do
+      {:error, :too_many_variables}
+    else
+      {:ok, vars |> Enum.zip(@var_pool) |> Map.new()}
+    end
+  end
+
+  defp to_triple_pattern(%FactPattern{predicate: predicate, args: [subject, object]}, var_to_atom) do
+    {to_pattern_term(subject, var_to_atom), predicate, to_pattern_term(object, var_to_atom)}
+  end
+
+  defp to_pattern_term(%Var{} = var, var_to_atom), do: Map.fetch!(var_to_atom, var)
+  defp to_pattern_term(term, _var_to_atom), do: term
+
+  defp translate_binding(binding, atom_to_var) do
+    Map.new(binding, fn {atom, term} -> {Map.fetch!(atom_to_var, atom), term} end)
+  end
+end

--- a/lib/riptide/derivation/matcher.ex
+++ b/lib/riptide/derivation/matcher.ex
@@ -18,8 +18,8 @@ defmodule Riptide.Derivation.Matcher do
   `bindings/2`/`evaluate/2` call, never persisted.
   """
 
-  alias Riptide.Derivation.{Rule, Var}
   alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Rule, Var}
 
   @max_variables 64
   @var_pool Enum.map(1..@max_variables, &String.to_atom("$riptide_derivation_var_#{&1}"))
@@ -54,7 +54,9 @@ defmodule Riptide.Derivation.Matcher do
   @spec evaluate(Rule.t(), RDF.Graph.t()) ::
           {:ok, [RDF.Triple.t()]}
           | {:error,
-             :too_many_variables | {:unsupported_literal, Rule.literal()} | {:unsafe_rule, Var.t()}}
+             :too_many_variables
+             | {:unsupported_literal, Rule.literal()}
+             | {:unsafe_rule, Var.t()}}
   def evaluate(%Rule{head: head} = rule, %RDF.Graph{} = graph) do
     with :ok <- check_safety(head, rule.body),
          {:ok, results} <- bindings(rule, graph) do

--- a/test/riptide/derivation/matcher_golden_case_test.exs
+++ b/test/riptide/derivation/matcher_golden_case_test.exs
@@ -1,0 +1,41 @@
+defmodule Riptide.Derivation.MatcherGoldenCaseTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.{Matcher, Parser}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  test "a Rule joins facts that originated from separate, independently-built graphs" do
+    {:ok, rule} = Parser.decode("colleague(X, Y) :- worksAt(X, Org), worksAt(Y, Org).")
+
+    # Each of these stands in for one Riptide stream's current state — a
+    # real caller (6d-i) would fold each stream's own event log into one
+    # of these graphs independently, with no shared context between them.
+    alice_stream_graph = RDF.Graph.new([{t("alice"), rel("worksAt"), t("acme")}])
+    bob_stream_graph = RDF.Graph.new([{t("bob"), rel("worksAt"), t("acme")}])
+    carol_stream_graph = RDF.Graph.new([{t("carol"), rel("worksAt"), t("globex")}])
+
+    merged_graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add(alice_stream_graph)
+      |> RDF.Graph.add(bob_stream_graph)
+      |> RDF.Graph.add(carol_stream_graph)
+
+    assert {:ok, triples} = Matcher.evaluate(rule, merged_graph)
+
+    # alice and bob share "acme" (from two different origin graphs) and
+    # therefore join with each other, plus each with themselves; carol's
+    # "globex" has no other member, so she only joins reflexively with
+    # herself. Confirms the join binds a shared variable across facts that
+    # came from different graphs, not just within one.
+    assert MapSet.new(triples) ==
+             MapSet.new([
+               {t("alice"), rel("colleague"), t("alice")},
+               {t("alice"), rel("colleague"), t("bob")},
+               {t("bob"), rel("colleague"), t("alice")},
+               {t("bob"), rel("colleague"), t("bob")},
+               {t("carol"), rel("colleague"), t("carol")}
+             ])
+  end
+end

--- a/test/riptide/derivation/matcher_test.exs
+++ b/test/riptide/derivation/matcher_test.exs
@@ -122,4 +122,63 @@ defmodule Riptide.Derivation.MatcherTest do
       assert {:error, {:unsupported_literal, _}} = Matcher.bindings(rule, RDF.Graph.new())
     end
   end
+
+  describe "evaluate/2 — concluding the Head" do
+    test "substitutes each binding into the Head to produce concluded triples" do
+      {:ok, rule} = Parser.decode("sibling(X, Y) :- parent(P, X), parent(P, Y).")
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("parent"), t("bob")},
+          {t("alice"), rel("parent"), t("carol")}
+        ])
+
+      assert {:ok, triples} = Matcher.evaluate(rule, graph)
+
+      assert MapSet.new(triples) ==
+               MapSet.new([
+                 {t("bob"), rel("sibling"), t("bob")},
+                 {t("bob"), rel("sibling"), t("carol")},
+                 {t("carol"), rel("sibling"), t("bob")},
+                 {t("carol"), rel("sibling"), t("carol")}
+               ])
+    end
+
+    test "a well-formed Body that matches nothing concludes no triples" do
+      {:ok, rule} = Parser.decode("sibling(X, Y) :- parent(P, X), parent(P, Y).")
+
+      assert Matcher.evaluate(rule, RDF.Graph.new()) == {:ok, []}
+    end
+
+    test "a Head variable absent from the Body is rejected as unsafe, before any graph access" do
+      head = %FactPattern{predicate: rel("bad"), args: [%Var{name: "X"}, %Var{name: "Unbound"}]}
+      body = [%FactPattern{predicate: rel("f"), args: [%Var{name: "X"}, %Var{name: "X"}]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert Matcher.evaluate(rule, RDF.Graph.new()) ==
+               {:error, {:unsafe_rule, %Var{name: "Unbound"}}}
+    end
+
+    test "evaluate/2 also enforces fact-pattern-only scope" do
+      # Head vars (Svc, Target) are both bound by the fact-pattern literal
+      # alone, so this Rule is safe — isolating the scope-check failure
+      # from the safety check (Outcome is body-only, irrelevant to safety).
+      {:ok, rule} =
+        Parser.decode(
+          "deployed(Svc, Target) :- pendingDeploy(Svc, Target), capability(deployService, Svc, Target, Outcome)."
+        )
+
+      assert {:error, {:unsupported_literal, _}} = Matcher.evaluate(rule, RDF.Graph.new())
+    end
+  end
 end

--- a/test/riptide/derivation/matcher_test.exs
+++ b/test/riptide/derivation/matcher_test.exs
@@ -99,4 +99,27 @@ defmodule Riptide.Derivation.MatcherTest do
       assert Matcher.bindings(rule, RDF.Graph.new()) == {:error, :too_many_variables}
     end
   end
+
+  describe "bindings/2 — scope enforcement" do
+    alias Riptide.Derivation.Literal.CapabilityReference
+
+    test "a Body containing a capability(...) literal is rejected" do
+      {:ok, rule} =
+        Parser.decode(
+          "deployed(Svc, Outcome) :- pendingDeploy(Svc, Target), capability(deployService, Svc, Target, Outcome)."
+        )
+
+      assert {:error, {:unsupported_literal, %CapabilityReference{}}} =
+               Matcher.bindings(rule, RDF.Graph.new())
+    end
+
+    test "a Body containing a rule(...) literal is rejected" do
+      {:ok, rule} =
+        Parser.decode(
+          "notified(Svc, Result) :- capability(deployService, Svc, Svc, Outcome), rule(notifyTeam, Svc, Outcome, Result)."
+        )
+
+      assert {:error, {:unsupported_literal, _}} = Matcher.bindings(rule, RDF.Graph.new())
+    end
+  end
 end

--- a/test/riptide/derivation/matcher_test.exs
+++ b/test/riptide/derivation/matcher_test.exs
@@ -1,0 +1,102 @@
+defmodule Riptide.Derivation.MatcherTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.{Matcher, Parser, Rule, Signature, Var}
+  alias Riptide.Derivation.Literal.FactPattern
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp plain(bindings) do
+    Map.new(bindings, fn {%Var{name: name}, term} -> {name, term} end)
+  end
+
+  describe "bindings/2 — joins" do
+    test "a two-literal shared-variable join" do
+      {:ok, rule} = Parser.decode("sibling(X, Y) :- parent(P, X), parent(P, Y).")
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("parent"), t("bob")},
+          {t("alice"), rel("parent"), t("carol")}
+        ])
+
+      assert {:ok, results} = Matcher.bindings(rule, graph)
+      plain_sets = results |> Enum.map(&plain/1) |> MapSet.new()
+
+      expected =
+        MapSet.new([
+          %{"P" => t("alice"), "X" => t("bob"), "Y" => t("bob")},
+          %{"P" => t("alice"), "X" => t("bob"), "Y" => t("carol")},
+          %{"P" => t("alice"), "X" => t("carol"), "Y" => t("bob")},
+          %{"P" => t("alice"), "X" => t("carol"), "Y" => t("carol")}
+        ])
+
+      assert plain_sets == expected
+    end
+
+    test "a chained multi-hop join" do
+      {:ok, rule} = Parser.decode("path(X, Y) :- edge(X, Z), edge(Z, Y).")
+
+      graph =
+        RDF.Graph.new([
+          {t("a"), rel("edge"), t("b")},
+          {t("b"), rel("edge"), t("c")},
+          {t("c"), rel("edge"), t("d")}
+        ])
+
+      assert {:ok, results} = Matcher.bindings(rule, graph)
+      plain_sets = results |> Enum.map(&plain/1) |> MapSet.new()
+
+      expected =
+        MapSet.new([
+          %{"X" => t("a"), "Z" => t("b"), "Y" => t("c")},
+          %{"X" => t("b"), "Z" => t("c"), "Y" => t("d")}
+        ])
+
+      assert plain_sets == expected
+    end
+
+    test "a self-join — the same variable used twice in one literal" do
+      {:ok, rule} = Parser.decode("loop(X, X) :- edge(X, X).")
+
+      graph =
+        RDF.Graph.new([
+          {t("a"), rel("edge"), t("a")},
+          {t("a"), rel("edge"), t("b")}
+        ])
+
+      assert {:ok, results} = Matcher.bindings(rule, graph)
+      assert [binding] = results
+      assert plain(binding) == %{"X" => t("a")}
+    end
+
+    test "a well-formed Body that matches nothing returns an empty list, not an error" do
+      {:ok, rule} = Parser.decode("sibling(X, Y) :- parent(P, X), parent(P, Y).")
+
+      assert Matcher.bindings(rule, RDF.Graph.new()) == {:ok, []}
+    end
+
+    test "a Rule with more than 64 distinct Body variables is rejected" do
+      body =
+        for i <- 1..33 do
+          %FactPattern{predicate: rel("f"), args: [%Var{name: "V#{i}"}, %Var{name: "W#{i}"}]}
+        end
+
+      head = %FactPattern{predicate: rel("g"), args: [%Var{name: "V1"}, %Var{name: "W1"}]}
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert Matcher.bindings(rule, RDF.Graph.new()) == {:error, :too_many_variables}
+    end
+  end
+end

--- a/test/riptide/derivation/matcher_test.exs
+++ b/test/riptide/derivation/matcher_test.exs
@@ -1,8 +1,8 @@
 defmodule Riptide.Derivation.MatcherTest do
   use ExUnit.Case, async: true
 
-  alias Riptide.Derivation.{Matcher, Parser, Rule, Signature, Var}
   alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Matcher, Parser, Rule, Signature, Var}
 
   defp t(name), do: RDF.iri("urn:test:" <> name)
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)


### PR DESCRIPTION
## Summary
- Implements the Phase 6c-i-b design spec (docs/superpowers/specs/2026-08-28-phase-6c-i-b-fact-pattern-matching-design.md) — the second link in the Sub-project 6 walking skeleton, following 6c-i-a (PR #83).
- `Riptide.Derivation.Matcher.bindings/2` — joins across a Rule's Body fact-pattern literals against a caller-supplied `RDF.Graph.t()`, via a thin adapter over `RDF.Query`/`RDF.Query.BGP` (already available transitively through the `rdf` hex dependency — no new dependency).
- `Riptide.Derivation.Matcher.evaluate/2` — Datalog rule safety (range restriction) checking plus Head substitution, concluding each binding into an output triple.
- A real safety finding closed during design: `RDF.Query.BGP`'s matcher requires atom-based variables, so Body variables are translated through a small, fixed, compile-time-created pool of placeholder atoms rather than `String.to_atom/1` on untrusted/LLM-authorable variable-name text — avoiding the same unbounded-atom-creation risk class this codebase has already fixed twice.
- Scope enforcement: a Body containing a `capability(...)`/`rule(...)` literal is rejected (needs 6b-i's WASI substrate, not yet built).
- Golden-case suite covers a shared-variable join, a chained multi-hop join, a self-join, an unsatisfiable-Body case, the 64-variable cap, both scope-enforcement rejections, Rule safety rejection, and — the exit criterion's explicit multi-stream requirement — a join across facts assembled from separately-constructed graphs merged together.

## Test plan
- [x] mix test — full suite passes (338 tests, 0 failures)
- [x] mix credo --strict
- [x] mix format --check-formatted
- [x] Golden-case multi-stream join suite (test/riptide/derivation/matcher_golden_case_test.exs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)