### PR TITLE
Draft: Resolve: "Bitemporal fact shape"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery) — 12 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape) — 11 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -728,3 +728,34 @@ third task is found by `Discovery.find/2`'s keyword tier, and invoked directly v
 
 **Status**: Phase 6g-i shipped 2026-08-29. 12 phases remaining across the primary spine and the
 three parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6a — Bitemporal fact shape
+
+Foundation-track phase (§7 of the design spec, `depends on: nothing`), independent of every
+other Sub-project 6 phase. **Shipped 2026-08-29** — see
+`docs/superpowers/specs/2026-08-29-phase-6a-bitemporal-fact-shape-design.md`.
+
+Lets a Fact carry a ValidTime interval (RDF-star `validFrom`/`validTo` annotations, simple
+`xsd:dateTime` literal values) distinct from its TransactionTime, via the existing LDP write
+path's Turtle body (annotation-sugar syntax `s p o {| pred obj |}`) — no new write API. Two
+findings, both verified empirically rather than assumed, collapsed this phase's scope well
+below the parent spec's own framing: (1) the vendored `rdf` dependency's `RDF.Query.BGP` engine
+already treats RDF-star quoted-triple patterns as first-class, variable-bindable pattern
+elements — no duplication into a parallel plain-triple form is needed for the derivation layer
+to reason over ValidTime, contrary to the parent spec's §8.4 assumption; that duplication
+concern becomes 6c-iii-b's (much smaller than assumed) job of widening `FactPattern.args` to
+admit quoted-triple patterns, not a storage-layer mechanism. (2) The existing write/read/storage
+path — `TurtleCodec`, `RiptideWeb.LDP.ResourceController`, `Event`/`Patch`'s `%{v: 1, ...}`
+envelope, and real Ra-backed `StreamServer` persistence — already round-trips RDF-star content
+correctly with **zero** code changes beyond widening `Patch.triple`'s Dialyzer type (a
+type-only change; runtime behavior needed no fix). Also found and documented: Turtle-star's bare
+`<<s p o>> pred obj .` form only asserts the annotation triple, not the base fact — the
+annotation-sugar form `s p o {| pred obj |}` is the one this phase's spec designates as correct,
+asserting both. Full OWL-Time reified `Instant`/`Interval` individuals were considered and ruled
+out in favor of simple literal-valued annotations, since nothing implements Allen-relation
+comparison yet; the Allen-relation vocabulary subset (`before`/`after`/`meets`/`overlaps`/
+`during`/`starts`/`finishes`/`equals`) is named in the spec for a future querying phase to
+implement against, not built here.
+
+**Status**: Phase 6a shipped 2026-08-29. 11 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/rdf/patch.ex
+++ b/lib/riptide/rdf/patch.ex
@@ -7,7 +7,8 @@ defmodule Riptide.RDF.Patch do
   @enforce_keys [:additions, :removals]
   defstruct [:additions, :removals]
 
-  @type triple :: {RDF.IRI.t(), RDF.IRI.t(), RDF.Term.t()}
+  @type triple ::
+          {RDF.IRI.t() | RDF.Star.Triple.t(), RDF.IRI.t(), RDF.Term.t() | RDF.Star.Triple.t()}
   @type t :: %__MODULE__{additions: [triple()], removals: [triple()]}
 
   @spec apply(RDF.Graph.t(), t()) :: RDF.Graph.t()

--- a/test/riptide/rdf/patch_test.exs
+++ b/test/riptide/rdf/patch_test.exs
@@ -79,4 +79,35 @@ defmodule Riptide.RDF.PatchTest do
       end
     end
   end
+
+  describe "encode/1 and decode/1 — RDF-star (phase 6a)" do
+    test "a Patch containing a quoted-triple addition round-trips through encode/1 and decode/1, still at wire version 1" do
+      alice = RDF.iri("urn:test:alice")
+      works_at = RDF.iri("urn:riptide:relation:worksAt")
+      acme = RDF.iri("urn:test:acme")
+      valid_from = RDF.iri("urn:riptide:relation:validFrom")
+
+      base_triple = {alice, works_at, acme}
+      annotation_triple = {base_triple, valid_from, RDF.literal(~U[2026-01-01 00:00:00Z])}
+
+      patch = %Patch{additions: [base_triple, annotation_triple], removals: []}
+
+      assert Patch.encode(patch) == %{
+               v: 1,
+               additions: [base_triple, annotation_triple],
+               removals: []
+             }
+
+      assert Patch.decode(Patch.encode(patch)) == patch
+    end
+
+    test "an old-shape v1 wire map with no RDF-star anywhere still decodes via the same clause" do
+      old_wire = %{v: 1, additions: [{@alice, @name, RDF.literal("Alice")}], removals: []}
+
+      assert Patch.decode(old_wire) == %Patch{
+               additions: [{@alice, @name, RDF.literal("Alice")}],
+               removals: []
+             }
+    end
+  end
 end

--- a/test/riptide/stream/stream_server_test.exs
+++ b/test/riptide/stream/stream_server_test.exs
@@ -228,4 +228,25 @@ defmodule Riptide.Stream.StreamServerTest do
       end
     end
   end
+
+  test "a Patch addition whose triple is RDF-star-annotated survives a real Ra append/read round trip",
+       %{stream_id: stream_id} do
+    alice = RDF.iri("urn:test:alice")
+    works_at = RDF.iri("urn:riptide:relation:worksAt")
+    acme = RDF.iri("urn:test:acme")
+    valid_from = RDF.iri("urn:riptide:relation:validFrom")
+
+    base_triple = {alice, works_at, acme}
+    annotation_triple = {base_triple, valid_from, RDF.literal(~U[2026-01-01 00:00:00Z])}
+
+    patch = %Riptide.RDF.Patch{additions: [base_triple, annotation_triple], removals: []}
+    event = Event.new(stream_id, :patch, patch)
+
+    appended = StreamServer.append(stream_id, event)
+    assert appended.sequence == 1
+
+    assert {:ok, [read_back]} = StreamServer.get_since(stream_id, 0)
+    assert read_back.payload == patch
+    assert read_back.payload.additions == [base_triple, annotation_triple]
+  end
 end

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -198,6 +198,37 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
     assert put_conn.status == 400
   end
 
+  test "PUT with a Turtle-star ValidTime annotation round-trips both the base fact and the annotation" do
+    path = unique_path()
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id_for(path)) end)
+
+    turtle = """
+    @prefix ex: <https://pod.example/> .
+    @prefix rel: <urn:riptide:relation:> .
+    ex:x ex:y "z" {| rel:validFrom "2026-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> |} .
+    """
+
+    put_conn =
+      :put
+      |> conn(path, turtle)
+      |> put_req_header("content-type", "text/turtle")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert put_conn.status == 201
+
+    get_conn = :get |> conn(path) |> RiptideWeb.Endpoint.call(@opts)
+
+    assert get_conn.status == 200
+    # The base fact stays independently present (unaffected by the
+    # annotation, matching every other un-annotated PUT/GET test in this
+    # file — proving zero behavior change for callers that never set a
+    # ValidTime) ...
+    assert get_conn.resp_body =~ "ex:y \"z\""
+    # ... and the annotation itself survived the full write/read path.
+    assert get_conn.resp_body =~ "validFrom"
+    assert get_conn.resp_body =~ "2026-01-01"
+  end
+
   test "PATCH with malformed Turtle in additions returns 400 instead of crashing" do
     path = unique_path()
     on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id_for(path)) end)


### PR DESCRIPTION
## Summary
- Lets a Fact carry a ValidTime interval (RDF-star `validFrom`/`validTo`) distinct from its TransactionTime, via the existing LDP write path's Turtle body (annotation-sugar syntax `s p o {| pred obj |}`) — no new write API.
- Only `lib/` change: widens `Riptide.RDF.Patch.triple`'s Dialyzer type to admit a quoted triple (pure type annotation, zero runtime behavior change).
- Proves, rather than assumes, that no Phase 3a envelope version bump is needed: real encode/decode round trip, a live Ra `StreamServer` append/read round trip, and an HTTP-level round trip through `RiptideWeb.LDP.ResourceController` all stay at wire version 1.

Implements #59. Spec: `docs/superpowers/specs/2026-08-29-phase-6a-bitemporal-fact-shape-design.md` (PR #101).

## Test plan
- [x] `mix test` — full suite green (430 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR