### PR TITLE
Phase 6e-ii: Generalization Fidelity replay harness

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm) — 16 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness) — 15 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -609,4 +609,39 @@ free from `Matcher.evaluate/2`'s existing `check_safety/2` for whoever evaluates
 generalization later, most plausibly 6e-ii.
 
 **Status**: Phase 6e-i shipped 2026-08-29. 16 phases remaining across the primary spine and
+the three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6e-ii — Generalization Fidelity replay harness
+
+Fifth link in the walking skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → ...`),
+unblocked by 6e-i (needs a Generalization to test against) and 6b-i (needs the WASI sandbox
+to replay into). **Shipped 2026-08-29** — see
+`docs/superpowers/specs/2026-08-29-phase-6e-ii-generalization-fidelity-design.md`.
+
+`Riptide.Derivation.GeneralizationFidelity.check/3` checks whether a ground Trace (a
+`Rule.t()` whose Signature has no free parameters, per parent spec §5) replays faithfully.
+The key insight: a ground Trace's `CapabilityReference.result` field, once ground, already
+*is* that invocation's recorded output — no new Provenance/recording type was needed, and
+the harness never touches `AntiUnifier`/Generalization/substitution at all, reusing
+`ExecuteInterpreter.Context` and the real, unmodified `Capability.invoke/4` as-is. Replay is
+a straight-line recursive walk over the Body (no join search — everything's already
+concrete): FactPattern literals check graph membership via `RDF.Graph.include?/2`;
+`:effect`-kind Capabilities are re-invoked (real `wasmtime`) and compared against the
+recorded result; `:observe`-kind Capabilities are always trusted from the recorded result and
+never invoked, matching parent spec §4's literal wording that the external world isn't
+expected to be frozen between runs; `RuleReference` literals recurse through
+`context.rules`, reusing the same map `ExecuteInterpreter` already uses for live execution,
+with a nested fidelity failure wrapped as `{:nested, iri, inner_reason}` while a nested
+structural error propagates unwrapped (matching `ExecuteInterpreter`'s own convention). A
+pre-existing quirk was documented, not fixed: `ExecuteInterpreter.bind_result/3` binds a
+Capability's raw invoke output as a plain Elixir string rather than an `RDF.Term.t()`, as its
+declared type implies — fixing it would mean touching already-shipped, tested 6d-i code, and
+both sides of the fidelity check's `==` comparison come from the same `Capability.invoke/4`
+path regardless, so they stay mutually consistent. A round-trip integration test composes
+`AntiUnifier.generalize/2` → reconstruct each candidate via its own recovering substitution →
+`check/3` on each reconstructed Trace, satisfying the exit criterion's literal wording ("given
+a Generalization and its source Traces...") end-to-end via test composition rather than the
+module's own signature.
+
+**Status**: Phase 6e-ii shipped 2026-08-29. 15 phases remaining across the primary spine and
 the three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -11,6 +11,8 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
   ground `Rule.t()` + graph + `ExecuteInterpreter.Context.t()`, reused as-is.
   """
 
+  alias Riptide.Capability
+  alias Riptide.Capability.Definition
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
   alias Riptide.Derivation.{Rule, Var}
@@ -65,4 +67,39 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
       {:ok, {:fidelity_fail, {:fact_not_present, {subject, predicate, object}}}}
     end
   end
+
+  defp check_body(
+         [%CapabilityReference{capability: iri, args: args, result: result} | rest],
+         graph,
+         context
+       ) do
+    case Map.fetch(context.capabilities, iri) do
+      {:ok, %Definition{kind: :effect} = definition} ->
+        resolved_args = Enum.map(args, &term_to_arg/1)
+
+        case Capability.invoke(definition, context.tenant_id, context.current_subject, resolved_args) do
+          {:ok, ^result} ->
+            check_body(rest, graph, context)
+
+          {:ok, actual} ->
+            {:ok, {:fidelity_fail, {:capability_mismatch, iri, result, actual}}}
+
+          {:error, reason} ->
+            {:ok, {:fidelity_fail, {:capability_error, iri, reason}}}
+        end
+
+      :error ->
+        {:error, {:unresolvable, iri}}
+    end
+  end
+
+  # Capability.invoke/4 requires plain Elixir strings — a ground literal's
+  # arg is an RDF.Term.t() (an IRI or Literal), never a bare string on its
+  # own. Deliberate small duplication of ExecuteInterpreter's own private
+  # helper of the same name/shape (lib/riptide/derivation/execute_interpreter.ex)
+  # rather than exporting it across modules — matches this project's
+  # established tolerance for that.
+  defp term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
+  defp term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
+  defp term_to_arg(string) when is_binary(string), do: string
 end

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -74,6 +74,9 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
          context
        ) do
     case Map.fetch(context.capabilities, iri) do
+      {:ok, %Definition{kind: :observe}} ->
+        check_body(rest, graph, context)
+
       {:ok, %Definition{kind: :effect} = definition} ->
         resolved_args = Enum.map(args, &term_to_arg/1)
 

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -1,0 +1,56 @@
+defmodule Riptide.Derivation.GeneralizationFidelity do
+  @moduledoc """
+  Checks whether a ground Trace (a `Rule.t()` whose Signature has no free
+  parameters, per parent spec §5) replays faithfully: FactPattern presence
+  in the graph, `:effect` Capabilities re-invoked and compared, `:observe`
+  Capabilities trusted from their recorded result, RuleReference recursed
+  through `context.rules`. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6e-ii-generalization-fidelity-design.md`.
+
+  Never touches `AntiUnifier`/Generalization/substitution — operates on one
+  ground `Rule.t()` + graph + `ExecuteInterpreter.Context.t()`, reused as-is.
+  """
+
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
+  alias Riptide.Derivation.{Rule, Var}
+
+  @type reason ::
+          {:fact_not_present, {RDF.Term.t(), RDF.IRI.t(), RDF.Term.t()}}
+          | {:capability_mismatch, RDF.IRI.t(), term(), term()}
+          | {:capability_error, RDF.IRI.t(), term()}
+          | {:nested, RDF.IRI.t(), reason()}
+
+  @doc """
+  Replays `rule` (a ground Trace) against `graph`/`context` and reports
+  fidelity. `{:error, _}` only for a structural problem (not fully ground,
+  or the same unresolvable-IRI/unsupported-arity shapes `ExecuteInterpreter`
+  already reports for the identical situations).
+  """
+  @spec check(Rule.t(), RDF.Graph.t(), Context.t()) ::
+          {:ok, :fidelity_pass}
+          | {:ok, {:fidelity_fail, reason()}}
+          | {:error, :not_ground | {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+  def check(%Rule{} = rule, %RDF.Graph{} = graph, %Context{} = context) do
+    if ground?(rule) do
+      check_body(rule.body, graph, context)
+    else
+      {:error, :not_ground}
+    end
+  end
+
+  defp ground?(%Rule{head: head, body: body}), do: Enum.all?([head | body], &literal_ground?/1)
+
+  defp literal_ground?(%FactPattern{args: args}), do: Enum.all?(args, &term_ground?/1)
+
+  defp literal_ground?(%CapabilityReference{args: args, result: result}),
+    do: Enum.all?([result | args], &term_ground?/1)
+
+  defp literal_ground?(%RuleReference{args: args, result: result}),
+    do: Enum.all?([result | args], &term_ground?/1)
+
+  defp term_ground?(%Var{}), do: false
+  defp term_ground?(_term), do: true
+
+  defp check_body([], _graph, _context), do: {:ok, :fidelity_pass}
+end

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -105,4 +105,23 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
   defp term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
   defp term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
   defp term_to_arg(string) when is_binary(string), do: string
+
+  defp check_body([%RuleReference{rule: iri, args: args} | rest], graph, context) do
+    cond do
+      not Map.has_key?(context.rules, iri) ->
+        {:error, {:unresolvable, iri}}
+
+      length(args) != 1 ->
+        {:error, {:unsupported_arity, iri}}
+
+      true ->
+        nested_rule = Map.fetch!(context.rules, iri)
+
+        case check(nested_rule, graph, context) do
+          {:ok, :fidelity_pass} -> check_body(rest, graph, context)
+          {:ok, {:fidelity_fail, reason}} -> {:ok, {:fidelity_fail, {:nested, iri, reason}}}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
 end

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -53,4 +53,16 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
   defp term_ground?(_term), do: true
 
   defp check_body([], _graph, _context), do: {:ok, :fidelity_pass}
+
+  defp check_body(
+         [%FactPattern{predicate: predicate, args: [subject, object]} | rest],
+         graph,
+         context
+       ) do
+    if RDF.Graph.include?(graph, {subject, predicate, object}) do
+      check_body(rest, graph, context)
+    else
+      {:ok, {:fidelity_fail, {:fact_not_present, {subject, predicate, object}}}}
+    end
+  end
 end

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -32,7 +32,8 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
   @spec check(Rule.t(), RDF.Graph.t(), Context.t()) ::
           {:ok, :fidelity_pass}
           | {:ok, {:fidelity_fail, reason()}}
-          | {:error, :not_ground | {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+          | {:error,
+             :not_ground | {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
   def check(%Rule{} = rule, %RDF.Graph{} = graph, %Context{} = context) do
     if ground?(rule) do
       check_body(rule.body, graph, context)
@@ -80,7 +81,12 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
       {:ok, %Definition{kind: :effect} = definition} ->
         resolved_args = Enum.map(args, &term_to_arg/1)
 
-        case Capability.invoke(definition, context.tenant_id, context.current_subject, resolved_args) do
+        case Capability.invoke(
+               definition,
+               context.tenant_id,
+               context.current_subject,
+               resolved_args
+             ) do
           {:ok, ^result} ->
             check_body(rest, graph, context)
 
@@ -95,16 +101,6 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
         {:error, {:unresolvable, iri}}
     end
   end
-
-  # Capability.invoke/4 requires plain Elixir strings — a ground literal's
-  # arg is an RDF.Term.t() (an IRI or Literal), never a bare string on its
-  # own. Deliberate small duplication of ExecuteInterpreter's own private
-  # helper of the same name/shape (lib/riptide/derivation/execute_interpreter.ex)
-  # rather than exporting it across modules — matches this project's
-  # established tolerance for that.
-  defp term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
-  defp term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
-  defp term_to_arg(string) when is_binary(string), do: string
 
   defp check_body([%RuleReference{rule: iri, args: args} | rest], graph, context) do
     cond do
@@ -124,4 +120,14 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
         end
     end
   end
+
+  # Capability.invoke/4 requires plain Elixir strings — a ground literal's
+  # arg is an RDF.Term.t() (an IRI or Literal), never a bare string on its
+  # own. Deliberate small duplication of ExecuteInterpreter's own private
+  # helper of the same name/shape (lib/riptide/derivation/execute_interpreter.ex)
+  # rather than exporting it across modules — matches this project's
+  # established tolerance for that.
+  defp term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
+  defp term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
+  defp term_to_arg(string) when is_binary(string), do: string
 end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -385,4 +385,129 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) == {:ok, :fidelity_pass}
     end
   end
+
+  describe "check/3 — RuleReference" do
+    test "an unresolvable rule IRI is rejected as a structural error" do
+      rule_iri = RDF.iri("urn:riptide:rule:notRegistered")
+      head = %FactPattern{predicate: rel("lookup"), args: [t("alice"), "\"result\""]}
+
+      body = [%RuleReference{rule: rule_iri, args: [t("alice")], result: "\"result\""}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:error, {:unresolvable, rule_iri}}
+    end
+
+    test "a RuleReference with more than one arg is rejected as unsupported arity" do
+      rule_iri = RDF.iri("urn:riptide:rule:nested")
+      head = %FactPattern{predicate: rel("lookup"), args: [t("alice"), "\"result\""]}
+
+      body = [
+        %RuleReference{rule: rule_iri, args: [t("alice"), t("bob")], result: "\"result\""}
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      nested_rule = %Rule{
+        signature: %Signature{name: rule_iri, parameters: [], reads: [], produces: [rule_iri]},
+        head: %FactPattern{predicate: rule_iri, args: [t("alice"), "\"result\""]},
+        body: []
+      }
+
+      ctx = context(%{rules: %{rule_iri => nested_rule}})
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) ==
+               {:error, {:unsupported_arity, rule_iri}}
+    end
+
+    test "recurses into a nested ground Rule and passes when it replays faithfully" do
+      nested_iri = RDF.iri("urn:riptide:rule:colleagueOf")
+
+      nested_rule = %Rule{
+        signature: %Signature{
+          name: nested_iri,
+          parameters: [],
+          reads: [rel("worksAt")],
+          produces: [nested_iri]
+        },
+        head: %FactPattern{predicate: nested_iri, args: [t("alice"), t("acme")]},
+        body: [%FactPattern{predicate: rel("worksAt"), args: [t("alice"), t("acme")]}]
+      }
+
+      head = %FactPattern{predicate: rel("lookup"), args: [t("alice"), t("acme")]}
+      body = [%RuleReference{rule: nested_iri, args: [t("alice")], result: t("acme")}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      graph = RDF.Graph.new([{t("alice"), rel("worksAt"), t("acme")}])
+      ctx = context(%{rules: %{nested_iri => nested_rule}})
+
+      assert GeneralizationFidelity.check(rule, graph, ctx) == {:ok, :fidelity_pass}
+    end
+
+    test "wraps a nested fidelity failure as {:nested, iri, inner_reason}" do
+      nested_iri = RDF.iri("urn:riptide:rule:colleagueOf")
+
+      nested_rule = %Rule{
+        signature: %Signature{
+          name: nested_iri,
+          parameters: [],
+          reads: [rel("worksAt")],
+          produces: [nested_iri]
+        },
+        head: %FactPattern{predicate: nested_iri, args: [t("alice"), t("acme")]},
+        body: [%FactPattern{predicate: rel("worksAt"), args: [t("alice"), t("acme")]}]
+      }
+
+      head = %FactPattern{predicate: rel("lookup"), args: [t("alice"), t("acme")]}
+      body = [%RuleReference{rule: nested_iri, args: [t("alice")], result: t("acme")}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      # graph deliberately empty — the nested Rule's own worksAt fact is missing.
+      ctx = context(%{rules: %{nested_iri => nested_rule}})
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) ==
+               {:ok,
+                {:fidelity_fail,
+                 {:nested, nested_iri, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}}
+    end
+  end
 end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -331,4 +331,58 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
                {:error, {:unresolvable, cap_iri}}
     end
   end
+
+  describe "check/3 — CapabilityReference, :observe kind" do
+    test "never invokes — trusts the recorded result even with a Definition that would error if invoked" do
+      cap_iri = RDF.iri("urn:riptide:capability:externalPriceFeed")
+
+      # component intentionally points at a nonexistent file. If check/3
+      # ever actually invoked this (a regression), Capability.invoke/4
+      # would return {:error, {:trap, _}} and this test would fail on the
+      # {:ok, :fidelity_pass} assertion below — proving non-invocation
+      # rather than merely asserting it.
+      definition = %Definition{
+        name: cap_iri,
+        kind: :observe,
+        component: "test/fixtures/riptide_capability/does_not_exist.wasm",
+        function: "greet",
+        fuel_limit: 100_000_000,
+        timeout_ms: 5_000,
+        memory_limits: %{
+          max_memory_size: nil,
+          max_table_elements: nil,
+          max_instances: nil,
+          max_tables: nil
+        }
+      }
+
+      head = %FactPattern{predicate: rel("observed"), args: [t("riptide"), "\"stale but trusted\""]}
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Alice")],
+          result: "\"stale but trusted\""
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      # No FakeStore policy is registered at all — an :effect invocation
+      # would also fail authorization first, doubling the proof that this
+      # path never reaches Capability.invoke/4.
+      ctx = context(%{capabilities: %{cap_iri => definition}})
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) == {:ok, :fidelity_pass}
+    end
+  end
 end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -1,9 +1,10 @@
 defmodule Riptide.Derivation.GeneralizationFidelityTest do
   use ExUnit.Case, async: true
 
+  alias Riptide.Capability.Definition
   alias Riptide.Derivation.GeneralizationFidelity
   alias Riptide.Derivation.ExecuteInterpreter.Context
-  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
   alias Riptide.Derivation.{Rule, Signature, Var}
 
   defp t(name), do: RDF.iri("urn:test:" <> name)
@@ -14,6 +15,61 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
       overrides
     )
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    on_exit(fn ->
+      if pid = Process.whereis(FakeStore) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp greet_definition(name, kind \\ :effect) do
+    %Definition{
+      name: RDF.iri("urn:riptide:capability:" <> name),
+      kind: kind,
+      component: "test/fixtures/riptide_capability/fixture.wasm",
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
   end
 
   describe "check/3 — groundness precondition" do
@@ -137,6 +193,142 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       # *first* literal's reason, proving Body order is respected.
       assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
                {:ok, {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
+    end
+  end
+
+  describe "check/3 — CapabilityReference, :effect kind" do
+    test "passes when the fresh invocation matches the recorded result" do
+      cap_iri = RDF.iri("urn:riptide:capability:greetAlice")
+
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetAlice"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      head = %FactPattern{predicate: rel("greeted"), args: [t("riptide"), "\"Hello, Alice!\""]}
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Alice")],
+          result: "\"Hello, Alice!\""
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      ctx = context(%{capabilities: %{cap_iri => greet_definition("greetAlice")}})
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) == {:ok, :fidelity_pass}
+    end
+
+    test "fails with :capability_mismatch when the fresh invocation differs from the recorded result" do
+      cap_iri = RDF.iri("urn:riptide:capability:greetAlice")
+
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetAlice"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      head = %FactPattern{
+        predicate: rel("greeted"),
+        args: [t("riptide"), "\"stale recorded value\""]
+      }
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Alice")],
+          result: "\"stale recorded value\""
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      ctx = context(%{capabilities: %{cap_iri => greet_definition("greetAlice")}})
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) ==
+               {:ok,
+                {:fidelity_fail,
+                 {:capability_mismatch, cap_iri, "\"stale recorded value\"", "\"Hello, Alice!\""}}}
+    end
+
+    test "fails with :capability_error when the invocation itself errors (unauthorized)" do
+      cap_iri = RDF.iri("urn:riptide:capability:notGranted")
+      FakeStore.start(%{})
+
+      head = %FactPattern{predicate: rel("greeted"), args: [t("riptide"), "\"Hello, Alice!\""]}
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Alice")],
+          result: "\"Hello, Alice!\""
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      ctx = context(%{capabilities: %{cap_iri => greet_definition("notGranted")}})
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) ==
+               {:ok, {:fidelity_fail, {:capability_error, cap_iri, :unauthorized}}}
+    end
+
+    test "an unresolvable capability IRI is rejected as a structural error" do
+      cap_iri = RDF.iri("urn:riptide:capability:notRegistered")
+      head = %FactPattern{predicate: rel("greeted"), args: [t("riptide"), "\"Hello, Alice!\""]}
+
+      body = [
+        %CapabilityReference{
+          capability: cap_iri,
+          args: [RDF.literal("Alice")],
+          result: "\"Hello, Alice!\""
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:error, {:unresolvable, cap_iri}}
     end
   end
 end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -1,0 +1,75 @@
+defmodule Riptide.Derivation.GeneralizationFidelityTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.GeneralizationFidelity
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Rule, Signature, Var}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp context(overrides \\ %{}) do
+    Map.merge(
+      %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
+      overrides
+    )
+  end
+
+  describe "check/3 — groundness precondition" do
+    test "a fully ground Rule with an empty Body passes trivially" do
+      head = %FactPattern{predicate: rel("greeted"), args: [t("alice"), RDF.literal("hi")]}
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: []
+      }
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:ok, :fidelity_pass}
+    end
+
+    test "a Var anywhere in the Head is rejected as not_ground, even with an empty Body" do
+      head = %FactPattern{predicate: rel("greeted"), args: [%Var{name: "X"}, RDF.literal("hi")]}
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: []
+      }
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:error, :not_ground}
+    end
+
+    test "a Var anywhere in the Body is rejected as not_ground" do
+      head = %FactPattern{predicate: rel("greeted"), args: [t("alice"), RDF.literal("hi")]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "X"}, t("acme")]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:error, :not_ground}
+    end
+  end
+end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -72,4 +72,71 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
                {:error, :not_ground}
     end
   end
+
+  describe "check/3 — FactPattern" do
+    test "passes when the fact is present in the graph" do
+      head = %FactPattern{predicate: rel("greeted"), args: [t("alice"), RDF.literal("hi")]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [t("alice"), t("acme")]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [rel("worksAt")],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      graph = RDF.Graph.new([{t("alice"), rel("worksAt"), t("acme")}])
+
+      assert GeneralizationFidelity.check(rule, graph, context()) == {:ok, :fidelity_pass}
+    end
+
+    test "fails with :fact_not_present when the fact is missing from the graph" do
+      head = %FactPattern{predicate: rel("greeted"), args: [t("alice"), RDF.literal("hi")]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [t("alice"), t("acme")]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [rel("worksAt")],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:ok, {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
+    end
+
+    test "short-circuits: a failing first literal is reported without evaluating the second" do
+      head = %FactPattern{predicate: rel("greeted"), args: [t("alice"), RDF.literal("hi")]}
+
+      body = [
+        %FactPattern{predicate: rel("worksAt"), args: [t("alice"), t("acme")]},
+        %FactPattern{predicate: rel("approved"), args: [t("acme"), t("bob")]}
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [rel("worksAt"), rel("approved")],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      # Neither fact is present — if the second literal were evaluated first
+      # or the walk didn't short-circuit, this assertion still pins the
+      # *first* literal's reason, proving Body order is respected.
+      assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
+               {:ok, {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
+    end
+  end
 end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -510,4 +510,110 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
                  {:nested, nested_iri, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}}
     end
   end
+
+  alias Riptide.Derivation.AntiUnifier
+
+  describe "check/3 — round-trip with AntiUnifier.generalize/2" do
+    test "each source Trace, reconstructed from the generalization via its own recovering substitution, replays faithfully" do
+      cap_iri = RDF.iri("urn:riptide:capability:greetPerson")
+
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      trace1 =
+        %Rule{
+          signature: %Signature{
+            name: rel("greeted"),
+            parameters: [t("alice"), "\"Hello, Alice!\""],
+            reads: [rel("pendingDeploy")],
+            produces: [rel("greeted")]
+          },
+          head: %FactPattern{predicate: rel("greeted"), args: [t("alice"), "\"Hello, Alice!\""]},
+          body: [
+            %FactPattern{predicate: rel("pendingDeploy"), args: [t("alice"), RDF.literal("v1")]},
+            %CapabilityReference{
+              capability: cap_iri,
+              args: [RDF.literal("Alice")],
+              result: "\"Hello, Alice!\""
+            }
+          ]
+        }
+
+      trace2 =
+        %Rule{
+          signature: %Signature{
+            name: rel("greeted"),
+            parameters: [t("bob"), "\"Hello, Bob!\""],
+            reads: [rel("pendingDeploy")],
+            produces: [rel("greeted")]
+          },
+          head: %FactPattern{predicate: rel("greeted"), args: [t("bob"), "\"Hello, Bob!\""]},
+          body: [
+            %FactPattern{predicate: rel("pendingDeploy"), args: [t("bob"), RDF.literal("v2")]},
+            %CapabilityReference{
+              capability: cap_iri,
+              args: [RDF.literal("Bob")],
+              result: "\"Hello, Bob!\""
+            }
+          ]
+        }
+
+      assert {:ok, [{generalization, sub1, sub2}]} = AntiUnifier.generalize(trace1, trace2)
+
+      reconstructed1 = substitute_rule(generalization, sub1)
+      reconstructed2 = substitute_rule(generalization, sub2)
+
+      assert reconstructed1 == trace1
+      assert reconstructed2 == trace2
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v2")}
+        ])
+
+      ctx = context(%{capabilities: %{cap_iri => greet_definition("greetPerson")}})
+
+      assert GeneralizationFidelity.check(reconstructed1, graph, ctx) == {:ok, :fidelity_pass}
+      assert GeneralizationFidelity.check(reconstructed2, graph, ctx) == {:ok, :fidelity_pass}
+    end
+  end
+
+  defp substitute_rule(%Rule{head: head, body: body, signature: signature} = rule, substitution) do
+    %{
+      rule
+      | head: substitute_literal(head, substitution),
+        body: Enum.map(body, &substitute_literal(&1, substitution)),
+        signature: %{
+          signature
+          | parameters: Enum.map(signature.parameters, &substitute_term(&1, substitution))
+        }
+    }
+  end
+
+  defp substitute_literal(%FactPattern{} = lit, substitution) do
+    %{lit | args: Enum.map(lit.args, &substitute_term(&1, substitution))}
+  end
+
+  defp substitute_literal(%CapabilityReference{} = lit, substitution) do
+    %{
+      lit
+      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
+        result: substitute_term(lit.result, substitution)
+    }
+  end
+
+  defp substitute_literal(%RuleReference{} = lit, substitution) do
+    %{
+      lit
+      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
+        result: substitute_term(lit.result, substitution)
+    }
+  end
+
+  defp substitute_term(%Var{} = var, substitution), do: Map.fetch!(substitution, var)
+  defp substitute_term(term, _substitution), do: term
 end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -2,8 +2,8 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
   use ExUnit.Case, async: true
 
   alias Riptide.Capability.Definition
-  alias Riptide.Derivation.GeneralizationFidelity
   alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.GeneralizationFidelity
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
   alias Riptide.Derivation.{Rule, Signature, Var}
 
@@ -166,7 +166,8 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       }
 
       assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
-               {:ok, {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
+               {:ok,
+                {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
     end
 
     test "short-circuits: a failing first literal is reported without evaluating the second" do
@@ -192,7 +193,8 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       # or the walk didn't short-circuit, this assertion still pins the
       # *first* literal's reason, proving Body order is respected.
       assert GeneralizationFidelity.check(rule, RDF.Graph.new(), context()) ==
-               {:ok, {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
+               {:ok,
+                {:fidelity_fail, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}
     end
   end
 
@@ -356,7 +358,10 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
         }
       }
 
-      head = %FactPattern{predicate: rel("observed"), args: [t("riptide"), "\"stale but trusted\""]}
+      head = %FactPattern{
+        predicate: rel("observed"),
+        args: [t("riptide"), "\"stale but trusted\""]
+      }
 
       body = [
         %CapabilityReference{
@@ -507,7 +512,8 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       assert GeneralizationFidelity.check(rule, RDF.Graph.new(), ctx) ==
                {:ok,
                 {:fidelity_fail,
-                 {:nested, nested_iri, {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}}
+                 {:nested, nested_iri,
+                  {:fact_not_present, {t("alice"), rel("worksAt"), t("acme")}}}}}
     end
   end
 


### PR DESCRIPTION
## Summary

Implements Sub-project 6, phase **6e-ii** (issue #79) — the fifth link in the walking
skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → ...`), unblocked by 6e-i
(needs a Generalization to test against) and 6b-i (needs the WASI sandbox to replay into).

Adds `Riptide.Derivation.GeneralizationFidelity.check/3`: given a ground `Rule.t()` (a
Trace, per parent spec §5), replays it per-literal-kind and reports fidelity pass/fail.

- A ground Trace's `CapabilityReference.result` field, once ground, already *is* that
  invocation's recorded output — no new Provenance/recording type is needed.
- FactPattern literals check graph membership via `RDF.Graph.include?/2`.
- `:effect`-kind Capabilities are re-invoked (real `wasmtime`) and compared against the
  recorded result; `:observe`-kind Capabilities are always trusted from the recorded
  result and never invoked (verified via a Definition that would error if actually
  invoked).
- `RuleReference` literals recurse through `context.rules` — reusing
  `ExecuteInterpreter.Context` as-is, no new struct — with the same `:unresolvable`/
  `:unsupported_arity` error shapes 6d-i already established; a nested fidelity failure
  is wrapped as `{:nested, iri, inner_reason}`, while a nested structural error
  propagates unwrapped (matching `ExecuteInterpreter`'s own convention).
- A round-trip integration test composes `AntiUnifier.generalize/2` → reconstruct each
  candidate via its own recovering substitution → `check/3` on each reconstructed Trace,
  satisfying the exit criterion's literal wording ("given a Generalization and its source
  Traces...") end-to-end.
- `ExecuteInterpreter.bind_result/3`'s pre-existing raw-string-vs-`RDF.Term.t()` quirk is
  documented, not fixed — out of scope for this phase, matching 6d-i's own precedent of
  naming real inconsistencies rather than silently papering over them.

Design spec: `docs/superpowers/specs/2026-08-29-phase-6e-ii-generalization-fidelity-design.md`
(held open, not yet merged — merging on explicit instruction only once this implementation
is done).

## Test plan

- [x] `mix test test/riptide/derivation/generalization_fidelity_test.exs` — 16/16 passing:
  groundness precondition, FactPattern pass/fail/short-circuit, `:effect` Capability
  pass/mismatch/error/unresolvable, `:observe` Capability never-invoked, RuleReference
  unresolvable/unsupported-arity/nested-pass/nested-fail, and the full
  `AntiUnifier.generalize/2` round-trip.
- [x] Full `mix test` (with `wasmtime` v48.0.1 on `PATH`) — 382 tests, 0 failures (one
  earlier run hit 1 failure in the unrelated, pre-existing `ra`-cluster timing flake
  class documented in `PROGRESS.md`; a clean rerun passed)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [x] `PROGRESS.md` updated (6e-ii marked shipped, remaining count 16 → 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)