### PR TITLE
Phase 6d-i: Mechanical wiring

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate) — 18 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring) — 17 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -559,3 +559,25 @@ this project uses, and no current Capability needs it.
 
 **Status**: Phase 6b-i shipped 2026-08-29. 18 phases remaining across the primary spine and the
 three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6d-i — Mechanical wiring
+
+Third link in the walking skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → ...`), the
+first phase exercising 6b-i's `Riptide.Capability.invoke/4` and 6c-i-b's
+`Riptide.Derivation.Matcher` together in one real end-to-end path. **Shipped 2026-08-29**
+— see `docs/superpowers/specs/2026-08-29-phase-6d-i-mechanical-wiring-design.md`.
+
+`Riptide.Derivation.ExecuteInterpreter.call_template/3` is a direct generalization of
+`Matcher.evaluate/2`: a Rule's Body resolves left-to-right, with maximal runs of
+`FactPattern` literals resolved via a new `Matcher.bindings/3` (a backward-compatible
+seeded-join extension) and `CapabilityReference`/`RuleReference` literals invoked once per
+active branch — a `RuleReference` backtracks over its (possibly multiple) nested Outcomes,
+a `CapabilityReference` never does, since `Capability.invoke/4` is always single-valued.
+`NativeTemplate`/`Template` stay pure structural predicates over `Rule`, not new types, per
+the parent spec's own framing. A real inconsistency found during design between the parent
+spec's original worked example and the 2-arity Head invariant (established later, during
+6c-i-a's own implementation) was resolved by scoping `RuleReference` to exactly one input
+argument for this phase — documented explicitly, not silently papered over.
+
+**Status**: Phase 6d-i shipped 2026-08-29. 17 phases remaining across the primary spine and
+the three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -32,6 +32,7 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
 
   require Logger
 
+  alias Riptide.Capability
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
   alias Riptide.Derivation.{Matcher, Rule, Var}
@@ -100,10 +101,45 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
     end
   end
 
+  defp execute_body([%CapabilityReference{} = literal | rest], bindings, graph, context) do
+    case invoke_capability(literal, bindings, context) do
+      {:ok, new_bindings} -> execute_body(rest, new_bindings, graph, context)
+      :drop -> []
+    end
+  end
+
   defp conclude(%FactPattern{predicate: predicate, args: [subject, object]}, bindings) do
     {substitute(subject, bindings), predicate, substitute(object, bindings)}
   end
 
   defp substitute(%Var{} = var, bindings), do: Map.fetch!(bindings, var)
   defp substitute(term, _bindings), do: term
+
+  defp invoke_capability(%CapabilityReference{capability: iri, args: args, result: result}, bindings, context) do
+    definition = Map.fetch!(context.capabilities, iri)
+    resolved_args = args |> Enum.map(&substitute(&1, bindings)) |> Enum.map(&term_to_arg/1)
+
+    case Capability.invoke(definition, context.tenant_id, context.current_subject, resolved_args) do
+      {:ok, value} ->
+        {:ok, bind_result(bindings, result, value)}
+
+      {:error, reason} ->
+        Logger.warning("ExecuteInterpreter: capability #{inspect(iri)} invocation failed: #{inspect(reason)}")
+        :drop
+    end
+  end
+
+  # Capability.invoke/4 requires plain Elixir strings (they get inspect/1'd
+  # into wasmtime's --invoke wave-syntax call) — a bound Var's value is an
+  # RDF.Term.t() (an IRI or Literal from a fact-pattern match, or a literal
+  # constant straight from the Rule text), never a bare string on its own,
+  # so this conversion is mandatory, not a convenience. Passing an
+  # unconverted %RDF.IRI{}/%RDF.Literal{} through inspect/1 would produce
+  # invalid wave syntax (e.g. `~I<urn:test:alice>`), not a string literal.
+  defp term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
+  defp term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
+  defp term_to_arg(string) when is_binary(string), do: string
+
+  defp bind_result(bindings, %Var{} = var, value), do: Map.put(bindings, var, value)
+  defp bind_result(bindings, _constant, _value), do: bindings
 end

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -108,6 +108,12 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
     end
   end
 
+  defp execute_body([%RuleReference{} = literal | rest], bindings, graph, context) do
+    literal
+    |> invoke_rule(bindings, graph, context)
+    |> Enum.flat_map(&execute_body(rest, &1, graph, context))
+  end
+
   defp conclude(%FactPattern{predicate: predicate, args: [subject, object]}, bindings) do
     {substitute(subject, bindings), predicate, substitute(object, bindings)}
   end
@@ -126,6 +132,28 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
       {:error, reason} ->
         Logger.warning("ExecuteInterpreter: capability #{inspect(iri)} invocation failed: #{inspect(reason)}")
         :drop
+    end
+  end
+
+  defp invoke_rule(%RuleReference{rule: iri, args: [input_arg], result: result}, bindings, graph, context) do
+    nested_rule = Map.fetch!(context.rules, iri)
+    input_value = substitute(input_arg, bindings)
+    [head_subject | _] = nested_rule.head.args
+
+    seed =
+      case head_subject do
+        %Var{} = var -> %{var => input_value}
+        _constant -> %{}
+      end
+
+    case call_template(nested_rule, seed, graph, context) do
+      {:ok, triples} ->
+        Enum.map(triples, fn {_subject, _predicate, object} ->
+          bind_result(bindings, result, object)
+        end)
+
+      {:error, _reason} ->
+        []
     end
   end
 

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -1,0 +1,109 @@
+defmodule Riptide.Derivation.ExecuteInterpreter.Context do
+  @moduledoc """
+  The caller-supplied resolvers `Riptide.Derivation.ExecuteInterpreter.call_template/3`
+  needs — no Capability/Rule catalog exists yet (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6d-i-mechanical-wiring-design.md`
+  §1/§2), so IRI resolution is a plain caller-supplied map, mirroring
+  `Riptide.Derivation.Matcher`'s own caller-supplied-graph precedent.
+  """
+
+  @enforce_keys [:capabilities, :rules, :tenant_id, :current_subject]
+  defstruct [:capabilities, :rules, :tenant_id, :current_subject]
+
+  @type t :: %__MODULE__{
+          capabilities: %{RDF.IRI.t() => Riptide.Capability.Definition.t()},
+          rules: %{RDF.IRI.t() => Riptide.Derivation.Rule.t()},
+          tenant_id: String.t(),
+          current_subject: map() | nil
+        }
+end
+
+defmodule Riptide.Derivation.ExecuteInterpreter do
+  @moduledoc """
+  ExecuteInterpretation: ties 6b-i's `Riptide.Capability.invoke/4` and
+  6c-i-b's `Riptide.Derivation.Matcher` together into one recursive walk
+  over a Rule's Body. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6d-i-mechanical-wiring-design.md`
+  §3 — a direct generalization of `Matcher.evaluate/2`, not a parallel
+  algorithm: fact-pattern runs resolve via a real join
+  (`Matcher.bindings/3`), `CapabilityReference`/`RuleReference` literals
+  invoke once per branch.
+  """
+
+  require Logger
+
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
+  alias Riptide.Derivation.{Matcher, Rule, Var}
+
+  @doc """
+  Invokes `rule` end-to-end: resolves every fact-pattern run against
+  `graph`, invokes every Capability/Rule-reference literal via `context`'s
+  resolvers, and concludes the Head once per surviving branch. Returns
+  `{:error, _}` only for a structural problem (an unresolvable IRI, or a
+  `RuleReference` with other than one arg) — a well-formed Template that
+  simply produces no Outcomes returns `{:ok, []}`.
+  """
+  @spec call_template(Rule.t(), RDF.Graph.t(), Context.t()) ::
+          {:ok, [RDF.Triple.t()]}
+          | {:error, {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+  def call_template(%Rule{} = rule, %RDF.Graph{} = graph, %Context{} = context) do
+    call_template(rule, %{}, graph, context)
+  end
+
+  defp call_template(%Rule{} = rule, seed, %RDF.Graph{} = graph, %Context{} = context) do
+    with :ok <- check_resolvable(rule.body, context) do
+      bindings_list = execute_body(rule.body, seed, graph, context)
+      {:ok, Enum.map(bindings_list, &conclude(rule.head, &1))}
+    end
+  end
+
+  defp check_resolvable(body, context) do
+    Enum.reduce_while(body, :ok, fn literal, :ok ->
+      case check_literal_resolvable(literal, context) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp check_literal_resolvable(%FactPattern{}, _context), do: :ok
+
+  defp check_literal_resolvable(%CapabilityReference{capability: iri}, context) do
+    if Map.has_key?(context.capabilities, iri) do
+      :ok
+    else
+      {:error, {:unresolvable, iri}}
+    end
+  end
+
+  defp check_literal_resolvable(%RuleReference{rule: iri, args: args}, context) do
+    cond do
+      not Map.has_key?(context.rules, iri) -> {:error, {:unresolvable, iri}}
+      length(args) != 1 -> {:error, {:unsupported_arity, iri}}
+      true -> :ok
+    end
+  end
+
+  defp execute_body([], bindings, _graph, _context), do: [bindings]
+
+  defp execute_body([%FactPattern{} | _] = literals, bindings, graph, context) do
+    {fact_run, rest} = Enum.split_while(literals, &match?(%FactPattern{}, &1))
+
+    case Matcher.bindings(fact_run, graph, bindings) do
+      {:ok, extended_bindings_list} ->
+        Enum.flat_map(extended_bindings_list, &execute_body(rest, &1, graph, context))
+
+      {:error, reason} ->
+        Logger.warning("ExecuteInterpreter: fact-pattern run failed: #{inspect(reason)}")
+        []
+    end
+  end
+
+  defp conclude(%FactPattern{predicate: predicate, args: [subject, object]}, bindings) do
+    {substitute(subject, bindings), predicate, substitute(object, bindings)}
+  end
+
+  defp substitute(%Var{} = var, bindings), do: Map.fetch!(bindings, var)
+  defp substitute(term, _bindings), do: term
+end

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -121,7 +121,11 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
   defp substitute(%Var{} = var, bindings), do: Map.fetch!(bindings, var)
   defp substitute(term, _bindings), do: term
 
-  defp invoke_capability(%CapabilityReference{capability: iri, args: args, result: result}, bindings, context) do
+  defp invoke_capability(
+         %CapabilityReference{capability: iri, args: args, result: result},
+         bindings,
+         context
+       ) do
     definition = Map.fetch!(context.capabilities, iri)
     resolved_args = args |> Enum.map(&substitute(&1, bindings)) |> Enum.map(&term_to_arg/1)
 
@@ -130,12 +134,20 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
         {:ok, bind_result(bindings, result, value)}
 
       {:error, reason} ->
-        Logger.warning("ExecuteInterpreter: capability #{inspect(iri)} invocation failed: #{inspect(reason)}")
+        Logger.warning(
+          "ExecuteInterpreter: capability #{inspect(iri)} invocation failed: #{inspect(reason)}"
+        )
+
         :drop
     end
   end
 
-  defp invoke_rule(%RuleReference{rule: iri, args: [input_arg], result: result}, bindings, graph, context) do
+  defp invoke_rule(
+         %RuleReference{rule: iri, args: [input_arg], result: result},
+         bindings,
+         graph,
+         context
+       ) do
     nested_rule = Map.fetch!(context.rules, iri)
     input_value = substitute(input_arg, bindings)
     [head_subject | _] = nested_rule.head.args

--- a/lib/riptide/derivation/matcher.ex
+++ b/lib/riptide/derivation/matcher.ex
@@ -34,14 +34,28 @@ defmodule Riptide.Derivation.Matcher do
           {:ok, [%{Var.t() => RDF.Term.t()}]}
           | {:error, :too_many_variables | {:unsupported_literal, Rule.literal()}}
   def bindings(%Rule{body: body}, %RDF.Graph{} = graph) do
+    bindings(body, graph, %{})
+  end
+
+  @doc """
+  Like `bindings/2`, but takes a literal list directly plus a seed-bindings
+  map — any `Var` already present in `seed` is substituted as its bound
+  constant before building BGP triple patterns for the remaining free
+  variables, reusing the same fixed-atom-pool translation for whatever
+  stays unbound. `bindings/2` is `bindings(rule.body, graph, %{})`.
+  """
+  @spec bindings([Rule.literal()], RDF.Graph.t(), %{Var.t() => RDF.Term.t()}) ::
+          {:ok, [%{Var.t() => RDF.Term.t()}]}
+          | {:error, :too_many_variables | {:unsupported_literal, Rule.literal()}}
+  def bindings(body, %RDF.Graph{} = graph, seed) when is_list(body) and is_map(seed) do
     with :ok <- check_literal_kinds(body),
-         {:ok, var_to_atom} <- assign_variable_pool(body) do
-      triple_patterns = Enum.map(body, &to_triple_pattern(&1, var_to_atom))
+         {:ok, var_to_atom} <- assign_variable_pool(body, seed) do
+      triple_patterns = Enum.map(body, &to_triple_pattern(&1, var_to_atom, seed))
       bgp = %RDF.Query.BGP{triple_patterns: triple_patterns}
       {:ok, results} = RDF.Query.execute(bgp, graph)
 
       atom_to_var = Map.new(var_to_atom, fn {var, atom} -> {atom, var} end)
-      {:ok, Enum.map(results, &translate_binding(&1, atom_to_var))}
+      {:ok, Enum.map(results, &Map.merge(seed, translate_binding(&1, atom_to_var)))}
     end
   end
 
@@ -97,11 +111,12 @@ defmodule Riptide.Derivation.Matcher do
     end
   end
 
-  defp assign_variable_pool(body) do
+  defp assign_variable_pool(body, seed) do
     vars =
       body
       |> Enum.flat_map(fn %FactPattern{args: args} -> args end)
       |> Enum.filter(&match?(%Var{}, &1))
+      |> Enum.reject(&Map.has_key?(seed, &1))
       |> Enum.uniq()
 
     if length(vars) > @max_variables do
@@ -111,12 +126,18 @@ defmodule Riptide.Derivation.Matcher do
     end
   end
 
-  defp to_triple_pattern(%FactPattern{predicate: predicate, args: [subject, object]}, var_to_atom) do
-    {to_pattern_term(subject, var_to_atom), predicate, to_pattern_term(object, var_to_atom)}
+  defp to_triple_pattern(%FactPattern{predicate: predicate, args: [subject, object]}, var_to_atom, seed) do
+    {to_pattern_term(subject, var_to_atom, seed), predicate, to_pattern_term(object, var_to_atom, seed)}
   end
 
-  defp to_pattern_term(%Var{} = var, var_to_atom), do: Map.fetch!(var_to_atom, var)
-  defp to_pattern_term(term, _var_to_atom), do: term
+  defp to_pattern_term(%Var{} = var, var_to_atom, seed) do
+    case Map.fetch(seed, var) do
+      {:ok, term} -> term
+      :error -> Map.fetch!(var_to_atom, var)
+    end
+  end
+
+  defp to_pattern_term(term, _var_to_atom, _seed), do: term
 
   defp translate_binding(binding, atom_to_var) do
     Map.new(binding, fn {atom, term} -> {Map.fetch!(atom_to_var, atom), term} end)

--- a/lib/riptide/derivation/matcher.ex
+++ b/lib/riptide/derivation/matcher.ex
@@ -126,8 +126,13 @@ defmodule Riptide.Derivation.Matcher do
     end
   end
 
-  defp to_triple_pattern(%FactPattern{predicate: predicate, args: [subject, object]}, var_to_atom, seed) do
-    {to_pattern_term(subject, var_to_atom, seed), predicate, to_pattern_term(object, var_to_atom, seed)}
+  defp to_triple_pattern(
+         %FactPattern{predicate: predicate, args: [subject, object]},
+         var_to_atom,
+         seed
+       ) do
+    {to_pattern_term(subject, var_to_atom, seed), predicate,
+     to_pattern_term(object, var_to_atom, seed)}
   end
 
   defp to_pattern_term(%Var{} = var, var_to_atom, seed) do

--- a/test/riptide/derivation/execute_interpreter_test.exs
+++ b/test/riptide/derivation/execute_interpreter_test.exs
@@ -130,7 +130,12 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       ]
 
       rule = %Rule{
-        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
         head: head,
         body: body
       }
@@ -151,7 +156,12 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       ]
 
       rule = %Rule{
-        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
         head: head,
         body: body
       }
@@ -173,7 +183,12 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       ]
 
       rule = %Rule{
-        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
         head: head,
         body: body
       }
@@ -212,7 +227,12 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       ]
 
       rule = %Rule{
-        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
         head: head,
         body: body
       }
@@ -240,7 +260,12 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       ]
 
       rule = %Rule{
-        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
         head: head,
         body: body
       }
@@ -268,10 +293,15 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
           produces: [nested_iri]
         },
         head: %FactPattern{predicate: nested_iri, args: [%Var{name: "Person"}, %Var{name: "Org"}]},
-        body: [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "Person"}, %Var{name: "Org"}]}]
+        body: [
+          %FactPattern{predicate: rel("worksAt"), args: [%Var{name: "Person"}, %Var{name: "Org"}]}
+        ]
       }
 
-      outer_head = %FactPattern{predicate: rel("lookup"), args: [t("alice"), %Var{name: "Result"}]}
+      outer_head = %FactPattern{
+        predicate: rel("lookup"),
+        args: [t("alice"), %Var{name: "Result"}]
+      }
 
       outer_body = [
         %RuleReference{rule: nested_iri, args: [t("alice")], result: %Var{name: "Result"}}
@@ -326,7 +356,10 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
           reads: [],
           produces: [notify_team_iri]
         },
-        head: %FactPattern{predicate: notify_team_iri, args: [%Var{name: "Outcome"}, %Var{name: "Result"}]},
+        head: %FactPattern{
+          predicate: notify_team_iri,
+          args: [%Var{name: "Outcome"}, %Var{name: "Result"}]
+        },
         body: [
           %CapabilityReference{
             capability: notify_cap_iri,
@@ -340,17 +373,30 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       # literals sharing `Target`, assembled from separately-constructed
       # graphs merged together (matching 6c-i-b's own multi-stream-join
       # golden case style, per this phase's exit criterion).
-      deployed_head = %FactPattern{predicate: rel("deployed"), args: [%Var{name: "Svc"}, %Var{name: "Result"}]}
+      deployed_head = %FactPattern{
+        predicate: rel("deployed"),
+        args: [%Var{name: "Svc"}, %Var{name: "Result"}]
+      }
 
       deployed_body = [
-        %FactPattern{predicate: rel("pendingDeploy"), args: [%Var{name: "Svc"}, %Var{name: "Target"}]},
-        %FactPattern{predicate: rel("approved"), args: [%Var{name: "Target"}, %Var{name: "Owner"}]},
+        %FactPattern{
+          predicate: rel("pendingDeploy"),
+          args: [%Var{name: "Svc"}, %Var{name: "Target"}]
+        },
+        %FactPattern{
+          predicate: rel("approved"),
+          args: [%Var{name: "Target"}, %Var{name: "Owner"}]
+        },
         %CapabilityReference{
           capability: deploy_cap_iri,
           args: [%Var{name: "Owner"}],
           result: %Var{name: "Outcome"}
         },
-        %RuleReference{rule: notify_team_iri, args: [%Var{name: "Outcome"}], result: %Var{name: "Result"}}
+        %RuleReference{
+          rule: notify_team_iri,
+          args: [%Var{name: "Outcome"}],
+          result: %Var{name: "Result"}
+        }
       ]
 
       deployed_rule = %Rule{
@@ -366,7 +412,9 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
 
       pending_deploy_graph = RDF.Graph.new([{t("billing-svc"), rel("pendingDeploy"), t("v2")}])
       approved_graph = RDF.Graph.new([{t("v2"), rel("approved"), t("alice")}])
-      graph = RDF.Graph.new() |> RDF.Graph.add(pending_deploy_graph) |> RDF.Graph.add(approved_graph)
+
+      graph =
+        RDF.Graph.new() |> RDF.Graph.add(pending_deploy_graph) |> RDF.Graph.add(approved_graph)
 
       ctx =
         context(%{

--- a/test/riptide/derivation/execute_interpreter_test.exs
+++ b/test/riptide/derivation/execute_interpreter_test.exs
@@ -1,0 +1,133 @@
+defmodule Riptide.Derivation.ExecuteInterpreterTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.ExecuteInterpreter
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
+  alias Riptide.Derivation.{Rule, Signature, Var}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp context(overrides \\ %{}) do
+    Map.merge(
+      %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
+      overrides
+    )
+  end
+
+  describe "call_template/3 — fact-pattern-only Bodies" do
+    test "a single fact-pattern literal concludes one triple per match" do
+      head = %FactPattern{predicate: rel("sibling"), args: [%Var{name: "X"}, %Var{name: "Y"}]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "X"}, %Var{name: "Y"}]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      graph = RDF.Graph.new([{t("alice"), rel("worksAt"), t("acme")}])
+
+      assert ExecuteInterpreter.call_template(rule, graph, context()) ==
+               {:ok, [{t("alice"), rel("sibling"), t("acme")}]}
+    end
+
+    test "a fact-pattern run with zero matches returns {:ok, []}, not an error" do
+      head = %FactPattern{predicate: rel("sibling"), args: [%Var{name: "X"}, %Var{name: "Y"}]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "X"}, %Var{name: "Y"}]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), context()) == {:ok, []}
+    end
+  end
+
+  describe "call_template/3 — structural checks" do
+    test "an unresolvable capability IRI is rejected before any graph access" do
+      head = %FactPattern{predicate: rel("out"), args: [t("x"), %Var{name: "Result"}]}
+
+      body = [
+        %CapabilityReference{
+          capability: RDF.iri("urn:riptide:capability:notRegistered"),
+          args: [t("x")],
+          result: %Var{name: "Result"}
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        head: head,
+        body: body
+      }
+
+      assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), context()) ==
+               {:error, {:unresolvable, RDF.iri("urn:riptide:capability:notRegistered")}}
+    end
+
+    test "an unresolvable rule IRI is rejected before any graph access" do
+      head = %FactPattern{predicate: rel("out"), args: [t("x"), %Var{name: "Result"}]}
+
+      body = [
+        %RuleReference{
+          rule: RDF.iri("urn:riptide:rule:notRegistered"),
+          args: [t("x")],
+          result: %Var{name: "Result"}
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        head: head,
+        body: body
+      }
+
+      assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), context()) ==
+               {:error, {:unresolvable, RDF.iri("urn:riptide:rule:notRegistered")}}
+    end
+
+    test "a RuleReference with more than one arg is rejected as unsupported arity" do
+      nested_iri = RDF.iri("urn:riptide:rule:nested")
+      head = %FactPattern{predicate: rel("out"), args: [t("x"), %Var{name: "Result"}]}
+
+      body = [
+        %RuleReference{
+          rule: nested_iri,
+          args: [t("x"), t("y")],
+          result: %Var{name: "Result"}
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        head: head,
+        body: body
+      }
+
+      nested_rule = %Rule{
+        signature: %Signature{name: nested_iri, parameters: [], reads: [], produces: [nested_iri]},
+        head: %FactPattern{predicate: nested_iri, args: [%Var{name: "A"}, %Var{name: "B"}]},
+        body: [%FactPattern{predicate: rel("f"), args: [%Var{name: "A"}, %Var{name: "B"}]}]
+      }
+
+      ctx = context(%{rules: %{nested_iri => nested_rule}})
+
+      assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), ctx) ==
+               {:error, {:unsupported_arity, nested_iri}}
+    end
+  end
+end

--- a/test/riptide/derivation/execute_interpreter_test.exs
+++ b/test/riptide/derivation/execute_interpreter_test.exs
@@ -1,6 +1,11 @@
 defmodule Riptide.Derivation.ExecuteInterpreterTest do
-  use ExUnit.Case, async: true
+  # async: false — FakeStore is a single, fixed-named Agent shared by every
+  # test in this module; running them concurrently races start/stop against
+  # each other (see test/riptide/capability_test.exs, which established
+  # this same pattern for the same reason).
+  use ExUnit.Case, async: false
 
+  alias Riptide.Capability.Definition
   alias Riptide.Derivation.ExecuteInterpreter
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
@@ -14,6 +19,61 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
       overrides
     )
+  end
+
+  defp greet_capability_definition(name) do
+    %Definition{
+      name: RDF.iri("urn:riptide:capability:" <> name),
+      kind: :effect,
+      component: "test/fixtures/riptide_capability/fixture.wasm",
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    on_exit(fn ->
+      if pid = Process.whereis(FakeStore) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
   end
 
   describe "call_template/3 — fact-pattern-only Bodies" do
@@ -128,6 +188,71 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
 
       assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), ctx) ==
                {:error, {:unsupported_arity, nested_iri}}
+    end
+  end
+
+  describe "call_template/3 — CapabilityReference" do
+    test "a bare NativeTemplate (single CapabilityReference Body) invoked directly" do
+      cap_iri = RDF.iri("urn:riptide:capability:greetSomeone")
+
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetSomeone"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      head = %FactPattern{predicate: rel("greeted"), args: [t("riptide"), %Var{name: "Greeting"}]}
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Riptide")],
+          result: %Var{name: "Greeting"}
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        head: head,
+        body: body
+      }
+
+      ctx = context(%{capabilities: %{cap_iri => greet_capability_definition("greetSomeone")}})
+
+      assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), ctx) ==
+               {:ok, [{t("riptide"), rel("greeted"), "\"Hello, Riptide!\""}]}
+    end
+
+    test "a Capability invocation that fails authorization drops the branch and logs a warning" do
+      import ExUnit.CaptureLog
+
+      cap_iri = RDF.iri("urn:riptide:capability:notGranted")
+      FakeStore.start(%{})
+
+      head = %FactPattern{predicate: rel("greeted"), args: [t("riptide"), %Var{name: "Greeting"}]}
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Riptide")],
+          result: %Var{name: "Greeting"}
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{name: head.predicate, parameters: [], reads: [], produces: [head.predicate]},
+        head: head,
+        body: body
+      }
+
+      ctx = context(%{capabilities: %{cap_iri => greet_capability_definition("notGranted")}})
+
+      log =
+        capture_log(fn ->
+          assert ExecuteInterpreter.call_template(rule, RDF.Graph.new(), ctx) == {:ok, []}
+        end)
+
+      assert log =~ "notGranted"
     end
   end
 end

--- a/test/riptide/derivation/execute_interpreter_test.exs
+++ b/test/riptide/derivation/execute_interpreter_test.exs
@@ -255,4 +255,139 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       assert log =~ "notGranted"
     end
   end
+
+  describe "call_template/3 — RuleReference" do
+    test "a RuleReference to a nested Rule whose own fact-pattern run yields multiple bindings" do
+      nested_iri = RDF.iri("urn:riptide:rule:colleagueOf")
+
+      nested_rule = %Rule{
+        signature: %Signature{
+          name: nested_iri,
+          parameters: [%Var{name: "Person"}, %Var{name: "Org"}],
+          reads: [rel("worksAt")],
+          produces: [nested_iri]
+        },
+        head: %FactPattern{predicate: nested_iri, args: [%Var{name: "Person"}, %Var{name: "Org"}]},
+        body: [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "Person"}, %Var{name: "Org"}]}]
+      }
+
+      outer_head = %FactPattern{predicate: rel("lookup"), args: [t("alice"), %Var{name: "Result"}]}
+
+      outer_body = [
+        %RuleReference{rule: nested_iri, args: [t("alice")], result: %Var{name: "Result"}}
+      ]
+
+      outer_rule = %Rule{
+        signature: %Signature{
+          name: outer_head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [outer_head.predicate]
+        },
+        head: outer_head,
+        body: outer_body
+      }
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("worksAt"), t("acme")},
+          {t("alice"), rel("worksAt"), t("contractorco")}
+        ])
+
+      ctx = context(%{rules: %{nested_iri => nested_rule}})
+
+      assert {:ok, results} = ExecuteInterpreter.call_template(outer_rule, graph, ctx)
+
+      assert MapSet.new(results) ==
+               MapSet.new([
+                 {t("alice"), rel("lookup"), t("acme")},
+                 {t("alice"), rel("lookup"), t("contractorco")}
+               ])
+    end
+
+    test "the walking-skeleton shape: a multi-stream join feeding a Capability feeding a RuleReference" do
+      deploy_cap_iri = RDF.iri("urn:riptide:capability:deployService")
+      notify_cap_iri = RDF.iri("urn:riptide:capability:sendNotification")
+      notify_team_iri = RDF.iri("urn:riptide:rule:notifyTeam")
+
+      FakeStore.start(%{
+        {"acme", ["capabilities", "deployService"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ],
+        {"acme", ["capabilities", "sendNotification"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      notify_team_rule = %Rule{
+        signature: %Signature{
+          name: notify_team_iri,
+          parameters: [%Var{name: "Outcome"}, %Var{name: "Result"}],
+          reads: [],
+          produces: [notify_team_iri]
+        },
+        head: %FactPattern{predicate: notify_team_iri, args: [%Var{name: "Outcome"}, %Var{name: "Result"}]},
+        body: [
+          %CapabilityReference{
+            capability: notify_cap_iri,
+            args: [%Var{name: "Outcome"}],
+            result: %Var{name: "Result"}
+          }
+        ]
+      }
+
+      # pendingDeploy(Svc, Target), approved(Target, Owner) — two fact-pattern
+      # literals sharing `Target`, assembled from separately-constructed
+      # graphs merged together (matching 6c-i-b's own multi-stream-join
+      # golden case style, per this phase's exit criterion).
+      deployed_head = %FactPattern{predicate: rel("deployed"), args: [%Var{name: "Svc"}, %Var{name: "Result"}]}
+
+      deployed_body = [
+        %FactPattern{predicate: rel("pendingDeploy"), args: [%Var{name: "Svc"}, %Var{name: "Target"}]},
+        %FactPattern{predicate: rel("approved"), args: [%Var{name: "Target"}, %Var{name: "Owner"}]},
+        %CapabilityReference{
+          capability: deploy_cap_iri,
+          args: [%Var{name: "Owner"}],
+          result: %Var{name: "Outcome"}
+        },
+        %RuleReference{rule: notify_team_iri, args: [%Var{name: "Outcome"}], result: %Var{name: "Result"}}
+      ]
+
+      deployed_rule = %Rule{
+        signature: %Signature{
+          name: deployed_head.predicate,
+          parameters: deployed_head.args,
+          reads: [rel("pendingDeploy"), rel("approved")],
+          produces: [deployed_head.predicate]
+        },
+        head: deployed_head,
+        body: deployed_body
+      }
+
+      pending_deploy_graph = RDF.Graph.new([{t("billing-svc"), rel("pendingDeploy"), t("v2")}])
+      approved_graph = RDF.Graph.new([{t("v2"), rel("approved"), t("alice")}])
+      graph = RDF.Graph.new() |> RDF.Graph.add(pending_deploy_graph) |> RDF.Graph.add(approved_graph)
+
+      ctx =
+        context(%{
+          capabilities: %{
+            deploy_cap_iri => greet_capability_definition("deployService"),
+            notify_cap_iri => greet_capability_definition("sendNotification")
+          },
+          rules: %{notify_team_iri => notify_team_rule}
+        })
+
+      assert {:ok, [{subject, predicate, object}]} =
+               ExecuteInterpreter.call_template(deployed_rule, graph, ctx)
+
+      assert subject == t("billing-svc")
+      assert predicate == rel("deployed")
+      # object is notifyTeam's own concluded result — the wave-encoded
+      # greet() output, chained through both capability invocations and
+      # the RuleReference. The exact value matters less than proving both
+      # 6b-i's substrate (two real Capability invocations) and 6c-i-b's
+      # matching (the two-literal join) were genuinely exercised together.
+      assert is_binary(object) or match?(%RDF.Literal{}, object)
+    end
+  end
 end

--- a/test/riptide/derivation/matcher_test.exs
+++ b/test/riptide/derivation/matcher_test.exs
@@ -181,4 +181,41 @@ defmodule Riptide.Derivation.MatcherTest do
       assert {:error, {:unsupported_literal, _}} = Matcher.evaluate(rule, RDF.Graph.new())
     end
   end
+
+  describe "bindings/3 — seeded joins" do
+    test "a variable already in the seed is substituted as a constant, not left free" do
+      {:ok, rule} = Parser.decode("colleague(X, Y) :- worksAt(X, Y).")
+      [worksAt_literal] = rule.body
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("worksAt"), t("acme")},
+          {t("bob"), rel("worksAt"), t("acme")}
+        ])
+
+      seed = %{%Var{name: "X"} => t("alice")}
+
+      assert {:ok, results} = Matcher.bindings([worksAt_literal], graph, seed)
+      assert Enum.map(results, &plain/1) == [%{"X" => t("alice"), "Y" => t("acme")}]
+    end
+
+    test "an empty seed behaves exactly like bindings/2" do
+      {:ok, rule} = Parser.decode("colleague(X, Y) :- worksAt(X, Y).")
+
+      graph = RDF.Graph.new([{t("alice"), rel("worksAt"), t("acme")}])
+
+      assert Matcher.bindings(rule.body, graph, %{}) == Matcher.bindings(rule, graph)
+    end
+
+    test "seeded variables don't count against the 64-variable cap" do
+      body =
+        for i <- 1..33 do
+          %FactPattern{predicate: rel("f"), args: [%Var{name: "V#{i}"}, %Var{name: "W#{i}"}]}
+        end
+
+      seed = Map.new(1..33, fn i -> {%Var{name: "V#{i}"}, t("bound")} end)
+
+      assert {:ok, []} = Matcher.bindings(body, RDF.Graph.new(), seed)
+    end
+  end
 end

--- a/test/riptide/derivation/matcher_test.exs
+++ b/test/riptide/derivation/matcher_test.exs
@@ -185,7 +185,7 @@ defmodule Riptide.Derivation.MatcherTest do
   describe "bindings/3 — seeded joins" do
     test "a variable already in the seed is substituted as a constant, not left free" do
       {:ok, rule} = Parser.decode("colleague(X, Y) :- worksAt(X, Y).")
-      [worksAt_literal] = rule.body
+      [works_at_literal] = rule.body
 
       graph =
         RDF.Graph.new([
@@ -195,7 +195,7 @@ defmodule Riptide.Derivation.MatcherTest do
 
       seed = %{%Var{name: "X"} => t("alice")}
 
-      assert {:ok, results} = Matcher.bindings([worksAt_literal], graph, seed)
+      assert {:ok, results} = Matcher.bindings([works_at_literal], graph, seed)
       assert Enum.map(results, &plain/1) == [%{"X" => t("alice"), "Y" => t("acme")}]
     end
 


### PR DESCRIPTION
## Summary
- Implements the Phase 6d-i design spec (docs/superpowers/specs/2026-08-29-phase-6d-i-mechanical-wiring-design.md) — the third link in the Sub-project 6 walking skeleton, the first phase exercising 6b-i's `Riptide.Capability.invoke/4` and 6c-i-b's `Riptide.Derivation.Matcher` together in one real end-to-end path.
- `Riptide.Derivation.Matcher.bindings/3` — a backward-compatible extension of `bindings/2` accepting seed bindings, needed so `ExecuteInterpreter` can resolve fact-pattern runs with variables already bound from earlier steps in a Body. Zero changes to `bindings/2`'s existing public contract or the pre-existing Matcher test suites.
- `Riptide.Derivation.ExecuteInterpreter.call_template/3` — a direct generalization of `Matcher.evaluate/2`: resolves a Rule's Body left-to-right, joining `FactPattern` runs via `Matcher.bindings/3` and invoking `CapabilityReference`/`RuleReference` literals once per active branch. `RuleReference` backtracks over multiple nested Outcomes (a Rule's Interpretation isn't required to be single-valued); `CapabilityReference` never does (always single-valued by construction).
- A real inconsistency found during design between the parent spec's original worked example (`rule(notifyTeam, Svc, Outcome, Result)`, two inputs) and the 2-arity Head invariant established later during 6c-i-a's own implementation — resolved by scoping `RuleReference` to exactly one input argument for this phase, with a corrected golden case.
- `NativeTemplate`/`Template` stay pure structural predicates over `Riptide.Derivation.Rule`, no new types — matches the parent spec's own framing.
- Golden-case suite: a bare NativeTemplate invoked directly, fact-pattern-only Bodies (success and zero-match cases), unresolvable capability/rule IRIs, unsupported RuleReference arity, a failed Capability invocation (logged, not crashed), a RuleReference to a nested Rule with multiple bindings (multiple Outcomes returned), and the full walking-skeleton shape (a real two-literal join feeding a Capability feeding a RuleReference to a second NativeTemplate).

## Test plan
- [x] mix test — full suite passes (361 tests). One isolated `Riptide.AuthzTest` failure appeared on two separate full-suite runs, in different specific tests each time — this is the same pre-existing, load-dependent FakeStore/GenServer.stop race already investigated and documented earlier this session (full-suite Ra-cluster contention on this dev box), unrelated to this diff (authz_test.exs isn't touched here).
- [x] mix credo --strict
- [x] mix format --check-formatted
- [x] Golden-case suite (test/riptide/derivation/execute_interpreter_test.exs) — 9 tests covering every case in spec §7, plus 3 new Matcher.bindings/3 tests with zero changes to the pre-existing Matcher test suites — stress-tested 5 consecutive clean runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)