### PR TITLE
Phase 6f: LLM fallback loop

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration) — 14 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop) — 13 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -674,3 +674,29 @@ verified directly rather than assumed, after an initial proof attempt turned out
 
 **Status**: Phase 6e-iii shipped 2026-08-29. 14 phases remaining across the primary spine and
 the three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6f — LLM fallback loop
+
+Seventh link in the walking skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → 6e-iii →
+{6f, 6g-i}`), unblocked by 6e-iii (#66). **Shipped 2026-08-29** — see
+`docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`.
+
+`Riptide.Derivation.LLMFallback.run/3`: Task with no Catalog match → LLM-guided Capability
+invocation → ground Trace. The LLM authors Rule text directly, reusing `Parser.decode/1`
+completely unmodified — `Matcher`'s and `Parser`'s own doc comments already called Rule Body
+text "untrusted/LLM-authorable" before this phase existed. `ExecuteInterpreter` gained one
+small, purely additive `resolve_bindings/3`, exposing the bindings a live run needs to become
+a ground Trace via `AntiUnifier.substitute/2` (its fourth real production caller) — zero risk
+to `call_template/3`'s own shipped, tested behavior. The LLM call itself is Elixir-level
+platform infrastructure — a small injectable `Client` behaviour (real Anthropic-backed
+implementation + fake for tests), configured via `Application.get_env/3` exactly like
+`Riptide.Authz`'s own `authz_store` pattern. Investigated and ruled out modeling it as a
+Capability instead (conceptual mismatch — Riptide's own reasoning step, not a tenant-granted
+external-system integration — plus `Capability.invoke/4` hardcodes `-S inherit-network=n`
+today, so no Capability can reach the network at all yet). The capstone test — two
+`LLMFallback.run/3` calls → `AntiUnifier.generalize/2` → `DedupGate.propose/4` →
+`approve_review/2` → live in `Catalog.list_entries/1` — is the first test in this whole
+sub-project to exercise the entire walking skeleton end-to-end in one place.
+
+**Status**: Phase 6f shipped 2026-08-29. 13 phases remaining across the primary spine and the
+three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -59,6 +59,25 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
     end
   end
 
+  @doc """
+  Like `call_template/3`, but returns the raw bindings list produced by
+  matching/invoking `rule`'s Body instead of concluding each one into a
+  Head triple. `LLMFallback` (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`
+  §5) needs the full bindings — including Body-only variables that never
+  appear in the Head — to reconstruct a ground Trace via
+  `AntiUnifier.substitute/2`, which `call_template/3`'s own concluded-triple
+  return discards.
+  """
+  @spec resolve_bindings(Rule.t(), RDF.Graph.t(), Context.t()) ::
+          {:ok, [%{Var.t() => RDF.Term.t()}]}
+          | {:error, {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+  def resolve_bindings(%Rule{} = rule, %RDF.Graph{} = graph, %Context{} = context) do
+    with :ok <- check_resolvable(rule.body, context) do
+      {:ok, execute_body(rule.body, %{}, graph, context)}
+    end
+  end
+
   defp check_resolvable(body, context) do
     Enum.reduce_while(body, :ok, fn literal, :ok ->
       case check_literal_resolvable(literal, context) do

--- a/lib/riptide/derivation/llm_fallback.ex
+++ b/lib/riptide/derivation/llm_fallback.ex
@@ -1,0 +1,93 @@
+defmodule Riptide.Derivation.LLMFallback.Client do
+  @moduledoc """
+  Pluggable LLM access point for `Riptide.Derivation.LLMFallback` —
+  Riptide's own platform-level reasoning step, not a tenant-granted
+  external-system Capability (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`
+  §2). Configured via `Application.get_env(:riptide, :llm_fallback_client,
+  ...)`, the same pattern `Riptide.Authz` already uses for `:authz_store`.
+  """
+
+  @callback complete(prompt :: String.t()) :: {:ok, String.t()} | {:error, term()}
+end
+
+defmodule Riptide.Derivation.LLMFallback do
+  @moduledoc """
+  Task with no Catalog match -> LLM-guided Capability invocation -> ground
+  Trace. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`.
+  """
+
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.{AntiUnifier, ExecuteInterpreter, Parser, Rule}
+
+  @spec run(String.t(), RDF.Graph.t(), Context.t()) ::
+          {:ok, Rule.t()}
+          | {:error,
+             {:llm_error, term()}
+             | {:unparseable_response, term()}
+             | :no_match
+             | :ambiguous_match
+             | {:unresolvable, RDF.IRI.t()}
+             | {:unsupported_arity, RDF.IRI.t()}}
+  def run(task_description, %RDF.Graph{} = graph, %Context{} = context) do
+    client =
+      Application.get_env(:riptide, :llm_fallback_client, Riptide.Derivation.LLMFallback.Client.Anthropic)
+
+    with {:ok, response_text} <- call_client(client, task_description, context),
+         {:ok, candidate_rule} <- parse_response(response_text),
+         {:ok, binding} <- resolve_exactly_one_binding(candidate_rule, graph, context) do
+      {:ok, AntiUnifier.substitute(candidate_rule, binding)}
+    end
+  end
+
+  defp call_client(client, task_description, context) do
+    case client.complete(build_prompt(task_description, context)) do
+      {:ok, text} -> {:ok, text}
+      {:error, reason} -> {:error, {:llm_error, reason}}
+    end
+  end
+
+  defp parse_response(text) do
+    case Parser.decode(text) do
+      {:ok, rule} -> {:ok, rule}
+      {:error, reason} -> {:error, {:unparseable_response, reason}}
+    end
+  end
+
+  defp resolve_exactly_one_binding(rule, graph, context) do
+    with {:ok, bindings} <- ExecuteInterpreter.resolve_bindings(rule, graph, context) do
+      case bindings do
+        [] -> {:error, :no_match}
+        [binding] -> {:ok, binding}
+        [_ | _] -> {:error, :ambiguous_match}
+      end
+    end
+  end
+
+  defp build_prompt(task_description, context) do
+    capability_names =
+      context.capabilities |> Map.keys() |> Enum.map(&RDF.IRI.to_string/1) |> Enum.sort()
+
+    rule_names = context.rules |> Map.keys() |> Enum.map(&RDF.IRI.to_string/1) |> Enum.sort()
+
+    """
+    You are generating a single Datalog-style rule clause for Riptide.
+
+    Grammar:
+      predicate(args) :- literal, literal, ..., literal.
+    - Variables: UPPERCASE identifiers (e.g. Result, Target).
+    - Opaque values: "quoted strings".
+    - Entity references: <full IRI>.
+    - Capability call: capability(name, arg, ..., result) - result is always the last argument.
+    - Rule call: rule(name, arg, result).
+
+    Available capabilities: #{Enum.join(capability_names, ", ")}
+    Available rules: #{Enum.join(rule_names, ", ")}
+
+    Task: #{task_description}
+
+    Output ONLY the rule clause text. No markdown, no explanation, no other text.
+    """
+  end
+end

--- a/lib/riptide/derivation/llm_fallback.ex
+++ b/lib/riptide/derivation/llm_fallback.ex
@@ -18,8 +18,8 @@ defmodule Riptide.Derivation.LLMFallback do
   `docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`.
   """
 
-  alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.{AntiUnifier, ExecuteInterpreter, Parser, Rule}
+  alias Riptide.Derivation.ExecuteInterpreter.Context
 
   @spec run(String.t(), RDF.Graph.t(), Context.t()) ::
           {:ok, Rule.t()}
@@ -32,7 +32,11 @@ defmodule Riptide.Derivation.LLMFallback do
              | {:unsupported_arity, RDF.IRI.t()}}
   def run(task_description, %RDF.Graph{} = graph, %Context{} = context) do
     client =
