### PR TITLE
Draft: Resolve: "Supervised long-running process primitive"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape) — 11 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive) — 10 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -758,4 +758,32 @@ comparison yet; the Allen-relation vocabulary subset (`before`/`after`/`meets`/`
 implement against, not built here.
 
 **Status**: Phase 6a shipped 2026-08-29. 11 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6b-ii — Supervised long-running process primitive
+
+Foundation-track phase (§7 of the design spec, `depends on: nothing`), independent of every
+other Sub-project 6 phase. **Shipped 2026-08-29** — see
+`docs/superpowers/specs/2026-08-29-phase-6b-ii-supervised-process-design.md`.
+
+`Riptide.SupervisedProcess` — a reusable `DynamicSupervisor` + `Registry` primitive, typed for
+the revocable/restartable adaptation-safety property from session types with runtime adaptation
+(Di Giusto & Pérez, arXiv:1312.2699), that a future blob store (6j) and persistent Capability
+grant would be built from. The parent spec's own claim that `Riptide.Stream.StreamServer`'s
+supervision-tree shape was "a real, citable bridge to OTP semantics" turned out not to hold up —
+verified directly that `StreamServer` isn't a `GenServer` at all (Ra owns that process opaquely),
+and no `Supervisor`/`DynamicSupervisor`/`Registry` existed anywhere in Riptide's own code before
+this phase. Splits the adaptation-safety property into two honestly-distinct mechanisms rather
+than conflating them: voluntary restart/revoke gating (`request_restart/1`/`request_revoke/1`,
+refused via `{:error, :session_active}` when a session is active — a crash cannot be "refused,"
+by definition, so this is deliberately scoped to in-band, evaluable requests only) and
+crash-session legibility (`Riptide.SupervisedProcess.SessionTracker`, an ETS-backed detection
+mechanism — no resumption logic, just a legible trace instead of silent data loss). The
+session-active check runs inside the target process's own serialized mailbox
+(`handle_stop_if_idle/4`), closing a real race a design sketch checking from outside the process
+(`:sys.get_state/1` then a separate stop call) would have had. Restart and revoke share one
+supervisor mechanism (`:transient` restart type, differing only in exit reason — abnormal vs.
+`:normal`) rather than needing special-cased logic.
+
+**Status**: Phase 6b-ii shipped 2026-08-29. 10 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -33,6 +33,7 @@ defmodule Riptide.Application do
         Riptide.NewStreamRateLimit,
         {Plug.Cowboy, scheme: :http, plug: RiptideWeb.MetricsEndpoint, options: [port: 9090]},
         Riptide.Stream.Placement,
+        Riptide.SupervisedProcess.SessionTracker,
         {Cluster.Supervisor,
          [Application.get_env(:libcluster, :topologies, []), [name: Riptide.ClusterSupervisor]]}
       ] ++

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -34,6 +34,9 @@ defmodule Riptide.Application do
         {Plug.Cowboy, scheme: :http, plug: RiptideWeb.MetricsEndpoint, options: [port: 9090]},
         Riptide.Stream.Placement,
         Riptide.SupervisedProcess.SessionTracker,
+        {Registry, keys: :unique, name: Riptide.SupervisedProcess.Registry},
+        {DynamicSupervisor,
+         strategy: :one_for_one, name: Riptide.SupervisedProcess.DynamicSupervisor},
         {Cluster.Supervisor,
          [Application.get_env(:libcluster, :topologies, []), [name: Riptide.ClusterSupervisor]]}
       ] ++

--- a/lib/riptide/supervised_process.ex
+++ b/lib/riptide/supervised_process.ex
@@ -79,8 +79,11 @@ defmodule Riptide.SupervisedProcess do
 
   defp control(id, reason) do
     case Registry.lookup(@registry, id) do
-      [{pid, _module}] -> GenServer.call(pid, {:riptide_supervised_process, :stop_if_idle, reason})
-      [] -> {:error, :not_found}
+      [{pid, _module}] ->
+        GenServer.call(pid, {:riptide_supervised_process, :stop_if_idle, reason})
+
+      [] ->
+        {:error, :not_found}
     end
   end
 end

--- a/lib/riptide/supervised_process.ex
+++ b/lib/riptide/supervised_process.ex
@@ -39,4 +39,48 @@ defmodule Riptide.SupervisedProcess do
 
     DynamicSupervisor.start_child(@dynamic_supervisor, child_spec)
   end
+
+  @doc """
+  Requests a restart of the process registered under `id`: honored only
+  if `session_active?/1` reports the process idle, in which case it exits
+  abnormally (`:restart_requested` — not `:normal`/`:shutdown`), and
+  `:transient` brings a fresh instance back up under the same `id`
+  automatically. Refused (`{:error, :session_active}`) if a session is
+  active — the caller decides whether/when to retry; no internal queue.
+  """
+  @spec request_restart(term()) :: :ok | {:error, :session_active} | {:error, :not_found}
+  def request_restart(id), do: control(id, :restart_requested)
+
+  @doc """
+  Like `request_restart/1`, but exits `:normal` when honored — `:transient`
+  does not restart on a `:normal` exit, so the process is gone for good.
+  """
+  @spec request_revoke(term()) :: :ok | {:error, :session_active} | {:error, :not_found}
+  def request_revoke(id), do: control(id, :normal)
+
+  @doc """
+  Shared helper a consumer's own `handle_call` clause delegates to,
+  keeping the session-active check inside the target process's own
+  serialized mailbox — atomic with respect to any other message that
+  process might be handling, closing the race an outside-the-mailbox
+  check (e.g. `:sys.get_state/1` then a separate stop call) would have
+  (design spec §2).
+  """
+  @spec handle_stop_if_idle(module(), term(), term(), GenServer.from()) ::
+          {:reply, {:error, :session_active}, term()} | {:stop, term(), term()}
+  def handle_stop_if_idle(module, state, reason, from) do
+    if module.session_active?(state) do
+      {:reply, {:error, :session_active}, state}
+    else
+      GenServer.reply(from, :ok)
+      {:stop, reason, state}
+    end
+  end
+
+  defp control(id, reason) do
+    case Registry.lookup(@registry, id) do
+      [{pid, _module}] -> GenServer.call(pid, {:riptide_supervised_process, :stop_if_idle, reason})
+      [] -> {:error, :not_found}
+    end
+  end
 end

--- a/lib/riptide/supervised_process.ex
+++ b/lib/riptide/supervised_process.ex
@@ -1,0 +1,42 @@
+defmodule Riptide.SupervisedProcess do
+  @moduledoc """
+  A reusable supervised long-running process primitive, typed for the
+  revocable/restartable adaptation-safety property from session types
+  with runtime adaptation (Di Giusto & Pérez, arXiv:1312.2699). See
+  design spec
+  `docs/superpowers/specs/2026-08-29-phase-6b-ii-supervised-process-design.md`.
+
+  A consumer implements `@behaviour Riptide.SupervisedProcess` (just
+  `session_active?/1`), a normal `init/1`, and one boilerplate
+  `handle_call` clause forwarding to `handle_stop_if_idle/4` — no
+  `start_link/2` of its own; `start/3` calls `GenServer.start_link/3`
+  directly, registering the process via a 4-tuple `:via` name so a later
+  lookup also recovers which module's `session_active?/1` to call.
+  """
+
+  @callback session_active?(state :: term()) :: boolean()
+
+  @registry Riptide.SupervisedProcess.Registry
+  @dynamic_supervisor Riptide.SupervisedProcess.DynamicSupervisor
+
+  @doc """
+  Starts `module` (implementing `init/1` and this behaviour) under the
+  shared `DynamicSupervisor`, registered under `id` for later
+  `request_restart/1`/`request_revoke/1` lookups. Every managed process
+  uses `restart: :transient` uniformly (design spec §2) — restarted on
+  abnormal exit (a real crash, or `request_restart/1`), not restarted on
+  `:normal` exit (`request_revoke/1`).
+  """
+  @spec start(term(), module(), term()) :: {:ok, pid()} | {:error, term()}
+  def start(id, module, init_arg) do
+    via = {:via, Registry, {@registry, id, module}}
+
+    child_spec = %{
+      id: id,
+      start: {GenServer, :start_link, [module, init_arg, [name: via]]},
+      restart: :transient
+    }
+
+    DynamicSupervisor.start_child(@dynamic_supervisor, child_spec)
+  end
+end

--- a/lib/riptide/supervised_process/session_tracker.ex
+++ b/lib/riptide/supervised_process/session_tracker.ex
@@ -1,0 +1,48 @@
+defmodule Riptide.SupervisedProcess.SessionTracker do
+  @moduledoc """
+  Owns the ETS table `Riptide.SupervisedProcess` uses for crash-session
+  legibility — a complement to (not the same guarantee as) the voluntary
+  restart/revoke gating `Riptide.SupervisedProcess.handle_stop_if_idle/4`
+  implements: detects that a process was mid-session when it died, with
+  no resumption logic. See design spec
+  `docs/superpowers/specs/2026-08-29-phase-6b-ii-supervised-process-design.md`
+  §2, §4. A tiny GenServer only to own the table's lifetime, mirroring
+  `Riptide.Stream.Placement`'s own established pattern — every read/write
+  operates directly on the table, never routing through this process.
+  """
+
+  use GenServer
+
+  @table :riptide_supervised_process_sessions
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(:ok) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    {:ok, %{}}
+  end
+
+  @spec mark_session_active(term()) :: :ok
+  def mark_session_active(id) do
+    :ets.insert(@table, {id, :active})
+    :ok
+  end
+
+  @spec mark_session_idle(term()) :: :ok
+  def mark_session_idle(id) do
+    :ets.insert(@table, {id, :idle})
+    :ok
+  end
+
+  @spec was_active_at_crash?(term()) :: boolean()
+  def was_active_at_crash?(id) do
+    case :ets.lookup(@table, id) do
+      [{^id, :active}] -> true
+      _ -> false
+    end
+  end
+end

--- a/test/riptide/supervised_process/session_tracker_test.exs
+++ b/test/riptide/supervised_process/session_tracker_test.exs
@@ -1,0 +1,23 @@
+defmodule Riptide.SupervisedProcess.SessionTrackerTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.SupervisedProcess.SessionTracker
+
+  test "an id with no recorded session reports not active at crash" do
+    id = "session-#{System.unique_integer([:positive])}"
+    refute SessionTracker.was_active_at_crash?(id)
+  end
+
+  test "mark_session_active/1 then was_active_at_crash?/1 reports true" do
+    id = "session-#{System.unique_integer([:positive])}"
+    :ok = SessionTracker.mark_session_active(id)
+    assert SessionTracker.was_active_at_crash?(id)
+  end
+
+  test "mark_session_idle/1 after mark_session_active/1 reports false" do
+    id = "session-#{System.unique_integer([:positive])}"
+    :ok = SessionTracker.mark_session_active(id)
+    :ok = SessionTracker.mark_session_idle(id)
+    refute SessionTracker.was_active_at_crash?(id)
+  end
+end

--- a/test/riptide/supervised_process_test.exs
+++ b/test/riptide/supervised_process_test.exs
@@ -4,6 +4,7 @@ defmodule Riptide.SupervisedProcessTest do
   alias Riptide.SupervisedProcess
 
   defmodule Fixture do
+    @behaviour Riptide.SupervisedProcess
     use GenServer
 
     @impl GenServer
@@ -12,6 +13,13 @@ defmodule Riptide.SupervisedProcessTest do
     @impl GenServer
     def handle_call(:set_active, _from, state), do: {:reply, :ok, %{state | active: true}}
     def handle_call(:set_idle, _from, state), do: {:reply, :ok, %{state | active: false}}
+
+    def handle_call({:riptide_supervised_process, :stop_if_idle, reason}, from, state) do
+      Riptide.SupervisedProcess.handle_stop_if_idle(__MODULE__, state, reason, from)
+    end
+
+    @impl Riptide.SupervisedProcess
+    def session_active?(state), do: state.active
   end
 
   defp unique_id, do: "fixture-#{System.unique_integer([:positive])}"
@@ -35,6 +43,41 @@ defmodule Riptide.SupervisedProcessTest do
       assert pid_a != pid_b
       assert [{^pid_a, Fixture}] = Registry.lookup(Riptide.SupervisedProcess.Registry, id_a)
       assert [{^pid_b, Fixture}] = Registry.lookup(Riptide.SupervisedProcess.Registry, id_b)
+    end
+  end
+
+  describe "request_restart/1 — idle process" do
+    test "succeeds, and a fresh process comes back under the same id via :transient" do
+      id = unique_id()
+      {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+
+      assert :ok = SupervisedProcess.request_restart(id)
+
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1000
+
+      # :transient restarts on this abnormal exit reason, using the same
+      # child spec (same module/init_arg) — a fresh process re-registers
+      # under the same id without any new start/3 call.
+      wait_until(fn ->
+        case Registry.lookup(Riptide.SupervisedProcess.Registry, id) do
+          [{new_pid, Fixture}] -> new_pid != pid
+          [] -> false
+        end
+      end)
+    end
+  end
+
+  defp wait_until(fun, attempts \\ 50) do
+    if fun.() do
+      :ok
+    else
+      if attempts <= 1 do
+        flunk("condition never became true")
+      else
+        Process.sleep(10)
+        wait_until(fun, attempts - 1)
+      end
     end
   end
 end

--- a/test/riptide/supervised_process_test.exs
+++ b/test/riptide/supervised_process_test.exs
@@ -87,6 +87,38 @@ defmodule Riptide.SupervisedProcessTest do
     end
   end
 
+  describe "request_revoke/1 — idle process" do
+    test "succeeds, and the process does not come back (:transient doesn't restart on :normal)" do
+      id = unique_id()
+      {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+
+      assert :ok = SupervisedProcess.request_revoke(id)
+
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 1000
+
+      wait_until(fn -> Registry.lookup(Riptide.SupervisedProcess.Registry, id) == [] end)
+    end
+  end
+
+  describe "request_revoke/1 — active session" do
+    test "is refused, and the original process is confirmed still running unchanged" do
+      id = unique_id()
+      {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+      :ok = GenServer.call(pid, :set_active)
+
+      assert {:error, :session_active} = SupervisedProcess.request_revoke(id)
+
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "request_revoke/1 — unregistered id" do
+    test "returns {:error, :not_found}" do
+      assert {:error, :not_found} = SupervisedProcess.request_revoke(unique_id())
+    end
+  end
+
   defp wait_until(fun, attempts \\ 50) do
     if fun.() do
       :ok

--- a/test/riptide/supervised_process_test.exs
+++ b/test/riptide/supervised_process_test.exs
@@ -1,0 +1,40 @@
+defmodule Riptide.SupervisedProcessTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.SupervisedProcess
+
+  defmodule Fixture do
+    use GenServer
+
+    @impl GenServer
+    def init({id, active}), do: {:ok, %{id: id, active: active}}
+
+    @impl GenServer
+    def handle_call(:set_active, _from, state), do: {:reply, :ok, %{state | active: true}}
+    def handle_call(:set_idle, _from, state), do: {:reply, :ok, %{state | active: false}}
+  end
+
+  defp unique_id, do: "fixture-#{System.unique_integer([:positive])}"
+
+  describe "start/3" do
+    test "starts the process and registers it under id for lookup" do
+      id = unique_id()
+
+      assert {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+      assert Process.alive?(pid)
+      assert [{^pid, Fixture}] = Registry.lookup(Riptide.SupervisedProcess.Registry, id)
+    end
+
+    test "two different ids each get their own independently-addressable process" do
+      id_a = unique_id()
+      id_b = unique_id()
+
+      {:ok, pid_a} = SupervisedProcess.start(id_a, Fixture, {id_a, false})
+      {:ok, pid_b} = SupervisedProcess.start(id_b, Fixture, {id_b, false})
+
+      assert pid_a != pid_b
+      assert [{^pid_a, Fixture}] = Registry.lookup(Riptide.SupervisedProcess.Registry, id_a)
+      assert [{^pid_b, Fixture}] = Registry.lookup(Riptide.SupervisedProcess.Registry, id_b)
+    end
+  end
+end

--- a/test/riptide/supervised_process_test.exs
+++ b/test/riptide/supervised_process_test.exs
@@ -68,6 +68,25 @@ defmodule Riptide.SupervisedProcessTest do
     end
   end
 
+  describe "request_restart/1 — active session" do
+    test "is refused, and the original process is confirmed still running unchanged" do
+      id = unique_id()
+      {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+      :ok = GenServer.call(pid, :set_active)
+
+      assert {:error, :session_active} = SupervisedProcess.request_restart(id)
+
+      assert Process.alive?(pid)
+      assert [{^pid, Fixture}] = Registry.lookup(Riptide.SupervisedProcess.Registry, id)
+    end
+  end
+
+  describe "request_restart/1 — unregistered id" do
+    test "returns {:error, :not_found}" do
+      assert {:error, :not_found} = SupervisedProcess.request_restart(unique_id())
+    end
+  end
+
   defp wait_until(fun, attempts \\ 50) do
     if fun.() do
       :ok

--- a/test/riptide/supervised_process_test.exs
+++ b/test/riptide/supervised_process_test.exs
@@ -2,6 +2,7 @@ defmodule Riptide.SupervisedProcessTest do
   use ExUnit.Case, async: false
 
   alias Riptide.SupervisedProcess
+  alias Riptide.SupervisedProcess.SessionTracker
 
   defmodule Fixture do
     @behaviour Riptide.SupervisedProcess
@@ -19,12 +20,12 @@ defmodule Riptide.SupervisedProcessTest do
     end
 
     def handle_call(:mark_active, _from, state) do
-      Riptide.SupervisedProcess.SessionTracker.mark_session_active(state.id)
+      SessionTracker.mark_session_active(state.id)
       {:reply, :ok, state}
     end
 
     def handle_call(:mark_idle, _from, state) do
-      Riptide.SupervisedProcess.SessionTracker.mark_session_idle(state.id)
+      SessionTracker.mark_session_idle(state.id)
       {:reply, :ok, state}
     end
 
@@ -138,7 +139,7 @@ defmodule Riptide.SupervisedProcessTest do
       Process.exit(pid, :kill)
       refute Process.alive?(pid)
 
-      assert Riptide.SupervisedProcess.SessionTracker.was_active_at_crash?(id)
+      assert SessionTracker.was_active_at_crash?(id)
     end
 
     test "a process that marks itself idle before exiting normally reports no trace" do
@@ -150,7 +151,7 @@ defmodule Riptide.SupervisedProcessTest do
       Process.exit(pid, :kill)
       refute Process.alive?(pid)
 
-      refute Riptide.SupervisedProcess.SessionTracker.was_active_at_crash?(id)
+      refute SessionTracker.was_active_at_crash?(id)
     end
   end
 

--- a/test/riptide/supervised_process_test.exs
+++ b/test/riptide/supervised_process_test.exs
@@ -18,6 +18,16 @@ defmodule Riptide.SupervisedProcessTest do
       Riptide.SupervisedProcess.handle_stop_if_idle(__MODULE__, state, reason, from)
     end
 
+    def handle_call(:mark_active, _from, state) do
+      Riptide.SupervisedProcess.SessionTracker.mark_session_active(state.id)
+      {:reply, :ok, state}
+    end
+
+    def handle_call(:mark_idle, _from, state) do
+      Riptide.SupervisedProcess.SessionTracker.mark_session_idle(state.id)
+      {:reply, :ok, state}
+    end
+
     @impl Riptide.SupervisedProcess
     def session_active?(state), do: state.active
   end
@@ -116,6 +126,31 @@ defmodule Riptide.SupervisedProcessTest do
   describe "request_revoke/1 — unregistered id" do
     test "returns {:error, :not_found}" do
       assert {:error, :not_found} = SupervisedProcess.request_revoke(unique_id())
+    end
+  end
+
+  describe "crash-session legibility" do
+    test "a process killed uncleanly while marked active leaves a detectable trace" do
+      id = unique_id()
+      {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+      :ok = GenServer.call(pid, :mark_active)
+
+      Process.exit(pid, :kill)
+      refute Process.alive?(pid)
+
+      assert Riptide.SupervisedProcess.SessionTracker.was_active_at_crash?(id)
+    end
+
+    test "a process that marks itself idle before exiting normally reports no trace" do
+      id = unique_id()
+      {:ok, pid} = SupervisedProcess.start(id, Fixture, {id, false})
+      :ok = GenServer.call(pid, :mark_active)
+      :ok = GenServer.call(pid, :mark_idle)
+
+      Process.exit(pid, :kill)
+      refute Process.alive?(pid)
+
+      refute Riptide.SupervisedProcess.SessionTracker.was_active_at_crash?(id)
     end
   end
 


### PR DESCRIPTION
## Summary
- Ships `Riptide.SupervisedProcess` — a reusable `DynamicSupervisor` + `Registry` primitive, typed for the revocable/restartable adaptation-safety property from session types with runtime adaptation (Di Giusto & Pérez), that a future blob store (6j) and persistent Capability grant would be built from.
- Splits the adaptation-safety property into two honestly-distinct mechanisms: voluntary restart/revoke gating (`request_restart/1`/`request_revoke/1`, refused via `{:error, :session_active}` when a session is active, race-free by construction — the check runs inside the target's own serialized mailbox) and crash-session legibility (`Riptide.SupervisedProcess.SessionTracker`, an ETS-backed detection mechanism, no resumption logic).
- Restart and revoke share one supervisor mechanism (`:transient` restart type, differing only in exit reason) rather than needing special-cased logic.

Implements #74. Spec: `docs/superpowers/specs/2026-08-29-phase-6b-ii-supervised-process-design.md` (PR #103).

## Test plan
- [x] `mix test` — full suite green (443 tests; the one intermittent failure observed across reruns is the pre-existing, documented placement-cluster node-identity-bootstrap flake, PROGRESS.md §3c-ii — confirmed via multiple clean reruns of identical code)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR