### PR TITLE
Phase 6e-iii: DedupGate orchestration

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness) — 15 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration) — 14 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -644,4 +644,33 @@ a Generalization and its source Traces...") end-to-end via test composition rath
 module's own signature.
 
 **Status**: Phase 6e-ii shipped 2026-08-29. 15 phases remaining across the primary spine and
+the three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6e-iii — DedupGate orchestration
+
+Sixth link in the walking skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → 6e-iii →
+{6f, 6g-i}`), unblocked by 6e-i (#78), 6e-ii (#79), and 6d-i (#64). **Shipped 2026-08-29** —
+see `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`.
+
+Two new modules: `Riptide.Derivation.Catalog` (storage) and `Riptide.Derivation.DedupGate`
+(the `Reject`/`Merge`/`Admit` decision plus the human review workflow), scope-parameterized
+`Tenant`/`Hub` from the start. The key insight: a `CatalogEntry ⊑ Rule` is just more RDF
+Facts, so Catalog needed no new persistence subsystem — it reuses `StreamServer`/`Event`/
+`Patch`/`RuleRDFCodec`/`Matcher` exactly as `RiptideWeb.LDP.ResourceController` already does
+for LDP resources, as one more resource-stream namespace. `Merge` reuses
+`AntiUnifier.generalize/2` a second time (candidate × existing entry) instead of inventing a
+graph-merge algorithm; `Reject` vs. `Merge` reduces to a mechanical check on the recovering
+substitution's own values (`entry_unchanged? = Enum.all?(Map.values(sub_entry),
+&match?(%Var{}, &1))`) — no alpha-equivalence checker needed. `supersede_entry/2` and
+`resolve_pending_review/3` both retag rather than delete (a 2-triple patch swapping one
+`rdf:type`), avoiding a transitive-closure graph-deletion problem discovered while grounding
+the implementation plan and fixed in the spec before any code was written.
+`AntiUnifier.substitute/2` was promoted from a helper duplicated in 6e-i's and 6e-ii's own
+test files into real production code, since `DedupGate` needed it for real for the first
+time. One real finding surfaced only by testing: two "tied" candidate generalizations from
+`AntiUnifier.generalize/2` are not guaranteed to be alpha-equivalent to each other (a
+symmetric literal swap happens to produce isomorphic ones; an asymmetric one does not) —
+verified directly rather than assumed, after an initial proof attempt turned out to be wrong.
+
+**Status**: Phase 6e-iii shipped 2026-08-29. 14 phases remaining across the primary spine and
 the three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/anti_unifier.ex
+++ b/lib/riptide/derivation/anti_unifier.ex
@@ -244,4 +244,45 @@ defmodule Riptide.Derivation.AntiUnifier do
     |> Enum.filter(fn {_rule, count, _sub1, _sub2} -> count == min_count end)
     |> Enum.map(fn {rule, _count, sub1, sub2} -> {rule, sub1, sub2} end)
   end
+
+  @doc """
+  Reconstructs a ground Trace from `generalization` and one of `generalize/2`'s
+  own recovering substitutions — the inverse operation, applied by a caller
+  (never internally by `generalize/2` itself).
+  """
+  @spec substitute(Rule.t(), substitution()) :: Rule.t()
+  def substitute(%Rule{head: head, body: body, signature: signature} = rule, substitution) do
+    %{
+      rule
+      | head: substitute_literal(head, substitution),
+        body: Enum.map(body, &substitute_literal(&1, substitution)),
+        signature: %{
+          signature
+          | parameters: Enum.map(signature.parameters, &substitute_term(&1, substitution))
+        }
+    }
+  end
+
+  defp substitute_literal(%FactPattern{} = lit, substitution) do
+    %{lit | args: Enum.map(lit.args, &substitute_term(&1, substitution))}
+  end
+
+  defp substitute_literal(%CapabilityReference{} = lit, substitution) do
+    %{
+      lit
+      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
+        result: substitute_term(lit.result, substitution)
+    }
+  end
+
+  defp substitute_literal(%RuleReference{} = lit, substitution) do
+    %{
+      lit
+      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
+        result: substitute_term(lit.result, substitution)
+    }
+  end
+
+  defp substitute_term(%Var{} = var, substitution), do: Map.fetch!(substitution, var)
+  defp substitute_term(term, _substitution), do: term
 end

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -19,6 +19,7 @@ defmodule Riptide.Derivation.Catalog do
   @stream_id_prefix "https://riptide.example/"
   @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
   @riptide_catalog_entry RDF.iri("urn:riptide:vocab:CatalogEntry")
+  @riptide_superseded_catalog_entry RDF.iri("urn:riptide:vocab:SupersededCatalogEntry")
   @riptide_supersedes RDF.iri("urn:riptide:vocab:supersedes")
 
   @type scope :: {:tenant, String.t()} | :hub
@@ -56,6 +57,15 @@ defmodule Riptide.Derivation.Catalog do
 
   defp maybe_add_supersedes(graph, node, replaces),
     do: RDF.Graph.add(graph, {node, @riptide_supersedes, replaces})
+
+  @spec supersede_entry(scope(), RDF.BlankNode.t()) :: :ok | {:error, :not_ready}
+  def supersede_entry(scope, node) do
+    write_patch(
+      catalog_stream_id(scope),
+      [{node, @rdf_type, @riptide_superseded_catalog_entry}],
+      [{node, @rdf_type, @riptide_catalog_entry}]
+    )
+  end
 
   defp nodes_of_type(graph, type_iri) do
     fact_pattern = %FactPattern{predicate: @rdf_type, args: [%Var{name: "Node"}, type_iri]}

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -13,8 +13,13 @@ defmodule Riptide.Derivation.Catalog do
   alias Riptide.RDF.Patch
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
   alias Riptide.Derivation.{DedupGate, Rule}
+  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Matcher, RuleRDFCodec, Var}
 
   @stream_id_prefix "https://riptide.example/"
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_catalog_entry RDF.iri("urn:riptide:vocab:CatalogEntry")
+  @riptide_supersedes RDF.iri("urn:riptide:vocab:supersedes")
 
   @type scope :: {:tenant, String.t()} | :hub
 
@@ -28,7 +33,50 @@ defmodule Riptide.Derivation.Catalog do
   def pending_review_stream_id(scope), do: catalog_stream_id(scope) <> "/pending-review"
 
   @spec list_entries(scope()) :: {:ok, [{RDF.BlankNode.t(), Rule.t()}]} | {:error, :not_ready}
-  def list_entries(_scope), do: {:ok, []}
+  def list_entries(scope) do
+    with {:ok, graph} <- read_graph(catalog_stream_id(scope)) do
+      nodes = nodes_of_type(graph, @riptide_catalog_entry)
+      {:ok, Enum.map(nodes, &{&1, RuleRDFCodec.from_rdf(&1, graph)})}
+    end
+  end
+
+  @spec admit_entry(scope(), Rule.t(), RDF.BlankNode.t() | nil) :: :ok | {:error, :not_ready}
+  def admit_entry(scope, %Rule{} = rule, replaces) do
+    {node, rule_graph} = RuleRDFCodec.to_rdf(rule)
+
+    graph =
+      rule_graph
+      |> RDF.Graph.add({node, @rdf_type, @riptide_catalog_entry})
+      |> maybe_add_supersedes(node, replaces)
+
+    write_patch(catalog_stream_id(scope), RDF.Graph.triples(graph), [])
+  end
+
+  defp maybe_add_supersedes(graph, _node, nil), do: graph
+
+  defp maybe_add_supersedes(graph, node, replaces),
+    do: RDF.Graph.add(graph, {node, @riptide_supersedes, replaces})
+
+  defp nodes_of_type(graph, type_iri) do
+    fact_pattern = %FactPattern{predicate: @rdf_type, args: [%Var{name: "Node"}, type_iri]}
+    {:ok, bindings} = Matcher.bindings([fact_pattern], graph, %{})
+    Enum.map(bindings, &Map.fetch!(&1, %Var{name: "Node"}))
+  end
+
+  defp write_patch(stream_id, additions, removals) do
+    case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        StreamServer.append(
+          stream_id,
+          Event.new(stream_id, :patch, %Patch{additions: additions, removals: removals})
+        )
+
+        :ok
+
+      :error ->
+        {:error, :not_ready}
+    end
+  end
 
   @spec list_pending_reviews(scope()) ::
           {:ok, [{RDF.BlankNode.t(), DedupGate.PendingReview.t()}]} | {:error, :not_ready}

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -88,9 +88,27 @@ defmodule Riptide.Derivation.Catalog do
     end
   end
 
+  @riptide_pending_review RDF.iri("urn:riptide:vocab:PendingReview")
+
+  @spec queue_pending_review(scope(), DedupGate.PendingReview.t()) ::
+          {:ok, RDF.BlankNode.t()} | {:error, :not_ready}
+  def queue_pending_review(scope, %DedupGate.PendingReview{} = pending_review) do
+    {node, graph} = DedupGate.PendingReview.to_rdf(pending_review)
+
+    case write_patch(pending_review_stream_id(scope), RDF.Graph.triples(graph), []) do
+      :ok -> {:ok, node}
+      {:error, _reason} = error -> error
+    end
+  end
+
   @spec list_pending_reviews(scope()) ::
           {:ok, [{RDF.BlankNode.t(), DedupGate.PendingReview.t()}]} | {:error, :not_ready}
-  def list_pending_reviews(_scope), do: {:ok, []}
+  def list_pending_reviews(scope) do
+    with {:ok, graph} <- read_graph(pending_review_stream_id(scope)) do
+      nodes = nodes_of_type(graph, @riptide_pending_review)
+      {:ok, Enum.map(nodes, &{&1, DedupGate.PendingReview.from_rdf(&1, graph)})}
+    end
+  end
 
   defp read_graph(stream_id) do
     case Placement.lookup(stream_id) do

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -8,13 +8,12 @@ defmodule Riptide.Derivation.Catalog do
   §4.
   """
 
+  alias Riptide.Derivation.{DedupGate, Matcher, Rule, RuleRDFCodec, Var}
+  alias Riptide.Derivation.Literal.FactPattern
   alias Riptide.Event
   alias Riptide.Placement
   alias Riptide.RDF.Patch
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
-  alias Riptide.Derivation.{DedupGate, Rule}
-  alias Riptide.Derivation.Literal.FactPattern
-  alias Riptide.Derivation.{Matcher, RuleRDFCodec, Var}
 
   @stream_id_prefix "https://riptide.example/"
   @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
@@ -89,6 +88,8 @@ defmodule Riptide.Derivation.Catalog do
   end
 
   @riptide_pending_review RDF.iri("urn:riptide:vocab:PendingReview")
+  @riptide_approved_pending_review RDF.iri("urn:riptide:vocab:ApprovedPendingReview")
+  @riptide_declined_pending_review RDF.iri("urn:riptide:vocab:DeclinedPendingReview")
 
   @spec queue_pending_review(scope(), DedupGate.PendingReview.t()) ::
           {:ok, RDF.BlankNode.t()} | {:error, :not_ready}
@@ -110,22 +111,39 @@ defmodule Riptide.Derivation.Catalog do
     end
   end
 
+  @spec resolve_pending_review(scope(), RDF.BlankNode.t(), :approved | :declined) ::
+          :ok | {:error, :not_ready}
+  def resolve_pending_review(scope, node, :approved),
+    do: retag_pending(scope, node, @riptide_approved_pending_review)
+
+  def resolve_pending_review(scope, node, :declined),
+    do: retag_pending(scope, node, @riptide_declined_pending_review)
+
+  defp retag_pending(scope, node, new_type) do
+    write_patch(
+      pending_review_stream_id(scope),
+      [{node, @rdf_type, new_type}],
+      [{node, @rdf_type, @riptide_pending_review}]
+    )
+  end
+
   defp read_graph(stream_id) do
     case Placement.lookup(stream_id) do
-      nil ->
-        {:ok, RDF.Graph.new()}
+      nil -> {:ok, RDF.Graph.new()}
+      _nodes -> read_existing_graph(stream_id)
+    end
+  end
 
-      _nodes ->
-        case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
-          :ok ->
-            case StreamServer.get_since(stream_id, 0) do
-              {:ok, events} -> {:ok, fold_events(events)}
-              {:gap, _oldest} -> {:ok, RDF.Graph.new()}
-            end
-
-          :error ->
-            {:error, :not_ready}
+  defp read_existing_graph(stream_id) do
+    case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        case StreamServer.get_since(stream_id, 0) do
+          {:ok, events} -> {:ok, fold_events(events)}
+          {:gap, _oldest} -> {:ok, RDF.Graph.new()}
         end
+
+      :error ->
+        {:error, :not_ready}
     end
   end
 

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -1,0 +1,63 @@
+defmodule Riptide.Derivation.Catalog do
+  @moduledoc """
+  Catalog storage: a `CatalogEntry`/`PendingReview` is just more RDF Facts,
+  living in a dedicated resource stream — the same `StreamServer`/`Event`/
+  `Patch` mechanism `RiptideWeb.LDP.ResourceController` already uses for LDP
+  resources. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`
+  §4.
+  """
+
+  alias Riptide.Event
+  alias Riptide.Placement
+  alias Riptide.RDF.Patch
+  alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias Riptide.Derivation.{DedupGate, Rule}
+
+  @stream_id_prefix "https://riptide.example/"
+
+  @type scope :: {:tenant, String.t()} | :hub
+
+  @spec catalog_stream_id(scope()) :: String.t()
+  def catalog_stream_id({:tenant, tenant_id}),
+    do: @stream_id_prefix <> "tenants/" <> tenant_id <> "/catalog"
+
+  def catalog_stream_id(:hub), do: @stream_id_prefix <> "hub/catalog"
+
+  @spec pending_review_stream_id(scope()) :: String.t()
+  def pending_review_stream_id(scope), do: catalog_stream_id(scope) <> "/pending-review"
+
+  @spec list_entries(scope()) :: {:ok, [{RDF.BlankNode.t(), Rule.t()}]} | {:error, :not_ready}
+  def list_entries(_scope), do: {:ok, []}
+
+  @spec list_pending_reviews(scope()) ::
+          {:ok, [{RDF.BlankNode.t(), DedupGate.PendingReview.t()}]} | {:error, :not_ready}
+  def list_pending_reviews(_scope), do: {:ok, []}
+
+  defp read_graph(stream_id) do
+    case Placement.lookup(stream_id) do
+      nil ->
+        {:ok, RDF.Graph.new()}
+
+      _nodes ->
+        case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+          :ok ->
+            case StreamServer.get_since(stream_id, 0) do
+              {:ok, events} -> {:ok, fold_events(events)}
+              {:gap, _oldest} -> {:ok, RDF.Graph.new()}
+            end
+
+          :error ->
+            {:error, :not_ready}
+        end
+    end
+  end
+
+  defp fold_events(events) do
+    Enum.reduce(events, RDF.Graph.new(), fn
+      %Event{operation: :replace, payload: payload}, _acc -> payload
+      %Event{operation: :delete}, _acc -> RDF.Graph.new()
+      %Event{operation: :patch, payload: %Patch{} = patch}, acc -> Patch.apply(acc, patch)
+    end)
+  end
+end

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -1,0 +1,139 @@
+defmodule Riptide.Derivation.DedupGate.PendingReview do
+  @moduledoc """
+  A proposed Catalog change (`Admit` or `Merge`) awaiting human review, with
+  6e-ii's fidelity evidence attached. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`
+  §6.
+  """
+
+  alias Riptide.Derivation.{Rule, RuleRDFCodec}
+
+  @enforce_keys [:kind, :candidate, :fidelity_evidence, :replaces]
+  defstruct [:kind, :candidate, :fidelity_evidence, :replaces]
+
+  @type kind :: :admit | :merge
+  @type fidelity_evidence :: :fidelity_pass | {:fidelity_fail, term()}
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          candidate: Rule.t(),
+          fidelity_evidence: [fidelity_evidence()],
+          replaces: RDF.BlankNode.t() | nil
+        }
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_pending_review RDF.iri("urn:riptide:vocab:PendingReview")
+  @riptide_kind RDF.iri("urn:riptide:vocab:kind")
+  @riptide_candidate RDF.iri("urn:riptide:vocab:candidate")
+  @riptide_fidelity_evidence RDF.iri("urn:riptide:vocab:fidelityEvidence")
+  @riptide_fidelity_status RDF.iri("urn:riptide:vocab:fidelityStatus")
+  @riptide_fidelity_reason RDF.iri("urn:riptide:vocab:fidelityReason")
+  @riptide_replaces RDF.iri("urn:riptide:vocab:replaces")
+
+  @doc "See moduledoc. Returns the item's own (blank) node plus the graph fragment reifying it."
+  @spec to_rdf(t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%__MODULE__{} = pending_review) do
+    node = RDF.BlankNode.new()
+    {candidate_node, candidate_graph} = RuleRDFCodec.to_rdf(pending_review.candidate)
+    {evidence_head, evidence_graph} = encode_evidence(pending_review.fidelity_evidence)
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add(candidate_graph)
+      |> RDF.Graph.add(evidence_graph)
+      |> RDF.Graph.add({node, @rdf_type, @riptide_pending_review})
+      |> RDF.Graph.add({node, @riptide_kind, RDF.literal(Atom.to_string(pending_review.kind))})
+      |> RDF.Graph.add({node, @riptide_candidate, candidate_node})
+      |> RDF.Graph.add({node, @riptide_fidelity_evidence, evidence_head})
+      |> maybe_add_replaces(node, pending_review.replaces)
+
+    {node, graph}
+  end
+
+  defp maybe_add_replaces(graph, _node, nil), do: graph
+
+  defp maybe_add_replaces(graph, node, replaces),
+    do: RDF.Graph.add(graph, {node, @riptide_replaces, replaces})
+
+  defp encode_evidence(evidence_list) do
+    {nodes, graph} =
+      Enum.reduce(evidence_list, {[], RDF.Graph.new()}, fn evidence, {acc, graph} ->
+        {node, evidence_graph} = encode_one_evidence(evidence)
+        {[node | acc], RDF.Graph.add(graph, evidence_graph)}
+      end)
+
+    list = RDF.List.from(Enum.reverse(nodes))
+    {list.head, RDF.Graph.add(graph, list.graph)}
+  end
+
+  defp encode_one_evidence(:fidelity_pass) do
+    node = RDF.BlankNode.new()
+    {node, RDF.Graph.new() |> RDF.Graph.add({node, @riptide_fidelity_status, RDF.literal("pass")})}
+  end
+
+  defp encode_one_evidence({:fidelity_fail, reason}) do
+    node = RDF.BlankNode.new()
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add({node, @riptide_fidelity_status, RDF.literal("fail")})
+      |> RDF.Graph.add({node, @riptide_fidelity_reason, RDF.literal(inspect(reason))})
+
+    {node, graph}
+  end
+
+  @doc "See moduledoc. The inverse of `to_rdf/1`. Requires the item's own node to already be known."
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+
+    # Safe: "admit"/"merge" are the only two values `to_rdf/1` ever writes,
+    # and both atoms already exist in the atom table from this module's own
+    # @type/struct usage above — never derived from untrusted input.
+    kind =
+      description
+      |> RDF.Description.first(@riptide_kind)
+      |> RDF.Literal.value()
+      |> String.to_existing_atom()
+
+    candidate_node = RDF.Description.first(description, @riptide_candidate)
+    candidate = RuleRDFCodec.from_rdf(candidate_node, graph)
+    evidence_head = RDF.Description.first(description, @riptide_fidelity_evidence)
+
+    fidelity_evidence =
+      RDF.List.new(evidence_head, graph)
+      |> RDF.List.values()
+      |> Enum.map(&decode_one_evidence(&1, graph))
+
+    replaces = RDF.Description.first(description, @riptide_replaces)
+
+    %__MODULE__{
+      kind: kind,
+      candidate: candidate,
+      fidelity_evidence: fidelity_evidence,
+      replaces: replaces
+    }
+  end
+
+  defp decode_one_evidence(node, graph) do
+    description = RDF.Graph.get(graph, node)
+    status = description |> RDF.Description.first(@riptide_fidelity_status) |> RDF.Literal.value()
+
+    case status do
+      "pass" ->
+        :fidelity_pass
+
+      "fail" ->
+        reason = description |> RDF.Description.first(@riptide_fidelity_reason) |> RDF.Literal.value()
+        {:fidelity_fail, reason}
+    end
+  end
+end
+
+defmodule Riptide.Derivation.DedupGate do
+  @moduledoc """
+  Catalog lookup, the `Reject`/`Merge`/`Admit` decision, and the human
+  review workflow. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`.
+  """
+end

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -236,4 +236,29 @@ defmodule Riptide.Derivation.DedupGate do
   defp normalize_fidelity_result({:ok, :fidelity_pass}), do: :fidelity_pass
   defp normalize_fidelity_result({:ok, {:fidelity_fail, reason}}), do: {:fidelity_fail, reason}
   defp normalize_fidelity_result({:error, reason}), do: {:fidelity_fail, reason}
+
+  @spec approve_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
+  def approve_review(scope, node) do
+    with {:ok, pending_reviews} <- Catalog.list_pending_reviews(scope),
+         {_node, pending_review} <- List.keyfind(pending_reviews, node, 0, :not_found) do
+      apply_approved(scope, node, pending_review)
+    else
+      :not_found -> {:error, :not_found}
+      error -> error
+    end
+  end
+
+  defp apply_approved(scope, node, %PendingReview{kind: :admit} = pending_review) do
+    :ok = Catalog.admit_entry(scope, pending_review.candidate, nil)
+    Catalog.resolve_pending_review(scope, node, :approved)
+  end
+
+  defp apply_approved(scope, node, %PendingReview{kind: :merge} = pending_review) do
+    :ok = Catalog.admit_entry(scope, pending_review.candidate, pending_review.replaces)
+    :ok = Catalog.supersede_entry(scope, pending_review.replaces)
+    Catalog.resolve_pending_review(scope, node, :approved)
+  end
+
+  @spec decline_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
+  def decline_review(scope, node), do: Catalog.resolve_pending_review(scope, node, :declined)
 end

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -68,7 +68,9 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
 
   defp encode_one_evidence(:fidelity_pass) do
     node = RDF.BlankNode.new()
-    {node, RDF.Graph.new() |> RDF.Graph.add({node, @riptide_fidelity_status, RDF.literal("pass")})}
+
+    {node,
+     RDF.Graph.new() |> RDF.Graph.add({node, @riptide_fidelity_status, RDF.literal("pass")})}
   end
 
   defp encode_one_evidence({:fidelity_fail, reason}) do
@@ -124,7 +126,9 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
         :fidelity_pass
 
       "fail" ->
-        reason = description |> RDF.Description.first(@riptide_fidelity_reason) |> RDF.Literal.value()
+        reason =
+          description |> RDF.Description.first(@riptide_fidelity_reason) |> RDF.Literal.value()
+
         {:fidelity_fail, reason}
     end
   end
@@ -136,4 +140,73 @@ defmodule Riptide.Derivation.DedupGate do
   review workflow. See design spec
   `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`.
   """
+
+  alias Riptide.Derivation.DedupGate.PendingReview
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.{AntiUnifier, Catalog, GeneralizationFidelity, Rule}
+
+  @type candidates :: [{Rule.t(), AntiUnifier.substitution(), AntiUnifier.substitution()}]
+  @type outcome ::
+          {:rejected, reason :: term()}
+          | {:fidelity_failed, [PendingReview.fidelity_evidence()]}
+          | {:queued, RDF.BlankNode.t(), PendingReview.kind()}
+
+  @spec propose(Catalog.scope(), candidates(), RDF.Graph.t(), Context.t()) ::
+          {:ok, [outcome()]} | {:error, term()}
+  def propose(scope, candidates, graph, context) do
+    with {:ok, entries} <- Catalog.list_entries(scope) do
+      {:ok, Enum.map(candidates, &propose_one(scope, &1, entries, graph, context))}
+    end
+  end
+
+  defp propose_one(scope, {generalization, sub1, sub2}, entries, graph, context) do
+    trace1 = AntiUnifier.substitute(generalization, sub1)
+    trace2 = AntiUnifier.substitute(generalization, sub2)
+
+    case classify(generalization, entries) do
+      {:reject, reason} ->
+        {:rejected, reason}
+
+      {kind, replaces} ->
+        finish_proposal(scope, generalization, kind, replaces, trace1, trace2, graph, context)
+    end
+  end
+
+  defp finish_proposal(scope, generalization, kind, replaces, trace1, trace2, graph, context) do
+    case fidelity_evidence(trace1, trace2, graph, context) do
+      {:ok, evidence} ->
+        pending_review = %PendingReview{
+          kind: kind,
+          candidate: generalization,
+          fidelity_evidence: evidence,
+          replaces: replaces
+        }
+
+        {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
+        {:queued, node, kind}
+
+      {:error, evidence} ->
+        {:fidelity_failed, evidence}
+    end
+  end
+
+  defp classify(_candidate, []), do: {:admit, nil}
+  defp classify(_candidate, _entries), do: {:admit, nil}
+
+  defp fidelity_evidence(trace1, trace2, graph, context) do
+    evidence =
+      Enum.map([trace1, trace2], fn trace ->
+        trace |> GeneralizationFidelity.check(graph, context) |> normalize_fidelity_result()
+      end)
+
+    if Enum.all?(evidence, &(&1 == :fidelity_pass)) do
+      {:ok, evidence}
+    else
+      {:error, evidence}
+    end
+  end
+
+  defp normalize_fidelity_result({:ok, :fidelity_pass}), do: :fidelity_pass
+  defp normalize_fidelity_result({:ok, {:fidelity_fail, reason}}), do: {:fidelity_fail, reason}
+  defp normalize_fidelity_result({:error, reason}), do: {:fidelity_fail, reason}
 end

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -141,9 +141,9 @@ defmodule Riptide.Derivation.DedupGate do
   `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`.
   """
 
+  alias Riptide.Derivation.{AntiUnifier, Catalog, GeneralizationFidelity, Rule, Var}
   alias Riptide.Derivation.DedupGate.PendingReview
   alias Riptide.Derivation.ExecuteInterpreter.Context
-  alias Riptide.Derivation.{AntiUnifier, Catalog, GeneralizationFidelity, Rule}
 
   @type candidates :: [{Rule.t(), AntiUnifier.substitution(), AntiUnifier.substitution()}]
   @type outcome ::
@@ -190,8 +190,35 @@ defmodule Riptide.Derivation.DedupGate do
     end
   end
 
-  defp classify(_candidate, []), do: {:admit, nil}
-  defp classify(_candidate, _entries), do: {:admit, nil}
+  defp classify(candidate, entries) do
+    matching =
+      Enum.filter(entries, fn {_node, entry} ->
+        entry.head.predicate == candidate.head.predicate
+      end)
+
+    case Enum.find(matching, fn {_node, entry} -> entry_unchanged?(candidate, entry) end) do
+      {_node, _entry} ->
+        {:reject, :already_covered}
+
+      nil ->
+        case matching do
+          [] -> {:admit, nil}
+          [{node, _entry} | _rest] -> {:merge, node}
+        end
+    end
+  end
+
+  defp entry_unchanged?(candidate, entry) do
+    case AntiUnifier.generalize(candidate, entry) do
+      {:ok, results} ->
+        Enum.any?(results, fn {_generalization, _sub_candidate, sub_entry} ->
+          Enum.all?(Map.values(sub_entry), &match?(%Var{}, &1))
+        end)
+
+      {:error, :body_too_large} ->
+        false
+    end
+  end
 
   defp fidelity_evidence(trace1, trace2, graph, context) do
     evidence =

--- a/test/riptide/derivation/anti_unifier_test.exs
+++ b/test/riptide/derivation/anti_unifier_test.exs
@@ -91,8 +91,8 @@ defmodule Riptide.Derivation.AntiUnifierTest do
 
     # The two recovering substitutions must reconstruct each original Rule
     # exactly when applied to the generalization.
-    assert substitute_rule(generalization, sub1) == rule1
-    assert substitute_rule(generalization, sub2) == rule2
+    assert AntiUnifier.substitute(generalization, sub1) == rule1
+    assert AntiUnifier.substitute(generalization, sub2) == rule2
   end
 
   test "different Head predicates have no common structure" do
@@ -178,31 +178,4 @@ defmodule Riptide.Derivation.AntiUnifierTest do
     [{gen1, _, _}, {gen2, _, _}] = candidates
     refute gen1.body == gen2.body
   end
-
-  defp substitute_rule(%Rule{head: head, body: body, signature: signature} = rule, substitution) do
-    %{
-      rule
-      | head: substitute_literal(head, substitution),
-        body: Enum.map(body, &substitute_literal(&1, substitution)),
-        signature: %{
-          signature
-          | parameters: Enum.map(signature.parameters, &substitute_term(&1, substitution))
-        }
-    }
-  end
-
-  defp substitute_literal(%FactPattern{} = lit, substitution) do
-    %{lit | args: Enum.map(lit.args, &substitute_term(&1, substitution))}
-  end
-
-  defp substitute_literal(%CapabilityReference{} = lit, substitution) do
-    %{
-      lit
-      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
-        result: substitute_term(lit.result, substitution)
-    }
-  end
-
-  defp substitute_term(%Var{} = var, substitution), do: Map.fetch!(substitution, var)
-  defp substitute_term(term, _substitution), do: term
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -76,4 +76,21 @@ defmodule Riptide.Derivation.CatalogTest do
       assert MapSet.new(Enum.map(entries, &elem(&1, 1))) == MapSet.new([rule1, rule2])
     end
   end
+
+  describe "supersede_entry/2" do
+    test "a superseded entry disappears from list_entries/1; admitting with replaces: writes the supersedes link" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      old_rule = sample_rule("alice")
+      :ok = Catalog.admit_entry(scope, old_rule, nil)
+      {:ok, [{old_node, ^old_rule}]} = Catalog.list_entries(scope)
+
+      new_rule = sample_rule("bob")
+      :ok = Catalog.admit_entry(scope, new_rule, old_node)
+      :ok = Catalog.supersede_entry(scope, old_node)
+
+      assert {:ok, [{_node, ^new_rule}]} = Catalog.list_entries(scope)
+    end
+  end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -98,7 +98,10 @@ defmodule Riptide.Derivation.CatalogTest do
   describe "queue_pending_review/2 + list_pending_reviews/1 — real round-trip" do
     test "a queued PendingReview is found live by list_pending_reviews/1" do
       scope = unique_tenant()
-      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope)) end)
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
 
       pending_review = %PendingReview{
         kind: :admit,
@@ -109,6 +112,46 @@ defmodule Riptide.Derivation.CatalogTest do
 
       assert {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
       assert {:ok, [{^node, ^pending_review}]} = Catalog.list_pending_reviews(scope)
+    end
+  end
+
+  describe "resolve_pending_review/3" do
+    test "an approved item disappears from list_pending_reviews/1" do
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      pending_review = %PendingReview{
+        kind: :admit,
+        candidate: sample_rule("alice"),
+        fidelity_evidence: [:fidelity_pass, :fidelity_pass],
+        replaces: nil
+      }
+
+      {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
+      assert :ok == Catalog.resolve_pending_review(scope, node, :approved)
+      assert {:ok, []} = Catalog.list_pending_reviews(scope)
+    end
+
+    test "a declined item disappears from list_pending_reviews/1" do
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      pending_review = %PendingReview{
+        kind: :admit,
+        candidate: sample_rule("alice"),
+        fidelity_evidence: [:fidelity_pass, :fidelity_pass],
+        replaces: nil
+      }
+
+      {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
+      assert :ok == Catalog.resolve_pending_review(scope, node, :declined)
+      assert {:ok, []} = Catalog.list_pending_reviews(scope)
     end
   end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -154,4 +154,26 @@ defmodule Riptide.Derivation.CatalogTest do
       assert {:ok, []} = Catalog.list_pending_reviews(scope)
     end
   end
+
+  describe "Hub vs. Tenant scope isolation" do
+    test "admitting into :hub never surfaces in a Tenant's list_entries/1, and vice versa" do
+      tenant_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(tenant_scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(:hub))
+      end)
+
+      hub_rule = sample_rule("hub-pattern")
+      tenant_rule = sample_rule("tenant-pattern")
+
+      :ok = Catalog.admit_entry(:hub, hub_rule, nil)
+      :ok = Catalog.admit_entry(tenant_scope, tenant_rule, nil)
+
+      assert {:ok, [{_node, ^tenant_rule}]} = Catalog.list_entries(tenant_scope)
+      assert {:ok, hub_entries} = Catalog.list_entries(:hub)
+      assert Enum.any?(hub_entries, fn {_node, rule} -> rule == hub_rule end)
+      refute Enum.any?(hub_entries, fn {_node, rule} -> rule == tenant_rule end)
+    end
+  end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -2,6 +2,7 @@ defmodule Riptide.Derivation.CatalogTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.DedupGate.PendingReview
   alias Riptide.Derivation.Literal.FactPattern
   alias Riptide.Derivation.{Rule, Signature}
 
@@ -91,6 +92,23 @@ defmodule Riptide.Derivation.CatalogTest do
       :ok = Catalog.supersede_entry(scope, old_node)
 
       assert {:ok, [{_node, ^new_rule}]} = Catalog.list_entries(scope)
+    end
+  end
+
+  describe "queue_pending_review/2 + list_pending_reviews/1 — real round-trip" do
+    test "a queued PendingReview is found live by list_pending_reviews/1" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope)) end)
+
+      pending_review = %PendingReview{
+        kind: :admit,
+        candidate: sample_rule("alice"),
+        fidelity_evidence: [:fidelity_pass, :fidelity_pass],
+        replaces: nil
+      }
+
+      assert {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
+      assert {:ok, [{^node, ^pending_review}]} = Catalog.list_pending_reviews(scope)
     end
   end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -2,8 +2,28 @@ defmodule Riptide.Derivation.CatalogTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Rule, Signature}
 
   defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp sample_rule(subject_name) do
+    head = %FactPattern{predicate: rel("greeted"), args: [t(subject_name), RDF.literal("hi")]}
+
+    %Rule{
+      signature: %Signature{
+        name: head.predicate,
+        parameters: [],
+        reads: [],
+        produces: [head.predicate]
+      },
+      head: head,
+      body: []
+    }
+  end
 
   describe "stream_id helpers" do
     test "catalog_stream_id/1 for a Tenant scope" do
@@ -28,6 +48,32 @@ defmodule Riptide.Derivation.CatalogTest do
 
     test "list_pending_reviews/1 returns {:ok, []} for a Tenant with no pending reviews yet" do
       assert Catalog.list_pending_reviews(unique_tenant()) == {:ok, []}
+    end
+  end
+
+  describe "admit_entry/3 + list_entries/1 — real round-trip" do
+    test "an admitted entry (replaces: nil) is found live by list_entries/1" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      rule = sample_rule("alice")
+
+      assert :ok == Catalog.admit_entry(scope, rule, nil)
+      assert {:ok, [{_node, ^rule}]} = Catalog.list_entries(scope)
+    end
+
+    test "admitting two entries returns both, in either order" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      rule1 = sample_rule("alice")
+      rule2 = sample_rule("bob")
+
+      :ok = Catalog.admit_entry(scope, rule1, nil)
+      :ok = Catalog.admit_entry(scope, rule2, nil)
+
+      assert {:ok, entries} = Catalog.list_entries(scope)
+      assert MapSet.new(Enum.map(entries, &elem(&1, 1))) == MapSet.new([rule1, rule2])
     end
   end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -1,0 +1,33 @@
+defmodule Riptide.Derivation.CatalogTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Derivation.Catalog
+
+  defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+  describe "stream_id helpers" do
+    test "catalog_stream_id/1 for a Tenant scope" do
+      assert Catalog.catalog_stream_id({:tenant, "acme"}) ==
+               "https://riptide.example/tenants/acme/catalog"
+    end
+
+    test "catalog_stream_id/1 for the Hub scope" do
+      assert Catalog.catalog_stream_id(:hub) == "https://riptide.example/hub/catalog"
+    end
+
+    test "pending_review_stream_id/1 for a Tenant scope" do
+      assert Catalog.pending_review_stream_id({:tenant, "acme"}) ==
+               "https://riptide.example/tenants/acme/catalog/pending-review"
+    end
+  end
+
+  describe "reads on a never-written stream" do
+    test "list_entries/1 returns {:ok, []}, not an error, for a Tenant with no Catalog yet" do
+      assert Catalog.list_entries(unique_tenant()) == {:ok, []}
+    end
+
+    test "list_pending_reviews/1 returns {:ok, []} for a Tenant with no pending reviews yet" do
+      assert Catalog.list_pending_reviews(unique_tenant()) == {:ok, []}
+    end
+  end
+end

--- a/test/riptide/derivation/dedup_gate/pending_review_test.exs
+++ b/test/riptide/derivation/dedup_gate/pending_review_test.exs
@@ -1,0 +1,61 @@
+defmodule Riptide.Derivation.DedupGate.PendingReviewTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.DedupGate.PendingReview
+  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Rule, Signature}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp candidate_rule do
+    head = %FactPattern{predicate: rel("greeted"), args: [t("alice"), RDF.literal("hi")]}
+
+    %Rule{
+      signature: %Signature{
+        name: head.predicate,
+        parameters: [],
+        reads: [],
+        produces: [head.predicate]
+      },
+      head: head,
+      body: []
+    }
+  end
+
+  test "round-trips an :admit PendingReview with passing fidelity evidence, no replaces" do
+    pending_review = %PendingReview{
+      kind: :admit,
+      candidate: candidate_rule(),
+      fidelity_evidence: [:fidelity_pass, :fidelity_pass],
+      replaces: nil
+    }
+
+    {node, graph} = PendingReview.to_rdf(pending_review)
+
+    assert PendingReview.from_rdf(node, graph) == pending_review
+  end
+
+  test "round-trips a :merge PendingReview with mixed fidelity evidence and a replaces node" do
+    replaces_node = RDF.BlankNode.new()
+    original_reason = {:capability_mismatch, t("cap"), "a", "b"}
+
+    pending_review = %PendingReview{
+      kind: :merge,
+      candidate: candidate_rule(),
+      fidelity_evidence: [:fidelity_pass, {:fidelity_fail, original_reason}],
+      replaces: replaces_node
+    }
+
+    {node, graph} = PendingReview.to_rdf(pending_review)
+
+    # The failure reason is encoded via inspect/1 (design spec §6, deliberate
+    # — the reviewer needs to *see* why a check failed, not programmatically
+    # parse it) so it round-trips as the inspected string, not the original
+    # term.
+    assert PendingReview.from_rdf(node, graph) == %{
+             pending_review
+             | fidelity_evidence: [:fidelity_pass, {:fidelity_fail, inspect(original_reason)}]
+           }
+  end
+end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -364,4 +364,84 @@ defmodule Riptide.Derivation.DedupGateTest do
       refute candidate_a == candidate_b
     end
   end
+
+  describe "approve_review/2 — :admit" do
+    test "approving an :admit proposal writes a live CatalogEntry and resolves the pending item" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+      {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx =
+        context(%{
+          capabilities: %{
+            RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")
+          }
+        })
+
+      {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+
+      assert :ok == DedupGate.approve_review(scope, node)
+      assert {:ok, [{_entry_node, _rule}]} = Catalog.list_entries(scope)
+      assert {:ok, []} = Catalog.list_pending_reviews(scope)
+    end
+  end
+
+  describe "decline_review/2" do
+    test "declining a proposal writes nothing to the Catalog and resolves the pending item" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+      {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx =
+        context(%{
+          capabilities: %{
+            RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")
+          }
+        })
+
+      {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+
+      assert :ok == DedupGate.decline_review(scope, node)
+      assert {:ok, []} = Catalog.list_entries(scope)
+      assert {:ok, []} = Catalog.list_pending_reviews(scope)
+    end
+  end
 end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -444,4 +444,54 @@ defmodule Riptide.Derivation.DedupGateTest do
       assert {:ok, []} = Catalog.list_pending_reviews(scope)
     end
   end
+
+  describe "exit criterion (issue #66)" do
+    test "two independently-produced real Traces anti-unify, pass Admit with fidelity evidence and human review, and become a live CatalogEntry" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      # Two independently-produced real Traces (real wasmtime invocation via
+      # the fixture Capability, standing in for 6d-i's own NativeTemplate
+      # instances producing real Traces).
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+
+      assert {:ok, [{generalization, sub1, sub2}]} = AntiUnifier.generalize(trace1, trace2)
+      assert AntiUnifier.substitute(generalization, sub1) == trace1
+      assert AntiUnifier.substitute(generalization, sub2) == trace2
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx =
+        context(%{
+          capabilities: %{
+            RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")
+          }
+        })
+
+      assert {:ok, [{:queued, node, :admit}]} =
+               DedupGate.propose(scope, [{generalization, sub1, sub2}], graph, ctx)
+
+      assert {:ok, [{^node, pending_review}]} = Catalog.list_pending_reviews(scope)
+      assert pending_review.fidelity_evidence == [:fidelity_pass, :fidelity_pass]
+
+      assert :ok == DedupGate.approve_review(scope, node)
+
+      assert {:ok, [{_entry_node, ^generalization}]} = Catalog.list_entries(scope)
+    end
+  end
 end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -214,4 +214,60 @@ defmodule Riptide.Derivation.DedupGateTest do
       assert pending_review.replaces == existing_node
     end
   end
+
+  describe "propose/4 — fidelity-failure path" do
+    test "a candidate whose recorded Capability result doesn't match a fresh invocation never reaches pending-review" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      cap_iri = RDF.iri("urn:riptide:capability:greetPerson")
+
+      # trace2's own recorded result is deliberately stale/wrong — a fresh
+      # invocation of greet("Bob") always produces "Hello, Bob!", never this.
+      stale_trace2 = %Rule{
+        signature: %Signature{
+          name: rel("greeted"),
+          parameters: [t("bob"), "\"stale value\""],
+          reads: [rel("pendingDeploy")],
+          produces: [rel("greeted")]
+        },
+        head: %FactPattern{predicate: rel("greeted"), args: [t("bob"), "\"stale value\""]},
+        body: [
+          %FactPattern{predicate: rel("pendingDeploy"), args: [t("bob"), RDF.literal("v1")]},
+          %CapabilityReference{
+            capability: cap_iri,
+            args: [RDF.literal("Bob")],
+            result: "\"stale value\""
+          }
+        ]
+      }
+
+      trace1 = ground_greet_trace("alice", "Alice")
+      {:ok, candidates} = AntiUnifier.generalize(trace1, stale_trace2)
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx = context(%{capabilities: %{cap_iri => greet_definition("greetPerson")}})
+
+      assert {:ok, [{:fidelity_failed, evidence}]} =
+               DedupGate.propose(scope, candidates, graph, ctx)
+
+      assert :fidelity_pass in evidence
+      assert Enum.any?(evidence, &match?({:fidelity_fail, _}, &1))
+      assert {:ok, []} = Catalog.list_pending_reviews(scope)
+    end
+  end
 end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -270,4 +270,98 @@ defmodule Riptide.Derivation.DedupGateTest do
       assert {:ok, []} = Catalog.list_pending_reviews(scope)
     end
   end
+
+  describe "propose/4 — multiple tied AntiUnifier candidates" do
+    test "tied candidates are classified independently and land in different dispositions" do
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      # Three same-predicate Body literals with ASYMMETRIC structure, ground
+      # (real IRIs, not Vars — GeneralizationFidelity.check/3 requires
+      # ground input, so trace1/trace2 here must already be real Traces).
+      # Not 6e-i's own 2-literal swap test — that scenario's two tied
+      # candidates turn out to be alpha-equivalent to each other, i.e. mere
+      # renamings of each other (verified empirically); "tied on minimum
+      # variable count" only means equally economical, not equivalent, and a
+      # symmetric swap happens to produce isomorphic alignments. Here p1
+      # recurs across body positions 1 and 3 in trace1 (asymmetric — p2
+      # appears only once), and q1 recurs the same way in trace2, which
+      # makes the two resulting alignments genuinely different in shape, not
+      # just in variable naming — verified directly: with `candidate_a`/
+      # `candidate_b` bound to the two candidates below,
+      # `entry_unchanged?(candidate_a, candidate_a)` is (trivially) `true`,
+      # but `entry_unchanged?(candidate_b, candidate_a)` is `false` —
+      # candidate_b is NOT a mere renaming of candidate_a, it reveals genuine
+      # broadening.
+      trace1 = %Rule{
+        signature: %Signature{
+          name: rel("pair"),
+          parameters: [t("p1"), t("p2")],
+          reads: [rel("likes")],
+          produces: [rel("pair")]
+        },
+        head: %FactPattern{predicate: rel("pair"), args: [t("p1"), t("p2")]},
+        body: [
+          %FactPattern{predicate: rel("likes"), args: [t("p1"), RDF.literal("a")]},
+          %FactPattern{predicate: rel("likes"), args: [t("p2"), RDF.literal("b")]},
+          %FactPattern{predicate: rel("likes"), args: [t("p1"), RDF.literal("c")]}
+        ]
+      }
+
+      trace2 = %Rule{
+        signature: %Signature{
+          name: rel("pair"),
+          parameters: [t("q1"), t("q2")],
+          reads: [rel("likes")],
+          produces: [rel("pair")]
+        },
+        head: %FactPattern{predicate: rel("pair"), args: [t("q1"), t("q2")]},
+        body: [
+          %FactPattern{predicate: rel("likes"), args: [t("q1"), RDF.literal("b")]},
+          %FactPattern{predicate: rel("likes"), args: [t("q2"), RDF.literal("c")]},
+          %FactPattern{predicate: rel("likes"), args: [t("q1"), RDF.literal("a")]}
+        ]
+      }
+
+      {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+      assert length(candidates) == 2
+      [{candidate_a, _, _}, {candidate_b, _, _}] = candidates
+
+      # Seed the Catalog with candidate_a itself, verbatim — per the proof
+      # above, candidate_b is NOT a mere renaming of candidate_a, so
+      # re-proposing candidate_a is Reject (trivially unchanged) while
+      # candidate_b reveals genuine broadening (Merge).
+      :ok = Catalog.admit_entry(scope, candidate_a, nil)
+
+      # All six ground facts trace1/trace2 depend on — candidate_b's own
+      # reconstructed traces don't necessarily preserve trace1/trace2's
+      # exact Body order (AntiUnifier.generalize/2 orders a candidate's Body
+      # by its first input's own literal order, so a candidate built via a
+      # "crossed" alignment can reconstruct a same-content-different-order
+      # permutation of the second input — verified directly, harmless here
+      # since FactPattern fidelity checking is a graph membership test, not
+      # an order-sensitive one) — so the graph includes every fact either
+      # trace needs, not just in whichever order each was originally written.
+      graph =
+        RDF.Graph.new([
+          {t("p1"), rel("likes"), RDF.literal("a")},
+          {t("p2"), rel("likes"), RDF.literal("b")},
+          {t("p1"), rel("likes"), RDF.literal("c")},
+          {t("q1"), rel("likes"), RDF.literal("b")},
+          {t("q2"), rel("likes"), RDF.literal("c")},
+          {t("q1"), rel("likes"), RDF.literal("a")}
+        ])
+
+      ctx = context()
+
+      assert {:ok, outcomes} = DedupGate.propose(scope, candidates, graph, ctx)
+
+      assert [{:rejected, _reason}, {:queued, _node, :merge}] = outcomes
+      refute candidate_a == candidate_b
+    end
+  end
 end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -2,9 +2,9 @@ defmodule Riptide.Derivation.DedupGateTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Capability.Definition
+  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Rule, Signature}
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
-  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Rule, Signature}
 
   defp t(name), do: RDF.iri("urn:test:" <> name)
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
@@ -120,11 +120,98 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       ctx =
         context(%{
-          capabilities: %{RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")}
+          capabilities: %{
+            RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")
+          }
         })
 
       assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
       assert {:ok, [{^node, _pending_review}]} = Catalog.list_pending_reviews(scope)
+    end
+  end
+
+  describe "propose/4 — Reject/Merge classification against a non-empty Catalog" do
+    test "a candidate already covered by an existing entry is Rejected, no review queued" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      # The existing entry is already the exact lgg of trace1/trace2 below —
+      # anti-unifying the same candidate against it a second time must find
+      # nothing new (entry_unchanged?).
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+      {:ok, [{existing_entry, _sub1, _sub2}]} = AntiUnifier.generalize(trace1, trace2)
+      :ok = Catalog.admit_entry(scope, existing_entry, nil)
+
+      trace3 = ground_greet_trace("carol", "Carol")
+      {:ok, candidates} = AntiUnifier.generalize(trace1, trace3)
+
+      graph = RDF.Graph.new()
+      ctx = context()
+
+      assert {:ok, [{:rejected, _reason}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, []} = Catalog.list_pending_reviews(scope)
+    end
+
+    test "a candidate broader than an existing entry is queued as :merge, replaces the existing node" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      # A narrower existing entry: a single ground fact, no variables at all
+      # (trivially still a valid Rule — an empty Body, a ground Head).
+      # A proper RDF.Literal (not a raw Elixir string) — a raw string is what
+      # a real CapabilityReference.result value looks like (a known,
+      # documented 6d-i/6e-ii quirk), but raw strings get coerced into
+      # RDF.Literal by real RDF.Graph storage on write, so a hand-built
+      # fixture asserting round-trip equality needs to already be in the
+      # form real storage will hand back.
+      existing_entry = %Rule{
+        signature: %Signature{
+          name: rel("greeted"),
+          parameters: [t("alice"), RDF.literal("Hello, Alice!")],
+          reads: [],
+          produces: [rel("greeted")]
+        },
+        head: %FactPattern{
+          predicate: rel("greeted"),
+          args: [t("alice"), RDF.literal("Hello, Alice!")]
+        },
+        body: []
+      }
+
+      :ok = Catalog.admit_entry(scope, existing_entry, nil)
+      {:ok, [{existing_node, ^existing_entry}]} = Catalog.list_entries(scope)
+
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+      {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx =
+        context(%{
+          capabilities: %{
+            RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")
+          }
+        })
+
+      assert {:ok, [{:queued, node, :merge}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, [{^node, pending_review}]} = Catalog.list_pending_reviews(scope)
+      assert pending_review.replaces == existing_node
     end
   end
 end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -1,0 +1,130 @@
+defmodule Riptide.Derivation.DedupGateTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Capability.Definition
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
+  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Rule, Signature}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+  defp context(overrides \\ %{}) do
+    Map.merge(
+      %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
+      overrides
+    )
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    on_exit(fn ->
+      if pid = Process.whereis(FakeStore) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp greet_definition(name) do
+    %Definition{
+      name: RDF.iri("urn:riptide:capability:" <> name),
+      kind: :effect,
+      component: "test/fixtures/riptide_capability/fixture.wasm",
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+  end
+
+  defp ground_greet_trace(subject_name, arg_name) do
+    cap_iri = RDF.iri("urn:riptide:capability:greetPerson")
+    result = "\"Hello, #{arg_name}!\""
+
+    %Rule{
+      signature: %Signature{
+        name: rel("greeted"),
+        parameters: [t(subject_name), result],
+        reads: [rel("pendingDeploy")],
+        produces: [rel("greeted")]
+      },
+      head: %FactPattern{predicate: rel("greeted"), args: [t(subject_name), result]},
+      body: [
+        %FactPattern{predicate: rel("pendingDeploy"), args: [t(subject_name), RDF.literal("v1")]},
+        %CapabilityReference{capability: cap_iri, args: [RDF.literal(arg_name)], result: result}
+      ]
+    }
+  end
+
+  describe "propose/4 — Admit path on an empty Catalog" do
+    test "a novel candidate against an empty Catalog is queued as :admit with passing fidelity evidence" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+
+      assert {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx =
+        context(%{
+          capabilities: %{RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")}
+        })
+
+      assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, [{^node, _pending_review}]} = Catalog.list_pending_reviews(scope)
+    end
+  end
+end

--- a/test/riptide/derivation/generalization_fidelity_test.exs
+++ b/test/riptide/derivation/generalization_fidelity_test.exs
@@ -569,8 +569,8 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
 
       assert {:ok, [{generalization, sub1, sub2}]} = AntiUnifier.generalize(trace1, trace2)
 
-      reconstructed1 = substitute_rule(generalization, sub1)
-      reconstructed2 = substitute_rule(generalization, sub2)
+      reconstructed1 = AntiUnifier.substitute(generalization, sub1)
+      reconstructed2 = AntiUnifier.substitute(generalization, sub2)
 
       assert reconstructed1 == trace1
       assert reconstructed2 == trace2
@@ -587,39 +587,4 @@ defmodule Riptide.Derivation.GeneralizationFidelityTest do
       assert GeneralizationFidelity.check(reconstructed2, graph, ctx) == {:ok, :fidelity_pass}
     end
   end
-
-  defp substitute_rule(%Rule{head: head, body: body, signature: signature} = rule, substitution) do
-    %{
-      rule
-      | head: substitute_literal(head, substitution),
-        body: Enum.map(body, &substitute_literal(&1, substitution)),
-        signature: %{
-          signature
-          | parameters: Enum.map(signature.parameters, &substitute_term(&1, substitution))
-        }
-    }
-  end
-
-  defp substitute_literal(%FactPattern{} = lit, substitution) do
-    %{lit | args: Enum.map(lit.args, &substitute_term(&1, substitution))}
-  end
-
-  defp substitute_literal(%CapabilityReference{} = lit, substitution) do
-    %{
-      lit
-      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
-        result: substitute_term(lit.result, substitution)
-    }
-  end
-
-  defp substitute_literal(%RuleReference{} = lit, substitution) do
-    %{
-      lit
-      | args: Enum.map(lit.args, &substitute_term(&1, substitution)),
-        result: substitute_term(lit.result, substitution)
-    }
-  end
-
-  defp substitute_term(%Var{} = var, substitution), do: Map.fetch!(substitution, var)
-  defp substitute_term(term, _substitution), do: term
 end


### PR DESCRIPTION
## Summary

Implements Sub-project 6, phase **6e-iii** (issue #66) — the sixth link in the walking
skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → 6e-iii → {6f, 6g-i}`),
unblocked by 6e-i (#78), 6e-ii (#79), and 6d-i (#64).

Adds `Riptide.Derivation.Catalog` (storage) and `Riptide.Derivation.DedupGate`
(orchestration): Catalog lookup, the `Reject`/`Merge`/`Admit` decision, and the human
review workflow, scope-parameterized `Tenant`/`Hub` from the start.

- A `CatalogEntry ⊑ Rule` is just more Facts — `Catalog` reuses `StreamServer`/`Event`/
  `Patch`/`RuleRDFCodec`/`Matcher` exactly as `ResourceController` already does for LDP
  resources, with zero new persistence infrastructure. Verified blank-node identity is
  stable across this storage path (no lossy Turtle round-trip, unlike the HTTP wire), so
  `RuleRDFCodec`'s default blank-node identity is a stable CatalogEntry/PendingReview id.
- `Merge` reuses `AntiUnifier.generalize/2` a second time (candidate × existing entry)
  instead of a new graph-merge algorithm. `Reject` vs. `Merge` is a mechanical check on
  the recovering substitution's own values
  (`entry_unchanged? = Enum.all?(Map.values(sub_entry), &match?(%Var{}, &1))`) — no
  alpha-equivalence checker.
- `supersede_entry/2` and `resolve_pending_review/3` both retag rather than delete (a
  2-triple patch: retract the old type, assert a new one) — retracting outright would
  need a transitive-closure walk nothing else in this design needs, found while
  grounding the implementation plan and fixed in the (still-open) spec before writing
  any code.
- `AntiUnifier.substitute/2` is promoted from a helper duplicated in 6e-i's and 6e-ii's
  own test files into real production code — `DedupGate` is its first production caller.
- One real finding surfaced only by testing: two "tied" candidate generalizations from
  `AntiUnifier.generalize/2` are not guaranteed to be alpha-equivalent to each other — a
  symmetric literal swap happens to produce isomorphic candidates, an asymmetric one does
  not. An initial "proof" that the symmetric case would classify differently turned out
  to be wrong when actually run; verified an asymmetric construction directly before
  committing to it.

Design spec: `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`
(held open, not yet merged — merging on explicit instruction only, same as the spec for
6e-ii's own precedent this session).

## Test plan

- [x] `mix test test/riptide/derivation/anti_unifier_test.exs` — 5/5 passing (updated to
      call the promoted `AntiUnifier.substitute/2`, no behavior change)
- [x] `mix test test/riptide/derivation/generalization_fidelity_test.exs` — 16/16 passing
      (same update)
- [x] `mix test test/riptide/derivation/dedup_gate/pending_review_test.exs` — 2/2 passing
- [x] `mix test test/riptide/derivation/catalog_test.exs` — 12/12 passing: stream-id
      helpers, empty-stream reads, `admit_entry/3` + `list_entries/1` round-trip,
      `supersede_entry/2`, `queue_pending_review/2` + `list_pending_reviews/1`
      round-trip, `resolve_pending_review/3` (approved + declined), Hub vs. Tenant scope
      isolation
- [x] `mix test test/riptide/derivation/dedup_gate_test.exs` — 8/8 passing: `Admit` on an
      empty Catalog, `Reject`/`Merge` classification, fidelity-failure path, tied
      `AntiUnifier` candidates landing in provably different dispositions,
      `approve_review/2`/`decline_review/2`, and the full exit-criterion round-trip (two
      real fixture-Capability Traces → `AntiUnifier.generalize/2` → `propose/4` →
      `approve_review/2` → live in `Catalog.list_entries/1`)
- [x] Full `mix test` (with `wasmtime` v48.0.1 on `PATH`) — 404 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [x] `PROGRESS.md` updated (6e-iii marked shipped, remaining count 15 → 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)