-      Application.get_env(:riptide, :llm_fallback_client, Riptide.Derivation.LLMFallback.Client.Anthropic)
+      Application.get_env(
+        :riptide,
+        :llm_fallback_client,
+        Riptide.Derivation.LLMFallback.Client.Anthropic
+      )
 
     with {:ok, response_text} <- call_client(client, task_description, context),
          {:ok, candidate_rule} <- parse_response(response_text),

--- a/lib/riptide/derivation/llm_fallback/client/anthropic.ex
+++ b/lib/riptide/derivation/llm_fallback/client/anthropic.ex
@@ -1,0 +1,60 @@
+defmodule Riptide.Derivation.LLMFallback.Client.Anthropic do
+  @moduledoc """
+  Real implementation of `Riptide.Derivation.LLMFallback.Client` against
+  Anthropic's Messages API. Tesla-based (already a direct dependency,
+  `mix.exs`), matching this project's existing outbound-HTTP precedent
+  (`Riptide.Auth.JwksStrategy`'s JWKS fetch). See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`
+  §4.
+  """
+
+  @behaviour Riptide.Derivation.LLMFallback.Client
+
+  @api_url "https://api.anthropic.com/v1/messages"
+  @api_version "2023-06-01"
+  @model "claude-sonnet-5"
+  @max_tokens 1024
+
+  @impl true
+  @spec complete(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def complete(prompt) do
+    with {:ok, api_key} <- fetch_api_key(),
+         {:ok, %Tesla.Env{status: 200, body: body}} <-
+           Tesla.post(build_client(api_key), @api_url, request_body(prompt)) do
+      extract_text(body)
+    else
+      {:ok, %Tesla.Env{status: status, body: body}} -> {:error, {:http_error, status, body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_api_key do
+    case System.get_env("ANTHROPIC_API_KEY") do
+      nil -> {:error, :missing_api_key}
+      key -> {:ok, key}
+    end
+  end
+
+  defp build_client(api_key) do
+    adapter = Application.get_env(:riptide, :llm_fallback_tesla_adapter, Tesla.Adapter.Httpc)
+
+    Tesla.client(
+      [
+        {Tesla.Middleware.Headers, [{"x-api-key", api_key}, {"anthropic-version", @api_version}]},
+        Tesla.Middleware.JSON
+      ],
+      adapter
+    )
+  end
+
+  defp request_body(prompt) do
+    %{
+      model: @model,
+      max_tokens: @max_tokens,
+      messages: [%{role: "user", content: prompt}]
+    }
+  end
+
+  defp extract_text(%{"content" => [%{"type" => "text", "text" => text} | _]}), do: {:ok, text}
+  defp extract_text(body), do: {:error, {:unexpected_response_shape, body}}
+end

--- a/test/riptide/derivation/execute_interpreter_test.exs
+++ b/test/riptide/derivation/execute_interpreter_test.exs
@@ -438,4 +438,71 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       assert is_binary(object) or match?(%RDF.Literal{}, object)
     end
   end
+
+  describe "resolve_bindings/3" do
+    test "returns the raw bindings list instead of concluding into triples" do
+      head = %FactPattern{predicate: rel("sibling"), args: [%Var{name: "X"}, %Var{name: "Y"}]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "X"}, %Var{name: "Y"}]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      graph = RDF.Graph.new([{t("alice"), rel("worksAt"), t("acme")}])
+
+      assert ExecuteInterpreter.resolve_bindings(rule, graph, context()) ==
+               {:ok, [%{%Var{name: "X"} => t("alice"), %Var{name: "Y"} => t("acme")}]}
+    end
+
+    test "an unresolvable capability IRI is rejected before any graph access" do
+      head = %FactPattern{predicate: rel("out"), args: [t("x"), %Var{name: "Result"}]}
+
+      body = [
+        %CapabilityReference{
+          capability: RDF.iri("urn:riptide:capability:notRegistered"),
+          args: [t("x")],
+          result: %Var{name: "Result"}
+        }
+      ]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert ExecuteInterpreter.resolve_bindings(rule, RDF.Graph.new(), context()) ==
+               {:error, {:unresolvable, RDF.iri("urn:riptide:capability:notRegistered")}}
+    end
+
+    test "a Body with zero matches returns {:ok, []}, not an error" do
+      head = %FactPattern{predicate: rel("sibling"), args: [%Var{name: "X"}, %Var{name: "Y"}]}
+      body = [%FactPattern{predicate: rel("worksAt"), args: [%Var{name: "X"}, %Var{name: "Y"}]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert ExecuteInterpreter.resolve_bindings(rule, RDF.Graph.new(), context()) == {:ok, []}
+    end
+  end
 end

--- a/test/riptide/derivation/llm_fallback/client/anthropic_test.exs
+++ b/test/riptide/derivation/llm_fallback/client/anthropic_test.exs
@@ -1,0 +1,49 @@
+defmodule Riptide.Derivation.LLMFallback.Client.AnthropicTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Derivation.LLMFallback.Client.Anthropic
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_tesla_adapter, Tesla.Mock)
+    System.put_env("ANTHROPIC_API_KEY", "test-key")
+    on_exit(fn -> System.delete_env("ANTHROPIC_API_KEY") end)
+    :ok
+  end
+
+  test "complete/1 sends the prompt and extracts the response text" do
+    Tesla.Mock.mock(fn %Tesla.Env{method: :post, url: url, body: body} = env ->
+      assert url == "https://api.anthropic.com/v1/messages"
+      assert {"x-api-key", "test-key"} in env.headers
+      assert {"anthropic-version", "2023-06-01"} in env.headers
+
+      assert %{"messages" => [%{"role" => "user", "content" => "greet Alice"}]} =
+               Jason.decode!(body)
+
+      # Tesla.Middleware.JSON only auto-decodes a response when the response
+      # itself carries a `content-type: application/json` header (verified
+      # directly — without it, `Anthropic.complete/1`'s own `body` argument
+      # stays a raw JSON string and `extract_text/1` would fail to match).
+      # A real Anthropic API response always sets this, so this is also more
+      # realistic mock data, not just a workaround.
+      %Tesla.Env{
+        status: 200,
+        headers: [{"content-type", "application/json"}],
+        body: Jason.encode!(%{"content" => [%{"type" => "text", "text" => "greeted(...)."}]})
+      }
+    end)
+
+    assert Anthropic.complete("greet Alice") == {:ok, "greeted(...)."}
+  end
+
+  test "a non-200 response surfaces as {:error, {:http_error, status, body}}" do
+    Tesla.Mock.mock(fn _env -> %Tesla.Env{status: 429, body: "rate limited"} end)
+
+    assert Anthropic.complete("greet Alice") == {:error, {:http_error, 429, "rate limited"}}
+  end
+
+  test "a missing ANTHROPIC_API_KEY surfaces as {:error, :missing_api_key}" do
+    System.delete_env("ANTHROPIC_API_KEY")
+
+    assert Anthropic.complete("greet Alice") == {:error, :missing_api_key}
+  end
+end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -186,4 +186,16 @@ defmodule Riptide.Derivation.LLMFallbackTest do
       end)
     end
   end
+
+  describe "run/3 — no match" do
+    test "a response whose Body matches nothing in the graph is :no_match" do
+      response = "greeted(<urn:test:riptide>, Result) :- pendingDeploy(<urn:test:riptide>, Result)."
+
+      ctx = context()
+
+      with_fake_client({:ok, response}, fn ->
+        assert LLMFallback.run("greet Alice", RDF.Graph.new(), ctx) == {:error, :no_match}
+      end)
+    end
+  end
 end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -198,4 +198,22 @@ defmodule Riptide.Derivation.LLMFallbackTest do
       end)
     end
   end
+
+  describe "run/3 — ambiguous match" do
+    test "a response whose Body matches more than one way is :ambiguous_match" do
+      response = "greeted(<urn:test:riptide>, Target) :- pendingDeploy(<urn:test:riptide>, Target)."
+
+      graph =
+        RDF.Graph.new([
+          {t("riptide"), rel("pendingDeploy"), t("v1")},
+          {t("riptide"), rel("pendingDeploy"), t("v2")}
+        ])
+
+      ctx = context()
+
+      with_fake_client({:ok, response}, fn ->
+        assert LLMFallback.run("deploy riptide", graph, ctx) == {:error, :ambiguous_match}
+      end)
+    end
+  end
 end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -172,4 +172,18 @@ defmodule Riptide.Derivation.LLMFallbackTest do
       end)
     end
   end
+
+  describe "run/3 — unresolvable capability reference" do
+    test "a response naming a capability the tenant doesn't have registered is a real, surfaced error" do
+      response =
+        "greeted(<urn:test:riptide>, Greeting) :- capability(notRegistered, \"Alice\", Greeting)."
+
+      ctx = context()
+
+      with_fake_client({:ok, response}, fn ->
+        assert {:error, {:unresolvable, iri}} = LLMFallback.run("greet Alice", RDF.Graph.new(), ctx)
+        assert iri == cap("notRegistered")
+      end)
+    end
+  end
 end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -161,4 +161,15 @@ defmodule Riptide.Derivation.LLMFallbackTest do
       end)
     end
   end
+
+  describe "run/3 — unparseable response" do
+    test "a response that isn't valid rule text is a real, surfaced error" do
+      ctx = context()
+
+      with_fake_client({:ok, "this is not a rule clause at all"}, fn ->
+        assert {:error, {:unparseable_response, _reason}} =
+                 LLMFallback.run("do something", RDF.Graph.new(), ctx)
+      end)
+    end
+  end
 end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -82,8 +82,12 @@ defmodule Riptide.Derivation.LLMFallbackTest do
 
     def start(result) do
       case Agent.start_link(fn -> %{result: result, last_prompt: nil} end, name: __MODULE__) do
