### PR TITLE
Draft: Resolve: "Exact/keyword Discovery"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop) — 13 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery) — 12 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -699,4 +699,32 @@ today, so no Capability can reach the network at all yet). The capstone test —
 sub-project to exercise the entire walking skeleton end-to-end in one place.
 
 **Status**: Phase 6f shipped 2026-08-29. 13 phases remaining across the primary spine and the
+three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6g-i — Exact/keyword Discovery
+
+Eighth link in the walking skeleton, and its own final step (`6b-i → 6c-i-a → 6c-i-b → 6d-i →
+6e-i → 6e-ii → 6e-iii → {6f, 6g-i}`), unblocked by 6e-iii (#66). **Shipped 2026-08-29** — see
+`docs/superpowers/specs/2026-08-29-phase-6g-i-exact-keyword-discovery-design.md`.
+
+`Riptide.Derivation.Discovery.find/2`: exact/keyword lookup over CatalogEntry. Tokenizes the
+query and each found entry's predicate local name (camelCase-aware), ranks word-set-equal
+entries above any partial-overlap keyword match, and breaks ties within either tier by
+specificity (free-variable count) — the same idea 6e-i/6e-iii already established for
+anti-unification scoring. `recency` and `StabilityClass` conflict-resolution tiers were both
+investigated and explicitly deferred, for two different concrete reasons: `recency` isn't
+actually free (`Catalog.list_entries/1` folds the event log into an unordered `RDF.Graph`,
+discarding admission order — a blank-node-counter proxy was considered and rejected as unsound
+for a distributed, Ra-replicated system); `StabilityClass` doesn't exist as a field anywhere in
+shipped code and would mean retrofitting `Capability.Definition` for something issue #68 never
+asked for. `ExecuteInterpreter.call_template/4` — an already-implemented private clause used
+internally by `invoke_rule/4` — became public (pure visibility widening, zero behavior change),
+letting a caller seed a found template's free variables against a new Task's own concrete
+arguments. The capstone test closes the walking skeleton's own `{6f, 6g-i}` branch end-to-end
+for the first time with **zero** LLM calls: two `LLMFallback.run/3` calls admit a CatalogEntry
+via the full `AntiUnifier.generalize/2` → `DedupGate.propose/4` → `approve_review/2` path, a
+third task is found by `Discovery.find/2`'s keyword tier, and invoked directly via
+`ExecuteInterpreter.call_template/4`.
+
+**Status**: Phase 6g-i shipped 2026-08-29. 12 phases remaining across the primary spine and the
 three parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/discovery.ex
+++ b/lib/riptide/derivation/discovery.ex
@@ -1,0 +1,74 @@
+defmodule Riptide.Derivation.Discovery do
+  @moduledoc """
+  Exact/keyword lookup over CatalogEntry — the walking skeleton's own final
+  step. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6g-i-exact-keyword-discovery-design.md`.
+  Word-set equality between the query and a found entry's predicate local
+  name ranks above any partial-overlap keyword match; free-variable count
+  (specificity) breaks ties within either tier.
+  """
+
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
+  alias Riptide.Derivation.{Catalog, Rule, Var}
+
+  @spec find(Catalog.scope(), String.t()) ::
+          {:ok, [{RDF.BlankNode.t(), Rule.t()}]} | {:error, :not_ready}
+  def find(scope, query_text) do
+    with {:ok, entries} <- Catalog.list_entries(scope) do
+      query_words = MapSet.new(tokenize(query_text))
+
+      ranked =
+        entries
+        |> Enum.map(fn {node, rule} -> {node, rule, score(rule, query_words)} end)
+        |> Enum.reject(fn {_node, _rule, score} -> score == :no_match end)
+        |> Enum.sort_by(fn {_node, rule, score} -> sort_key(score, rule) end)
+        |> Enum.map(fn {node, rule, _score} -> {node, rule} end)
+
+      {:ok, ranked}
+    end
+  end
+
+  defp score(rule, query_words) do
+    predicate_words = MapSet.new(camel_words(local_name(rule.signature.name)))
+    overlap = MapSet.intersection(predicate_words, query_words)
+
+    cond do
+      MapSet.equal?(predicate_words, query_words) -> {:exact}
+      MapSet.size(overlap) > 0 -> {:keyword, MapSet.size(overlap)}
+      true -> :no_match
+    end
+  end
+
+  defp sort_key({:exact}, rule), do: {0, 0, specificity(rule)}
+  defp sort_key({:keyword, overlap}, rule), do: {1, -overlap, specificity(rule)}
+
+  defp specificity(%Rule{head: head, body: body}) do
+    count_vars(head.args) + Enum.reduce(body, 0, &(count_vars(literal_terms(&1)) + &2))
+  end
+
+  defp literal_terms(%FactPattern{args: args}), do: args
+  defp literal_terms(%CapabilityReference{args: args, result: result}), do: [result | args]
+  defp literal_terms(%RuleReference{args: args, result: result}), do: [result | args]
+
+  defp count_vars(terms), do: Enum.count(terms, &match?(%Var{}, &1))
+
+  defp local_name(iri) do
+    iri
+    |> RDF.IRI.to_string()
+    |> String.split(":")
+    |> List.last()
+  end
+
+  defp camel_words(name) do
+    name
+    |> String.replace(~r/([a-z0-9])([A-Z])/, "\\1 \\2")
+    |> String.downcase()
+    |> String.split(~r/[^a-z0-9]+/, trim: true)
+  end
+
+  defp tokenize(text) do
+    text
+    |> String.downcase()
+    |> String.split(~r/[^a-z0-9]+/, trim: true)
+  end
+end

--- a/lib/riptide/derivation/discovery.ex
+++ b/lib/riptide/derivation/discovery.ex
@@ -8,8 +8,8 @@ defmodule Riptide.Derivation.Discovery do
   (specificity) breaks ties within either tier.
   """
 
-  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
   alias Riptide.Derivation.{Catalog, Rule, Var}
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
 
   @spec find(Catalog.scope(), String.t()) ::
           {:ok, [{RDF.BlankNode.t(), Rule.t()}]} | {:error, :not_ready}

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -52,7 +52,19 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
     call_template(rule, %{}, graph, context)
   end
 
-  defp call_template(%Rule{} = rule, seed, %RDF.Graph{} = graph, %Context{} = context) do
+  @doc """
+  Like `call_template/3`, but starts execution from a caller-supplied
+  `seed` instead of an empty binding map. `invoke_rule/4` already used
+  this internally to seed a nested Rule's Head variable before this
+  became a public entry point; a found Discovery result (`Riptide.Derivation.Discovery`
+  design spec `docs/superpowers/specs/2026-08-29-phase-6g-i-exact-keyword-discovery-design.md`
+  §2) is the same shape of caller — a template still needs its own free
+  variables bound to a new Task's concrete arguments before invocation.
+  """
+  @spec call_template(Rule.t(), %{Var.t() => RDF.Term.t()}, RDF.Graph.t(), Context.t()) ::
+          {:ok, [RDF.Triple.t()]}
+          | {:error, {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+  def call_template(%Rule{} = rule, seed, %RDF.Graph{} = graph, %Context{} = context) do
     with :ok <- check_resolvable(rule.body, context) do
       bindings_list = execute_body(rule.body, seed, graph, context)
       {:ok, Enum.map(bindings_list, &conclude(rule.head, &1))}

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -62,4 +62,16 @@ defmodule Riptide.Derivation.DiscoveryTest do
       assert {:ok, [{_node, ^rule}]} = Discovery.find(scope, "deploy the service")
     end
   end
+
+  describe "find/2 — no match" do
+    test "a query with zero word overlap returns {:ok, []}, not an error" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      rule = sample_rule("pendingDeploy", 0)
+      :ok = Catalog.admit_entry(scope, rule, nil)
+
+      assert Discovery.find(scope, "unrelated task") == {:ok, []}
+    end
+  end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -106,4 +106,10 @@ defmodule Riptide.Derivation.DiscoveryTest do
                Discovery.find(scope, "pending deploy")
     end
   end
+
+  describe "find/2 — empty Catalog" do
+    test "a Tenant scope with no CatalogEntry admitted yet returns {:ok, []}" do
+      assert Discovery.find(unique_tenant(), "anything") == {:ok, []}
+    end
+  end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -1,0 +1,53 @@
+defmodule Riptide.Derivation.DiscoveryTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.Discovery
+  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Rule, Signature, Var}
+
+  defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  # free_var_count: 0, 1, or 2 — controls how many of the Head's two
+  # FactPattern args are free `Var`s (a FactPattern always has exactly 2
+  # args, subject + object), giving each test control over specificity
+  # without needing a real Body.
+  defp sample_rule(predicate_local_name, free_var_count) do
+    predicate = rel(predicate_local_name)
+
+    head_args =
+      case free_var_count do
+        0 -> [t("subject"), RDF.literal("object")]
+        1 -> [%Var{name: "X"}, RDF.literal("object")]
+        2 -> [%Var{name: "X"}, %Var{name: "Y"}]
+      end
+
+    head = %FactPattern{predicate: predicate, args: head_args}
+
+    %Rule{
+      signature: %Signature{
+        name: predicate,
+        parameters: Enum.filter(head_args, &match?(%Var{}, &1)),
+        reads: [],
+        produces: [predicate]
+      },
+      head: head,
+      body: []
+    }
+  end
+
+  describe "find/2 — exact match" do
+    test "a query whose words exactly match a found entry's predicate is ranked" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      rule = sample_rule("pendingDeploy", 0)
+      :ok = Catalog.admit_entry(scope, rule, nil)
+
+      assert {:ok, [{_node, ^rule}]} = Discovery.find(scope, "pending deploy")
+    end
+  end
+end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -74,4 +74,20 @@ defmodule Riptide.Derivation.DiscoveryTest do
       assert Discovery.find(scope, "unrelated task") == {:ok, []}
     end
   end
+
+  describe "find/2 — specificity tiebreak" do
+    test "within the same tier, fewer free variables ranks first" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      specific_rule = sample_rule("greeted", 0)
+      general_rule = sample_rule("greeted", 1)
+
+      :ok = Catalog.admit_entry(scope, general_rule, nil)
+      :ok = Catalog.admit_entry(scope, specific_rule, nil)
+
+      assert {:ok, [{_node1, ^specific_rule}, {_node2, ^general_rule}]} =
+               Discovery.find(scope, "greeted")
+    end
+  end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -1,15 +1,18 @@
 defmodule Riptide.Derivation.DiscoveryTest do
   use ExUnit.Case, async: false
 
-  alias Riptide.Derivation.Catalog
-  alias Riptide.Derivation.Discovery
+  alias Riptide.Capability.Definition
+  alias Riptide.Derivation.ExecuteInterpreter
+  alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Discovery, LLMFallback}
   alias Riptide.Derivation.{Rule, Signature, Var}
 
   defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
 
   defp t(name), do: RDF.iri("urn:test:" <> name)
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp cap(name), do: RDF.iri("urn:riptide:capability:" <> name)
 
   # free_var_count: 0, 1, or 2 — controls how many of the Head's two
   # FactPattern args are free `Var`s (a FactPattern always has exactly 2
@@ -110,6 +113,132 @@ defmodule Riptide.Derivation.DiscoveryTest do
   describe "find/2 — empty Catalog" do
     test "a Tenant scope with no CatalogEntry admitted yet returns {:ok, []}" do
       assert Discovery.find(unique_tenant(), "anything") == {:ok, []}
+    end
+  end
+
+  defp context(overrides) do
+    Map.merge(
+      %Context{capabilities: %{}, rules: %{}, tenant_id: "acme", current_subject: nil},
+      overrides
+    )
+  end
+
+  defp greet_definition(name) do
+    %Definition{
+      name: cap(name),
+      kind: :effect,
+      component: "test/fixtures/riptide_capability/fixture.wasm",
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(_tenant_id, _path_prefix) do
+      [%Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}]
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+  end
+
+  defmodule FakeClient do
+    @behaviour Riptide.Derivation.LLMFallback.Client
+
+    @impl true
+    def complete(_prompt), do: Agent.get(__MODULE__, & &1)
+
+    def start(result) do
+      case Agent.start_link(fn -> result end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> Agent.update(pid, fn _ -> result end); pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    on_exit(fn ->
+      if pid = Process.whereis(FakeClient) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  describe "exit criterion (issue #68) — the full walking skeleton, third occurrence" do
+    test "a CatalogEntry admitted by DedupGate is found by Discovery and invoked without an LLM call" do
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      ctx = context(%{capabilities: %{cap("greetPerson") => greet_definition("greetPerson")}})
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("alice"), rel("hasName"), RDF.literal("Alice")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("hasName"), RDF.literal("Bob")}
+        ])
+
+      response1 =
+        "greet(<urn:test:alice>, Result) :- pendingDeploy(<urn:test:alice>, Target), hasName(<urn:test:alice>, Name), capability(greetPerson, Name, Result)."
+
+      response2 =
+        "greet(<urn:test:bob>, Result) :- pendingDeploy(<urn:test:bob>, Target), hasName(<urn:test:bob>, Name), capability(greetPerson, Name, Result)."
+
+      FakeClient.start({:ok, response1})
+      Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_client, FakeClient)
+      assert {:ok, trace1} = LLMFallback.run("greet Alice", graph, ctx)
+
+      FakeClient.start({:ok, response2})
+      assert {:ok, trace2} = LLMFallback.run("greet Bob", graph, ctx)
+
+      assert {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
+      assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert :ok == DedupGate.approve_review(scope, node)
+
+      # Third occurrence: found via Discovery's keyword path ("greet" is not
+      # among the found entry's own predicate words — pending/deploy/has/name
+      # — so this is genuinely a keyword match, not exact), then invoked
+      # directly — no LLMFallback.run/3 call anywhere below this line.
+      assert {:ok, [{_found_node, found_rule}]} = Discovery.find(scope, "greet Carol")
+
+      [subject_var | _] = found_rule.signature.parameters
+
+      carol_graph =
+        RDF.Graph.new([
+          {t("carol"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("carol"), rel("hasName"), RDF.literal("Carol")}
+        ])
+
+      seed = %{subject_var => t("carol")}
+
+      assert ExecuteInterpreter.call_template(found_rule, seed, carol_graph, ctx) ==
+               {:ok, [{t("carol"), rel("greet"), "\"Hello, Carol!\""}]}
     end
   end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -90,4 +90,20 @@ defmodule Riptide.Derivation.DiscoveryTest do
                Discovery.find(scope, "greeted")
     end
   end
+
+  describe "find/2 — exact outranks a higher-overlap keyword hit" do
+    test "tier is the primary sort key, not raw overlap count" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      exact_rule = sample_rule("pendingDeploy", 0)
+      keyword_rule = sample_rule("pendingDeployNow", 0)
+
+      :ok = Catalog.admit_entry(scope, keyword_rule, nil)
+      :ok = Catalog.admit_entry(scope, exact_rule, nil)
+
+      assert {:ok, [{_node1, ^exact_rule}, {_node2, ^keyword_rule}]} =
+               Discovery.find(scope, "pending deploy")
+    end
+  end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -50,4 +50,16 @@ defmodule Riptide.Derivation.DiscoveryTest do
       assert {:ok, [{_node, ^rule}]} = Discovery.find(scope, "pending deploy")
     end
   end
+
+  describe "find/2 — keyword match" do
+    test "a query with partial word overlap, no exact candidate, is found via keyword fallback" do
+      scope = unique_tenant()
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+
+      rule = sample_rule("pendingDeploy", 0)
+      :ok = Catalog.admit_entry(scope, rule, nil)
+
+      assert {:ok, [{_node, ^rule}]} = Discovery.find(scope, "deploy the service")
+    end
+  end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -2,10 +2,11 @@ defmodule Riptide.Derivation.DiscoveryTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Capability.Definition
+  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Discovery}
   alias Riptide.Derivation.ExecuteInterpreter
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.FactPattern
-  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Discovery, LLMFallback}
+  alias Riptide.Derivation.LLMFallback
   alias Riptide.Derivation.{Rule, Signature, Var}
 
   defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
@@ -163,8 +164,12 @@ defmodule Riptide.Derivation.DiscoveryTest do
 
     def start(result) do
       case Agent.start_link(fn -> result end, name: __MODULE__) do
-        {:ok, pid} -> pid
-        {:error, {:already_started, pid}} -> Agent.update(pid, fn _ -> result end); pid
+        {:ok, pid} ->
+          pid
+
+        {:error, {:already_started, pid}} ->
+          Agent.update(pid, fn _ -> result end)
+          pid
       end
     end
   end

--- a/test/riptide/derivation/execute_interpreter_test.exs
+++ b/test/riptide/derivation/execute_interpreter_test.exs
@@ -505,4 +505,26 @@ defmodule Riptide.Derivation.ExecuteInterpreterTest do
       assert ExecuteInterpreter.resolve_bindings(rule, RDF.Graph.new(), context()) == {:ok, []}
     end
   end
+
+  describe "call_template/4 — caller-supplied seed" do
+    test "a Head variable bound only via the seed (no Body literal touches it) still concludes" do
+      head = %FactPattern{predicate: rel("greeted"), args: [%Var{name: "X"}, RDF.literal("hi")]}
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: [%Var{name: "X"}],
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: []
+      }
+
+      seed = %{%Var{name: "X"} => t("alice")}
+
+      assert ExecuteInterpreter.call_template(rule, seed, RDF.Graph.new(), context()) ==
+               {:ok, [{t("alice"), rel("greeted"), RDF.literal("hi")}]}
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Ships `Riptide.Derivation.Discovery.find/2` — exact/keyword lookup over CatalogEntry, specificity-based tiebreaking within each tier.
- Makes `ExecuteInterpreter.call_template/4` public (pure visibility change) so a found template can be invoked against new concrete arguments.
- Closes the Sub-project 6 walking skeleton's own `{6f, 6g-i}` branch: a task repeated a third time is found via Discovery and invoked with zero LLM calls (capstone test in `discovery_test.exs`).

Implements #68. Spec: `docs/superpowers/specs/2026-08-29-phase-6g-i-exact-keyword-discovery-design.md` (PR #99).

## Test plan
- [x] `mix test` — full suite green (426 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR