### PR TITLE
Phase 6e-i: Anti-unification algorithm

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring) — 17 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm) — 16 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -580,4 +580,33 @@ spec's original worked example and the 2-arity Head invariant (established later
 argument for this phase — documented explicitly, not silently papered over.
 
 **Status**: Phase 6d-i shipped 2026-08-29. 17 phases remaining across the primary spine and
+the three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6e-i — Anti-unification algorithm
+
+Fourth link in the walking skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → ...`),
+unblocked by 6c-i-a alone. **Shipped 2026-08-29** — see
+`docs/superpowers/specs/2026-08-29-phase-6e-i-anti-unification-design.md`.
+
+`Riptide.Derivation.AntiUnifier.generalize/2` computes a Rule × Rule least-general-
+generalization (Plotkin 1970) plus the two recovering substitutions, operating purely over
+6c-i-a's in-memory representation — no execution substrate, no real Capability. A Rule's
+Body is a logical conjunction, so anti-unifying two Bodies is a search over which literal in
+one corresponds to which in the other (an alignment), pruned by the existing structural
+constraint that `FactPattern.predicate`/`CapabilityReference.capability`/`RuleReference.rule`
+are always fixed IRIs, never `Var.t()` — two literals can only pair if they share the same
+identifying IRI, kind, and arity. Multiple mutually-incomparable alignments are arbitrated
+via bottom-clause-style bounding, concretely read as: keep only the candidates introducing
+the fewest fresh variables, returning all ties (`generalize/2`'s own return type is a list
+for exactly this reason) rather than collapsing to one answer — a still-tied result is
+DedupGate's (6e-iii) concern, not this phase's. A real correctness point found during design,
+not obvious from Plotkin's classical statement: a `Var.t()` never short-circuits the
+"already the same" fast path via string-name equality, since two different Rules' same-named
+variables are unrelated (variable names are rule-local and arbitrary) — every `Var.t()`
+comparison goes through the shared, injective memo map unconditionally. Generalization safety
+(a Head variable absent from a possibly-shrunk Body) is deliberately not checked here — it's
+free from `Matcher.evaluate/2`'s existing `check_safety/2` for whoever evaluates a
+generalization later, most plausibly 6e-ii.
+
+**Status**: Phase 6e-i shipped 2026-08-29. 16 phases remaining across the primary spine and
 the three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/anti_unifier.ex
+++ b/lib/riptide/derivation/anti_unifier.ex
@@ -43,19 +43,63 @@ defmodule Riptide.Derivation.AntiUnifier do
   defp check_heads_compatible(%FactPattern{predicate: p}, %FactPattern{predicate: p}), do: :ok
   defp check_heads_compatible(_head1, _head2), do: {:error, :no_common_structure}
 
-  # Task 1: exactly one trivial pairing per shared identifying key — valid
-  # only when neither Body has two literals sharing a key. Task 2 replaces
-  # this with a full combinatorial bijection search.
+  # Alignments are built and returned in body1's own literal order, so the
+  # generalized Body's literal order (and thus its substitution round-trip)
+  # matches body1's — grouping/enumerating by key alone loses that order.
   defp alignments(body1, body2) do
+    indexed_body1 = Enum.with_index(body1)
+    groups1 = Enum.group_by(indexed_body1, fn {lit, _idx} -> literal_key(lit) end)
     groups2 = Enum.group_by(body2, &literal_key/1)
-    matched_keys = MapSet.new(Map.keys(groups2))
+    shared_keys = MapSet.intersection(MapSet.new(Map.keys(groups1)), MapSet.new(Map.keys(groups2)))
 
-    pairs =
-      body1
-      |> Enum.filter(&MapSet.member?(matched_keys, literal_key(&1)))
-      |> Enum.map(fn lit1 -> {lit1, hd(Map.fetch!(groups2, literal_key(lit1)))} end)
+    shared_keys
+    |> Enum.map(fn key -> all_bijections(Map.fetch!(groups1, key), Map.fetch!(groups2, key)) end)
+    |> cartesian_product()
+    |> Enum.map(fn combo ->
+      combo
+      |> List.flatten()
+      |> Enum.sort_by(fn {{_lit1, idx}, _lit2} -> idx end)
+      |> Enum.map(fn {{lit1, _idx}, lit2} -> {lit1, lit2} end)
+    end)
+  end
 
-    [pairs]
+  # All ways to pair up to min(length(list_a), length(list_b)) elements
+  # between the two lists — the shorter list is always fully paired; the
+  # longer list's excess elements are left unmatched in that pairing (and
+  # WHICH excess elements are left out, and in what order the rest pair,
+  # both vary across the returned alignments).
+  defp all_bijections(list_a, list_b) when length(list_a) <= length(list_b) do
+    list_b
+    |> combinations(length(list_a))
+    |> Enum.flat_map(&permutations/1)
+    |> Enum.map(fn chosen_b -> Enum.zip(list_a, chosen_b) end)
+  end
+
+  defp all_bijections(list_a, list_b) do
+    list_b
+    |> all_bijections(list_a)
+    |> Enum.map(fn pairs -> Enum.map(pairs, fn {b, a} -> {a, b} end) end)
+  end
+
+  defp permutations([]), do: [[]]
+
+  defp permutations(list) do
+    for elem <- list, rest <- permutations(list -- [elem]), do: [elem | rest]
+  end
+
+  defp combinations(_list, 0), do: [[]]
+  defp combinations([], _n), do: []
+
+  defp combinations([head | tail], n) do
+    with_head = for combo <- combinations(tail, n - 1), do: [head | combo]
+    without_head = combinations(tail, n)
+    with_head ++ without_head
+  end
+
+  defp cartesian_product([]), do: [[]]
+
+  defp cartesian_product([options | rest]) do
+    for option <- options, combo <- cartesian_product(rest), do: [option | combo]
   end
 
   defp literal_key(%FactPattern{predicate: p, args: args}), do: {:fact_pattern, p, length(args)}

--- a/lib/riptide/derivation/anti_unifier.ex
+++ b/lib/riptide/derivation/anti_unifier.ex
@@ -1,0 +1,195 @@
+defmodule Riptide.Derivation.AntiUnifier do
+  @moduledoc """
+  Rule × Rule → Rule least-general-generalization (Plotkin 1970), with
+  bottom-clause-style bounding arbitrating multiple mutually-incomparable
+  candidates. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6e-i-anti-unification-design.md`.
+
+  A Var never short-circuits the "already the same" fast path — not even
+  when both sides share a string name — since variable names are
+  rule-local and arbitrary (§3 of the design spec). Every Var comparison
+  goes through the shared, injective memo map below.
+  """
+
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
+  alias Riptide.Derivation.{Rule, Signature, Var}
+
+  @max_body_length 32
+
+  @type substitution :: %{Var.t() => RDF.Term.t() | Var.t()}
+
+  @spec generalize(Rule.t(), Rule.t()) ::
+          {:ok, [{Rule.t(), substitution, substitution}]}
+          | {:error, :no_common_structure | :body_too_large}
+  def generalize(%Rule{} = rule1, %Rule{} = rule2) do
+    with :ok <- check_body_length(rule1),
+         :ok <- check_body_length(rule2),
+         :ok <- check_heads_compatible(rule1.head, rule2.head) do
+      existing_var_names = collect_var_names(rule1, rule2)
+
+      candidates =
+        rule1.body
+        |> alignments(rule2.body)
+        |> Enum.map(&build_candidate(rule1.head, rule2.head, &1, existing_var_names))
+
+      {:ok, narrow_by_variable_count(candidates)}
+    end
+  end
+
+  defp check_body_length(%Rule{body: body}) do
+    if length(body) > @max_body_length, do: {:error, :body_too_large}, else: :ok
+  end
+
+  defp check_heads_compatible(%FactPattern{predicate: p}, %FactPattern{predicate: p}), do: :ok
+  defp check_heads_compatible(_head1, _head2), do: {:error, :no_common_structure}
+
+  # Task 1: exactly one trivial pairing per shared identifying key — valid
+  # only when neither Body has two literals sharing a key. Task 2 replaces
+  # this with a full combinatorial bijection search.
+  defp alignments(body1, body2) do
+    groups2 = Enum.group_by(body2, &literal_key/1)
+    matched_keys = MapSet.new(Map.keys(groups2))
+
+    pairs =
+      body1
+      |> Enum.filter(&MapSet.member?(matched_keys, literal_key(&1)))
+      |> Enum.map(fn lit1 -> {lit1, hd(Map.fetch!(groups2, literal_key(lit1)))} end)
+
+    [pairs]
+  end
+
+  defp literal_key(%FactPattern{predicate: p, args: args}), do: {:fact_pattern, p, length(args)}
+
+  defp literal_key(%CapabilityReference{capability: c, args: args}),
+    do: {:capability_reference, c, length(args)}
+
+  defp literal_key(%RuleReference{rule: r, args: args}), do: {:rule_reference, r, length(args)}
+
+  defp collect_var_names(rule1, rule2) do
+    [rule1, rule2]
+    |> Enum.flat_map(&vars_in_rule/1)
+    |> Enum.map(& &1.name)
+    |> MapSet.new()
+  end
+
+  defp vars_in_rule(%Rule{head: head, body: body}) do
+    Enum.flat_map([head | body], &vars_in_literal/1)
+  end
+
+  defp vars_in_literal(%FactPattern{args: args}), do: Enum.filter(args, &match?(%Var{}, &1))
+
+  defp vars_in_literal(%CapabilityReference{args: args, result: result}) do
+    Enum.filter([result | args], &match?(%Var{}, &1))
+  end
+
+  defp vars_in_literal(%RuleReference{args: args, result: result}) do
+    Enum.filter([result | args], &match?(%Var{}, &1))
+  end
+
+  defp build_candidate(head1, head2, pairs, existing_var_names) do
+    state0 = %{memo: %{}, counter: 0, existing: existing_var_names}
+
+    {subject, state1} = anti_unify_term(Enum.at(head1.args, 0), Enum.at(head2.args, 0), state0)
+    {object, state2} = anti_unify_term(Enum.at(head1.args, 1), Enum.at(head2.args, 1), state1)
+    generalized_head = %FactPattern{predicate: head1.predicate, args: [subject, object]}
+
+    {body, final_state} =
+      Enum.map_reduce(pairs, state2, fn {lit1, lit2}, state ->
+        anti_unify_literal_pair(lit1, lit2, state)
+      end)
+
+    signature = derive_signature(generalized_head, body)
+    generalized_rule = %Rule{signature: signature, head: generalized_head, body: body}
+    {sub1, sub2} = build_substitutions(final_state.memo)
+
+    {generalized_rule, map_size(final_state.memo), sub1, sub2}
+  end
+
+  defp anti_unify_literal_pair(
+         %FactPattern{predicate: p, args: [s1, o1]},
+         %FactPattern{args: [s2, o2]},
+         state
+       ) do
+    {subject, state1} = anti_unify_term(s1, s2, state)
+    {object, state2} = anti_unify_term(o1, o2, state1)
+    {%FactPattern{predicate: p, args: [subject, object]}, state2}
+  end
+
+  defp anti_unify_literal_pair(
+         %CapabilityReference{capability: c, args: args1, result: result1},
+         %CapabilityReference{args: args2, result: result2},
+         state
+       ) do
+    {generalized_args, state1} =
+      Enum.map_reduce(Enum.zip(args1, args2), state, fn {a1, a2}, s -> anti_unify_term(a1, a2, s) end)
+
+    {generalized_result, state2} = anti_unify_term(result1, result2, state1)
+    {%CapabilityReference{capability: c, args: generalized_args, result: generalized_result}, state2}
+  end
+
+  defp anti_unify_literal_pair(
+         %RuleReference{rule: r, args: args1, result: result1},
+         %RuleReference{args: args2, result: result2},
+         state
+       ) do
+    {generalized_args, state1} =
+      Enum.map_reduce(Enum.zip(args1, args2), state, fn {a1, a2}, s -> anti_unify_term(a1, a2, s) end)
+
+    {generalized_result, state2} = anti_unify_term(result1, result2, state1)
+    {%RuleReference{rule: r, args: generalized_args, result: generalized_result}, state2}
+  end
+
+  defp anti_unify_term(t1, t2, state) do
+    if same_shape?(t1, t2) do
+      {t1, state}
+    else
+      case Map.fetch(state.memo, {t1, t2}) do
+        {:ok, var} ->
+          {var, state}
+
+        :error ->
+          {var, counter} = fresh_var(state.counter, state.existing)
+          {var, %{state | memo: Map.put(state.memo, {t1, t2}, var), counter: counter}}
+      end
+    end
+  end
+
+  # A Var never takes the "already the same" fast path — see moduledoc.
+  defp same_shape?(%Var{}, _t2), do: false
+  defp same_shape?(_t1, %Var{}), do: false
+  defp same_shape?(t1, t2), do: t1 == t2
+
+  defp fresh_var(counter, existing_var_names) do
+    name = "$au_#{counter}"
+
+    if MapSet.member?(existing_var_names, name) do
+      fresh_var(counter + 1, existing_var_names)
+    else
+      {%Var{name: name}, counter + 1}
+    end
+  end
+
+  defp derive_signature(%FactPattern{predicate: name, args: params}, body) do
+    reads =
+      body
+      |> Enum.filter(&match?(%FactPattern{}, &1))
+      |> Enum.map(& &1.predicate)
+      |> Enum.uniq()
+
+    %Signature{name: name, parameters: params, reads: reads, produces: [name]}
+  end
+
+  defp build_substitutions(memo) do
+    sub1 = Map.new(memo, fn {{s, _t}, var} -> {var, s} end)
+    sub2 = Map.new(memo, fn {{_s, t}, var} -> {var, t} end)
+    {sub1, sub2}
+  end
+
+  defp narrow_by_variable_count(candidates) do
+    min_count = candidates |> Enum.map(fn {_rule, count, _sub1, _sub2} -> count end) |> Enum.min()
+
+    candidates
+    |> Enum.filter(fn {_rule, count, _sub1, _sub2} -> count == min_count end)
+    |> Enum.map(fn {rule, _count, sub1, sub2} -> {rule, sub1, sub2} end)
+  end
+end

--- a/lib/riptide/derivation/anti_unifier.ex
+++ b/lib/riptide/derivation/anti_unifier.ex
@@ -50,7 +50,9 @@ defmodule Riptide.Derivation.AntiUnifier do
     indexed_body1 = Enum.with_index(body1)
     groups1 = Enum.group_by(indexed_body1, fn {lit, _idx} -> literal_key(lit) end)
     groups2 = Enum.group_by(body2, &literal_key/1)
-    shared_keys = MapSet.intersection(MapSet.new(Map.keys(groups1)), MapSet.new(Map.keys(groups2)))
+
+    shared_keys =
+      MapSet.intersection(MapSet.new(Map.keys(groups1)), MapSet.new(Map.keys(groups2)))
 
     shared_keys
     |> Enum.map(fn key -> all_bijections(Map.fetch!(groups1, key), Map.fetch!(groups2, key)) end)
@@ -165,10 +167,14 @@ defmodule Riptide.Derivation.AntiUnifier do
          state
        ) do
     {generalized_args, state1} =
-      Enum.map_reduce(Enum.zip(args1, args2), state, fn {a1, a2}, s -> anti_unify_term(a1, a2, s) end)
+      Enum.map_reduce(Enum.zip(args1, args2), state, fn {a1, a2}, s ->
+        anti_unify_term(a1, a2, s)
+      end)
 
     {generalized_result, state2} = anti_unify_term(result1, result2, state1)
-    {%CapabilityReference{capability: c, args: generalized_args, result: generalized_result}, state2}
+
+    {%CapabilityReference{capability: c, args: generalized_args, result: generalized_result},
+     state2}
   end
 
   defp anti_unify_literal_pair(
@@ -177,7 +183,9 @@ defmodule Riptide.Derivation.AntiUnifier do
          state
        ) do
     {generalized_args, state1} =
-      Enum.map_reduce(Enum.zip(args1, args2), state, fn {a1, a2}, s -> anti_unify_term(a1, a2, s) end)
+      Enum.map_reduce(Enum.zip(args1, args2), state, fn {a1, a2}, s ->
+        anti_unify_term(a1, a2, s)
+      end)
 
     {generalized_result, state2} = anti_unify_term(result1, result2, state1)
     {%RuleReference{rule: r, args: generalized_args, result: generalized_result}, state2}

--- a/test/riptide/derivation/anti_unifier_test.exs
+++ b/test/riptide/derivation/anti_unifier_test.exs
@@ -43,9 +43,15 @@ defmodule Riptide.Derivation.AntiUnifierTest do
   test "a simple unique lgg shares one generalization variable for a value recurring across head and body" do
     rule1 =
       rule(
-        %FactPattern{predicate: rel("greeted"), args: [RDF.literal("alice"), %Var{name: "Result"}]},
+        %FactPattern{
+          predicate: rel("greeted"),
+          args: [RDF.literal("alice"), %Var{name: "Result"}]
+        },
         [
-          %FactPattern{predicate: rel("pendingDeploy"), args: [RDF.literal("alice"), RDF.literal("v1")]},
+          %FactPattern{
+            predicate: rel("pendingDeploy"),
+            args: [RDF.literal("alice"), RDF.literal("v1")]
+          },
           %CapabilityReference{
             capability: cap("deployService"),
             args: [RDF.literal("alice"), RDF.literal("v1")],
@@ -58,7 +64,10 @@ defmodule Riptide.Derivation.AntiUnifierTest do
       rule(
         %FactPattern{predicate: rel("greeted"), args: [RDF.literal("bob"), %Var{name: "Result"}]},
         [
-          %FactPattern{predicate: rel("pendingDeploy"), args: [RDF.literal("bob"), RDF.literal("v2")]},
+          %FactPattern{
+            predicate: rel("pendingDeploy"),
+            args: [RDF.literal("bob"), RDF.literal("v2")]
+          },
           %CapabilityReference{
             capability: cap("deployService"),
             args: [RDF.literal("bob"), RDF.literal("v2")],
@@ -99,8 +108,11 @@ defmodule Riptide.Derivation.AntiUnifierTest do
         %FactPattern{predicate: rel("f#{i}"), args: [%Var{name: "A#{i}"}, %Var{name: "B#{i}"}]}
       end
 
-    big_rule = rule(%FactPattern{predicate: rel("out"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, body)
-    small_rule = rule(%FactPattern{predicate: rel("out"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, [])
+    big_rule =
+      rule(%FactPattern{predicate: rel("out"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, body)
+
+    small_rule =
+      rule(%FactPattern{predicate: rel("out"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, [])
 
     assert AntiUnifier.generalize(big_rule, small_rule) == {:error, :body_too_large}
     assert AntiUnifier.generalize(small_rule, big_rule) == {:error, :body_too_large}

--- a/test/riptide/derivation/anti_unifier_test.exs
+++ b/test/riptide/derivation/anti_unifier_test.exs
@@ -132,6 +132,41 @@ defmodule Riptide.Derivation.AntiUnifierTest do
     assert hd(bar.args) == subject_var
   end
 
+  test "two same-predicate Body literals admit multiple alignments, tied at the same minimum variable count" do
+    rule1 =
+      rule(%FactPattern{predicate: rel("pair"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, [
+        %FactPattern{predicate: rel("likes"), args: [%Var{name: "X"}, RDF.literal("cats")]},
+        %FactPattern{predicate: rel("likes"), args: [%Var{name: "Y"}, RDF.literal("dogs")]}
+      ])
+
+    rule2 =
+      rule(%FactPattern{predicate: rel("pair"), args: [%Var{name: "A"}, %Var{name: "B"}]}, [
+        %FactPattern{predicate: rel("likes"), args: [%Var{name: "A"}, RDF.literal("dogs")]},
+        %FactPattern{predicate: rel("likes"), args: [%Var{name: "B"}, RDF.literal("cats")]}
+      ])
+
+    assert {:ok, candidates} = AntiUnifier.generalize(rule1, rule2)
+
+    # Both valid pairings (straight: X~A,Y~B; crossed: X~B,Y~A) introduce
+    # exactly 4 distinct fresh variables each and are mutually incomparable
+    # — neither should be discarded in favor of the other. The straight
+    # pairing legitimately reuses two of those variables across the head
+    # and body (per the shared-memo-map sharing rule), so occurrence count
+    # differs between the two candidates even though distinct-variable
+    # count does not — hence dedup before counting.
+    assert length(candidates) == 2
+
+    for {generalization, _sub1, _sub2} <- candidates do
+      assert all_generalization_vars?(generalization)
+      assert generalization |> vars_in_rule() |> Enum.uniq() |> length() == 4
+    end
+
+    # The two candidates must actually be structurally different from
+    # each other (not two copies of the same generalization).
+    [{gen1, _, _}, {gen2, _, _}] = candidates
+    refute gen1.body == gen2.body
+  end
+
   defp substitute_rule(%Rule{head: head, body: body, signature: signature} = rule, substitution) do
     %{
       rule

--- a/test/riptide/derivation/anti_unifier_test.exs
+++ b/test/riptide/derivation/anti_unifier_test.exs
@@ -1,0 +1,161 @@
+defmodule Riptide.Derivation.AntiUnifierTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.AntiUnifier
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
+  alias Riptide.Derivation.{Rule, Signature, Var}
+
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp cap(name), do: RDF.iri("urn:riptide:capability:" <> name)
+
+  defp rule(head, body) do
+    %Rule{
+      signature: %Signature{
+        name: head.predicate,
+        parameters: head.args,
+        reads: body |> Enum.filter(&match?(%FactPattern{}, &1)) |> Enum.map(& &1.predicate),
+        produces: [head.predicate]
+      },
+      head: head,
+      body: body
+    }
+  end
+
+  # Every variable in the generalization must be a fresh "$au_" one — the
+  # generalized Rule should never literally reuse either input's own
+  # variable names, even where an input's own name happened to survive
+  # unchanged by coincidence.
+  defp all_generalization_vars?(%Rule{} = rule) do
+    rule
+    |> vars_in_rule()
+    |> Enum.all?(&String.starts_with?(&1.name, "$au_"))
+  end
+
+  defp vars_in_rule(%Rule{head: head, body: body}) do
+    [head | body]
+    |> Enum.flat_map(fn
+      %FactPattern{args: args} -> args
+      %CapabilityReference{args: args, result: result} -> [result | args]
+    end)
+    |> Enum.filter(&match?(%Var{}, &1))
+  end
+
+  test "a simple unique lgg shares one generalization variable for a value recurring across head and body" do
+    rule1 =
+      rule(
+        %FactPattern{predicate: rel("greeted"), args: [RDF.literal("alice"), %Var{name: "Result"}]},
+        [
+          %FactPattern{predicate: rel("pendingDeploy"), args: [RDF.literal("alice"), RDF.literal("v1")]},
+          %CapabilityReference{
+            capability: cap("deployService"),
+            args: [RDF.literal("alice"), RDF.literal("v1")],
+            result: %Var{name: "Result"}
+          }
+        ]
+      )
+
+    rule2 =
+      rule(
+        %FactPattern{predicate: rel("greeted"), args: [RDF.literal("bob"), %Var{name: "Result"}]},
+        [
+          %FactPattern{predicate: rel("pendingDeploy"), args: [RDF.literal("bob"), RDF.literal("v2")]},
+          %CapabilityReference{
+            capability: cap("deployService"),
+            args: [RDF.literal("bob"), RDF.literal("v2")],
+            result: %Var{name: "Result"}
+          }
+        ]
+      )
+
+    assert {:ok, [{generalization, sub1, sub2}]} = AntiUnifier.generalize(rule1, rule2)
+
+    assert all_generalization_vars?(generalization)
+
+    # "alice"/"bob" recur in three places (head subject, pendingDeploy
+    # subject, capability's first arg) — all three must share ONE
+    # generalization variable, not three independent ones.
+    subject_var = hd(generalization.head.args)
+    [pending_deploy] = Enum.filter(generalization.body, &match?(%FactPattern{}, &1))
+    [capability] = Enum.filter(generalization.body, &match?(%CapabilityReference{}, &1))
+    assert hd(pending_deploy.args) == subject_var
+    assert hd(capability.args) == subject_var
+
+    # The two recovering substitutions must reconstruct each original Rule
+    # exactly when applied to the generalization.
+    assert substitute_rule(generalization, sub1) == rule1
+    assert substitute_rule(generalization, sub2) == rule2
+  end
+
+  test "different Head predicates have no common structure" do
+    rule1 = rule(%FactPattern{predicate: rel("a"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, [])
+    rule2 = rule(%FactPattern{predicate: rel("b"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, [])
+
+    assert AntiUnifier.generalize(rule1, rule2) == {:error, :no_common_structure}
+  end
+
+  test "a Body longer than 32 literals is rejected before any search begins" do
+    body =
+      for i <- 1..33 do
+        %FactPattern{predicate: rel("f#{i}"), args: [%Var{name: "A#{i}"}, %Var{name: "B#{i}"}]}
+      end
+
+    big_rule = rule(%FactPattern{predicate: rel("out"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, body)
+    small_rule = rule(%FactPattern{predicate: rel("out"), args: [%Var{name: "X"}, %Var{name: "Y"}]}, [])
+
+    assert AntiUnifier.generalize(big_rule, small_rule) == {:error, :body_too_large}
+    assert AntiUnifier.generalize(small_rule, big_rule) == {:error, :body_too_large}
+  end
+
+  test "same-named-but-unrelated variables never shortcut into the generalization unchanged" do
+    # Both rules use "X" for their head subject AND their bar/2 subject --
+    # the SAME (Var{"X"}, Var{"X"}) pair recurs, so the correct behavior is
+    # to reuse one fresh generalization variable across both occurrences.
+    # A buggy implementation that treats same-named Vars as "already
+    # equal" would instead leave the literal name "X" in the output.
+    rule1 =
+      rule(%FactPattern{predicate: rel("foo"), args: [%Var{name: "X"}, RDF.literal("a")]}, [
+        %FactPattern{predicate: rel("bar"), args: [%Var{name: "X"}, RDF.literal("p")]}
+      ])
+
+    rule2 =
+      rule(%FactPattern{predicate: rel("foo"), args: [%Var{name: "X"}, RDF.literal("b")]}, [
+        %FactPattern{predicate: rel("bar"), args: [%Var{name: "X"}, RDF.literal("q")]}
+      ])
+
+    assert {:ok, [{generalization, _sub1, _sub2}]} = AntiUnifier.generalize(rule1, rule2)
+    assert all_generalization_vars?(generalization)
+
+    # The shared X-vs-X pair must generalize to ONE variable, reused in
+    # both the head subject and bar's subject.
+    [subject_var, _] = generalization.head.args
+    [bar] = generalization.body
+    assert hd(bar.args) == subject_var
+  end
+
+  defp substitute_rule(%Rule{head: head, body: body, signature: signature} = rule, substitution) do
+    %{
+      rule
+      | head: substitute_literal(head, substitution),
+        body: Enum.map(body, &substitute_literal(&1, substitution)),
+        signature: %{
+          signature
+          | parameters: Enum.map(signature.parameters, &substitute_term(&1, substitution))
+        }
+    }
+  end
+
+  defp substitute_literal(%FactPattern{} = lit, substitution) do
+    %{lit | args: Enum.map(lit.args, &substitute_term(&1, substitution))}
+  end
+
+  defp substitute_literal(%CapabilityReference{} = lit, substitution) do
+    %{
+      lit
+      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
+        result: substitute_term(lit.result, substitution)
+    }
+  end
+
+  defp substitute_term(%Var{} = var, substitution), do: Map.fetch!(substitution, var)
+  defp substitute_term(term, _substitution), do: term
+end


### PR DESCRIPTION
## Summary

Implements Sub-project 6, phase **6e-i** (issue #78) — the fourth link in the walking
skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → ...`), unblocked by 6c-i-a alone.

Adds `Riptide.Derivation.AntiUnifier.generalize/2`: a pure, in-memory Rule × Rule
least-general-generalization (Plotkin 1970) over 6c-i-a's representation, with
bottom-clause-style bounding arbitrating multiple mutually-incomparable candidates when a
Rule's Body admits more than one valid literal alignment.

- Term-level anti-unification via a shared, injective memo map — the same mismatched
  term-pair recurring anywhere (a shared join variable across Body literals, or a value
  recurring between Head and Body) generalizes to the same fresh variable, preserving
  shared structure instead of erasing it.
- A `Var.t()` never short-circuits the "already equal" fast path via string-name equality
  — two different Rules' same-named variables are unrelated (names are rule-local and
  arbitrary); every `Var.t()` comparison goes through the memo map unconditionally.
- Body alignment is pruned by an existing structural constraint: `FactPattern.predicate`,
  `CapabilityReference.capability`, `RuleReference.rule` are always fixed IRIs, never
  `Var.t()`, so two literals can only pair if they share the same identifying IRI, kind,
  and arity. Genuine ambiguity only arises when a Body has two-or-more literals sharing a
  key; the full combinatorial bijection search handles that case.
- Arbitration keeps only the candidates introducing the fewest fresh variables, returning
  all ties (`generalize/2`'s return type is a list for exactly this reason) rather than
  collapsing to one answer — resolving a still-tied result is DedupGate's (6e-iii) job.
- A Head predicate mismatch is an immediate `{:error, :no_common_structure}`, never routed
  through the generic per-argument mismatch mechanism (a Head can't simply be dropped the
  way an unmatched Body literal can).
- A Body longer than 32 literals is rejected with `{:error, :body_too_large}` before any
  alignment search begins (the search is combinatorial in the worst case).
- Generalization safety (a Head variable absent from a possibly-shrunk Body) is
  deliberately not checked here — it's free from `Matcher.evaluate/2`'s existing
  `check_safety/2` for whoever evaluates a generalization later, most plausibly 6e-ii.

Design spec: `docs/superpowers/specs/2026-08-29-phase-6e-i-anti-unification-design.md`
(merged via #91).

## Test plan

- [x] `mix test test/riptide/derivation/anti_unifier_test.exs` — 5/5 passing:
  - a simple unique lgg sharing one generalization variable across Head and Body
  - different Head predicates → `{:error, :no_common_structure}`
  - a Body > 32 literals → `{:error, :body_too_large}` before any search
  - same-named-but-unrelated variables never shortcut into the output unchanged
  - two same-predicate Body literals admitting multiple alignments, tied at the same
    minimum variable count — arbitration returns both, not one arbitrarily
- [x] Full `mix test` — 366 tests, 7 pre-existing failures, all `wasmtime`-binary-missing
  (`Riptide.CapabilityTest`/`Riptide.Derivation.ExecuteInterpreterTest`), a known,
  documented per-session artifact of this admin box unrelated to 6e-i (which is pure
  in-memory and never touches `wasmtime`) — confirmed via real CI below.
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [x] `PROGRESS.md` updated (6e-i marked shipped, remaining count 17 → 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)