-        {:ok, pid} -> pid
-        {:error, {:already_started, pid}} -> Agent.update(pid, &%{&1 | result: result}); pid
+        {:ok, pid} ->
+          pid
+
+        {:error, {:already_started, pid}} ->
+          Agent.update(pid, &%{&1 | result: result})
+          pid
       end
     end
 
@@ -181,7 +185,9 @@ defmodule Riptide.Derivation.LLMFallbackTest do
       ctx = context()
 
       with_fake_client({:ok, response}, fn ->
-        assert {:error, {:unresolvable, iri}} = LLMFallback.run("greet Alice", RDF.Graph.new(), ctx)
+        assert {:error, {:unresolvable, iri}} =
+                 LLMFallback.run("greet Alice", RDF.Graph.new(), ctx)
+
         assert iri == cap("notRegistered")
       end)
     end
@@ -189,7 +195,8 @@ defmodule Riptide.Derivation.LLMFallbackTest do
 
   describe "run/3 — no match" do
     test "a response whose Body matches nothing in the graph is :no_match" do
-      response = "greeted(<urn:test:riptide>, Result) :- pendingDeploy(<urn:test:riptide>, Result)."
+      response =
+        "greeted(<urn:test:riptide>, Result) :- pendingDeploy(<urn:test:riptide>, Result)."
 
       ctx = context()
 
@@ -201,7 +208,8 @@ defmodule Riptide.Derivation.LLMFallbackTest do
 
   describe "run/3 — ambiguous match" do
     test "a response whose Body matches more than one way is :ambiguous_match" do
-      response = "greeted(<urn:test:riptide>, Target) :- pendingDeploy(<urn:test:riptide>, Target)."
+      response =
+        "greeted(<urn:test:riptide>, Target) :- pendingDeploy(<urn:test:riptide>, Target)."
 
       graph =
         RDF.Graph.new([
@@ -213,6 +221,17 @@ defmodule Riptide.Derivation.LLMFallbackTest do
 
       with_fake_client({:ok, response}, fn ->
         assert LLMFallback.run("deploy riptide", graph, ctx) == {:error, :ambiguous_match}
+      end)
+    end
+  end
+
+  describe "run/3 — LLM call failure" do
+    test "a failing Client.complete/1 call surfaces as {:llm_error, reason}" do
+      ctx = context()
+
+      with_fake_client({:error, :timeout}, fn ->
+        assert LLMFallback.run("greet Alice", RDF.Graph.new(), ctx) ==
+                 {:error, {:llm_error, :timeout}}
       end)
     end
   end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -1,0 +1,140 @@
+defmodule Riptide.Derivation.LLMFallbackTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Capability.Definition
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.LLMFallback
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp cap(name), do: RDF.iri("urn:riptide:capability:" <> name)
+
+  defp context(overrides \\ %{}) do
+    Map.merge(
+      %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
+      overrides
+    )
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    on_exit(fn ->
+      if pid = Process.whereis(FakeStore) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp greet_definition(name) do
+    %Definition{
+      name: cap(name),
+      kind: :effect,
+      component: "test/fixtures/riptide_capability/fixture.wasm",
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+  end
+
+  defmodule FakeClient do
+    @behaviour Riptide.Derivation.LLMFallback.Client
+
+    @impl true
+    def complete(_prompt) do
+      Agent.get(__MODULE__, & &1)
+    end
+
+    def start(result) do
+      case Agent.start_link(fn -> result end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    on_exit(fn ->
+      if pid = Process.whereis(FakeClient) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp with_fake_client(result, fun) do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_client, FakeClient)
+    FakeClient.start(result)
+    fun.()
+  end
+
+  describe "run/3 — pass case" do
+    test "an LLM-authored Rule, resolved via real Capability invocation, becomes a ground Trace" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetSomeone"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      response =
+        "greeted(<urn:test:riptide>, Greeting) :- capability(greetSomeone, \"Alice\", Greeting)."
+
+      ctx = context(%{capabilities: %{cap("greetSomeone") => greet_definition("greetSomeone")}})
+
+      with_fake_client({:ok, response}, fn ->
+        assert {:ok, trace} = LLMFallback.run("greet Alice", RDF.Graph.new(), ctx)
+
+        assert trace.head == %Riptide.Derivation.Literal.FactPattern{
+                 predicate: rel("greeted"),
+                 args: [t("riptide"), "\"Hello, Alice!\""]
+               }
+
+        assert [%Riptide.Derivation.Literal.CapabilityReference{} = capability_reference] =
+                 trace.body
+
+        assert capability_reference.capability == cap("greetSomeone")
+        assert capability_reference.args == [RDF.literal("Alice")]
+        assert capability_reference.result == "\"Hello, Alice!\""
+      end)
+    end
+  end
+end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -75,16 +75,19 @@ defmodule Riptide.Derivation.LLMFallbackTest do
     @behaviour Riptide.Derivation.LLMFallback.Client
 
     @impl true
-    def complete(_prompt) do
-      Agent.get(__MODULE__, & &1)
+    def complete(prompt) do
+      Agent.update(__MODULE__, &Map.put(&1, :last_prompt, prompt))
+      Map.fetch!(Agent.get(__MODULE__, & &1), :result)
     end
 
     def start(result) do
-      case Agent.start_link(fn -> result end, name: __MODULE__) do
+      case Agent.start_link(fn -> %{result: result, last_prompt: nil} end, name: __MODULE__) do
         {:ok, pid} -> pid
-        {:error, {:already_started, pid}} -> pid
+        {:error, {:already_started, pid}} -> Agent.update(pid, &%{&1 | result: result}); pid
       end
     end
+
+    def last_prompt, do: Agent.get(__MODULE__, & &1.last_prompt)
   end
 
   setup do
@@ -134,6 +137,27 @@ defmodule Riptide.Derivation.LLMFallbackTest do
         assert capability_reference.capability == cap("greetSomeone")
         assert capability_reference.args == [RDF.literal("Alice")]
         assert capability_reference.result == "\"Hello, Alice!\""
+      end)
+    end
+  end
+
+  describe "run/3 — prompt content" do
+    test "the prompt lists the tenant's real capability names, not a hallucinated one" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetSomeone"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      response =
+        "greeted(<urn:test:riptide>, Greeting) :- capability(greetSomeone, \"Alice\", Greeting)."
+
+      ctx = context(%{capabilities: %{cap("greetSomeone") => greet_definition("greetSomeone")}})
+
+      with_fake_client({:ok, response}, fn ->
+        {:ok, _trace} = LLMFallback.run("greet Alice", RDF.Graph.new(), ctx)
+
+        assert FakeClient.last_prompt() =~ "urn:riptide:capability:greetSomeone"
       end)
     end
   end

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -2,8 +2,8 @@ defmodule Riptide.Derivation.LLMFallbackTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Capability.Definition
+  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, LLMFallback}
   alias Riptide.Derivation.ExecuteInterpreter.Context
-  alias Riptide.Derivation.LLMFallback
 
   defp t(name), do: RDF.iri("urn:test:" <> name)
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
@@ -233,6 +233,57 @@ defmodule Riptide.Derivation.LLMFallbackTest do
         assert LLMFallback.run("greet Alice", RDF.Graph.new(), ctx) ==
                  {:error, {:llm_error, :timeout}}
       end)
+    end
+  end
+
+  describe "exit criterion (issue #67) — the full walking skeleton" do
+    test "a Task with no Catalog match, run through LLMFallback twice, anti-unifies, passes DedupGate's Admit path, and becomes a live CatalogEntry" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      scope = {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      ctx = context(%{capabilities: %{cap("greetPerson") => greet_definition("greetPerson")}})
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      response1 =
+        "greeted(<urn:test:alice>, Result) :- pendingDeploy(<urn:test:alice>, Target), capability(greetPerson, \"Alice\", Result)."
+
+      response2 =
+        "greeted(<urn:test:bob>, Result) :- pendingDeploy(<urn:test:bob>, Target), capability(greetPerson, \"Bob\", Result)."
+
+      trace1 =
+        with_fake_client({:ok, response1}, fn ->
+          assert {:ok, trace1} = LLMFallback.run("greet Alice", graph, ctx)
+          trace1
+        end)
+
+      trace2 =
+        with_fake_client({:ok, response2}, fn ->
+          assert {:ok, trace2} = LLMFallback.run("greet Bob", graph, ctx)
+          trace2
+        end)
+
+      assert {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+
+      assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+
+      assert :ok == DedupGate.approve_review(scope, node)
+
+      assert {:ok, [{_entry_node, _rule}]} = Catalog.list_entries(scope)
     end
   end
 end


### PR DESCRIPTION
## Summary

Implements Sub-project 6, phase **6f** (issue #67) — the seventh link in the walking
skeleton (`6b-i → 6c-i-a → 6c-i-b → 6d-i → 6e-i → 6e-ii → 6e-iii → {6f, 6g-i}`),
unblocked by 6e-iii (#66).

Adds `Riptide.Derivation.LLMFallback.run/3`: Task with no Catalog match → LLM-guided
Capability invocation → ground Trace.

- The LLM authors Rule text directly, reusing `Parser.decode/1` completely unmodified —
  `Matcher`'s and `Parser`'s own doc comments already called Rule Body text
  "untrusted/LLM-authorable" before this phase existed.
- `ExecuteInterpreter` gets one small, purely additive `resolve_bindings/3`, exposing the
  bindings a live run needs to become a ground Trace via `AntiUnifier.substitute/2` (its
  fourth real production caller) — zero risk to `call_template/3`'s own shipped, tested
  behavior.
- The LLM call itself is Elixir-level platform infrastructure — a small injectable
  `Client` behaviour (real Anthropic-backed implementation + fake for tests), configured
  via `Application.get_env/3` exactly like `Riptide.Authz`'s own `authz_store` pattern.
  Investigated and ruled out modeling it as a Capability instead (conceptual mismatch,
  plus `Capability.invoke/4` hardcodes `-S inherit-network=n` today — no Capability can
  reach the network at all yet).
- The capstone test is the first in this whole sub-project to exercise the *entire*
  walking skeleton end-to-end in one place: two `LLMFallback.run/3` calls →
  `AntiUnifier.generalize/2` → `DedupGate.propose/4` → `approve_review/2` → live in
  `Catalog.list_entries/1`.

Design spec: `docs/superpowers/specs/2026-08-29-phase-6f-llm-fallback-loop-design.md`
(held open, not yet merged — merging on explicit instruction only, matching this
session's established precedent for 6e-ii/6e-iii's own specs).

## Test plan

- [x] `mix test test/riptide/derivation/execute_interpreter_test.exs` — 13/13 passing
      (10 existing + 3 new `resolve_bindings/3` tests)
- [x] `mix test test/riptide/derivation/llm_fallback_test.exs` — 8/8 passing: pass case,
      prompt content, unparseable response, unresolvable capability, no-match,
      ambiguous-match, LLM-call failure, and the full walking-skeleton capstone
- [x] `mix test test/riptide/derivation/llm_fallback/client/anthropic_test.exs` — 3/3
      passing (Riptide's own request/response handling via `Tesla.Mock`, never a live
      call to Anthropic's API)
- [x] Full `mix test` (with `wasmtime` v48.0.1 on `PATH`) — 418 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — no issues
- [x] `PROGRESS.md` updated (6f marked shipped, remaining count 14 → 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)