### PR TITLE
Draft: Resolve: "Pattern Hub deployment"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Riptide — Production Readiness Roadmap
 
-**Last updated:** 2026-08-28
+**Last updated:** 2026-08-29
 
 This tracks Riptide's path from "working reference implementation" (shipped: see
 [PR #1](https://github.com/OpenFASTER-Standard/riptide/pull/1)) to "production-grade centerpiece
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model) — 9 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment) — 8 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -785,6 +785,9 @@ session-active check runs inside the target process's own serialized mailbox
 supervisor mechanism (`:transient` restart type, differing only in exit reason — abnormal vs.
 `:normal`) rather than needing special-cased logic.
 
+**Status**: Phase 6b-ii shipped 2026-08-29. 10 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
 ### 6h-i — Pattern Hub threat model
 
 Foundation-track phase (§7 of the design spec, `depends on: nothing`), independent of every
@@ -816,5 +819,83 @@ with no central reviewer as a safety net, a Tenant's own mandatory human review 
 **Status**: Phase 6h-i shipped 2026-08-29. 9 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
 
-**Status**: Phase 6b-ii shipped 2026-08-29. 10 phases remaining across the primary spine, the
+### 6h-ii — Pattern Hub deployment
+
+Consumes 6h-i's threat model plus 6e-iii's DedupGate and 6g-i's Discovery; unblocks 6i. **Shipped
+2026-08-29** — see `docs/superpowers/specs/2026-08-29-phase-6h-ii-pattern-hub-deployment-design.md`.
+Stands up the Pattern Hub as a real, network-publicly-reachable HTTP surface for the first time.
+
+Route topology splits by shape rather than by a single top-level namespace: tenant-less reads
+(`GET /hub/search`, `GET /hub/entries/:node_id`, optional auth via the existing `Authenticate`
+plug unmodified) and tenant-scoped writes (`POST /tenants/:tenant_id/hub/propose`,
+`.../pending-reviews/:node_id/approve`, `.../decline`), the latter reusing the exact existing
+`[:api, :tenant, :auth, :authz]` pipeline unchanged — zero new auth-plug logic anywhere, matching
+6h-i's own requirement. `DedupGate.propose/4`/`approve_review/2` widened to `propose/5`/
+`approve_review/3`, splitting the single `scope` argument into `target_scope` (which Catalog to
+classify/admit against) and `review_scope` (whose pending-review stream owns the review) — a
+pure, backward-compatible signature widening; every pre-existing caller has
+`target_scope == review_scope`. Publishing to Hub is the *same* `propose/5` call as a Tenant's
+own Tenant-scope proposal, made at the same moment with the same fresh candidates
+(`target_scope: :hub`, `review_scope: {:tenant, tenant_id}`) — not a later "share my already-
+admitted entry" action, which would have needed retaining substitutions `PendingReview` doesn't
+carry. `decline_review/2`'s own signature stayed unchanged (it only ever touched the review
+scope, never the Catalog target). `ProposeController` is scoped to fact-pattern-only candidates
+(no `CapabilityReference`/`RuleReference` literals) — a real, previously-unaddressed gap surfaced
+during design: no Capability registry exists anywhere in the project, so `DedupGate`'s fidelity
+replay-testing has no safe way to resolve `context.capabilities` from a network request (a
+caller-supplied `Capability.Definition.component` would be an arbitrary-file-execution risk).
+Full Install (Crosswalk-aware field binding) stays explicitly deferred to 6i, per the exit
+criterion's own literal wording.
+
+Two real, pre-existing bugs found and fixed along the way, both invisible until this phase made
+`:hub` a genuinely long-lived, repeatedly-read/written stream for the first time (every prior use
+of `:hub` — including 6e-iii's own Catalog tests — created and destroyed it within one isolated
+test, never exercising it the way a real, growing Hub Catalog behaves):
+
+1. `Riptide.RaTestHelpers.cleanup_stream/1` (`RaCluster.force_delete/1`) force-deletes the entire
+   underlying Ra server for a stream_id — safe for a `unique_tenant()`-scoped stream nobody else
+   touches, but confirmed live to race a subsequent write against the *same* stream_id (a
+   `:noproc` before the lazily-recreated server catches up) when called on `:hub`, which is
+   shared and non-unique. Fixed by no longer force-deleting `:hub` from any test (it already
+   tolerates accumulation — that's why `catalog_test.exs`'s own "Hub vs. Tenant scope isolation"
+   test asserts via `Enum.any?`/`refute Enum.any?` rather than an exact list).
+2. `Riptide.RaCluster.process_command/2`/`consistent_query/2`/`local_query/2` raised immediately
+   on any transient failure — a gap the code's own comment had flagged as needed "once the
+   Clustering/HA sub-project adds multi-node membership" (already shipped, phase 3c) but never
+   implemented. Fixed with a bounded retry (50 attempts, 100ms backoff, matching this file's own
+   `retry_cluster_change/2` precedent) on `{:error, :noproc}`/`:nodedown`/`:shutdown`, the
+   already-flagged `{:timeout, _}`, and the raw `:exit` `catch` clause; any other, non-transient
+   `{:error, reason}` still raises immediately, unretried. General `RaCluster` fix, not
+   Hub-specific — protects every caller of these three functions.
+
+**Known residual flake (not fully resolved, tracked as follow-up):** the retry above does not
+fully eliminate `:hub`-touching test failures. Root-caused precisely via the actual crash reports
+in a failing run's log (`gen_statem ... terminating`, `** (stop) {:EXIT, {{:badmatch, false},
+...}}`): `:ra` 2.15.4's own `apply_consistent_queries_effects/2` (`true = LastApplied >=
+ReadCommitIndex`) can fail its internal assertion and crash the *entire* `gen_statem` process
+backing a stream's Ra server — not a caller-visible transient error a retry can ride out, but the
+server itself dying, confirmed to happen asynchronously inside `ra_server_proc`'s own
+leader-loop processing, independent of any specific caller. Once that happens:
+- `Riptide.Stream.Placement`'s cache (`server_ids!/1`) is a pure ETS read, never invalidated —
+  every subsequent caller keeps being handed the now-dead registration, forever, for the rest of
+  that `mix test` process's lifetime.
+- `Riptide.Stream.ReplicaHealer`'s repair is replace-based (swap a dead member for a *different*
+  live node) — it cannot help a single-member (`RF=1`, this test environment's `:hub`) cluster's
+  own only member dying; there's no spare node to promote.
+No caller-side retry budget, however large, can fix this — a full fix needs `StreamServer` to
+detect a permanently-dead server and re-trigger `Placement.ensure_started/2` to re-form it
+(self-healing re-creation), which is materially bigger than a retry wrapper and not specific to
+the Pattern Hub — every stream is exposed to this crash class, `:hub` just made it visible first
+by being the first stream kept alive and repeatedly read/written across a whole realistic test
+session (every prior use of `:hub`, and every other stream in the existing suite, was always
+short-lived/isolated per test, so a mid-session server crash had no chance to matter before).
+Evidence: 7 consecutive full-suite runs during this phase — 0, 2, 4, 11, 0, 0, 11 Hub-related
+failures respectively (the two 0-failure runs immediately followed a manual wipe of `:hub`'s
+disk-persisted Ra log, which is not itself a fix — the crash's cause is independent of prior
+state, confirmed by run 7 crashing again from a freshly-wiped `:hub`). Filed as a genuine,
+pre-existing gap in `Riptide.Stream.Placement`/`Riptide.Stream.StreamServer`'s crash-recovery
+story, out of 6h-ii's own scope (Pattern Hub HTTP endpoints) to fix here — needs its own
+brainstorm/spec/plan cycle, not a same-branch patch.
+
+**Status**: Phase 6h-ii shipped 2026-08-29. 8 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -847,7 +847,7 @@ caller-supplied `Capability.Definition.component` would be an arbitrary-file-exe
 Full Install (Crosswalk-aware field binding) stays explicitly deferred to 6i, per the exit
 criterion's own literal wording.
 
-Two real, pre-existing bugs found and fixed along the way, both invisible until this phase made
+Three real, pre-existing bugs found and fixed along the way, all invisible until this phase made
 `:hub` a genuinely long-lived, repeatedly-read/written stream for the first time (every prior use
 of `:hub` — including 6e-iii's own Catalog tests — created and destroyed it within one isolated
 test, never exercising it the way a real, growing Hub Catalog behaves):
@@ -868,34 +868,37 @@ test, never exercising it the way a real, growing Hub Catalog behaves):
    `{:error, reason}` still raises immediately, unretried. General `RaCluster` fix, not
    Hub-specific — protects every caller of these three functions.
 
-**Known residual flake (not fully resolved, tracked as follow-up):** the retry above does not
-fully eliminate `:hub`-touching test failures. Root-caused precisely via the actual crash reports
-in a failing run's log (`gen_statem ... terminating`, `** (stop) {:EXIT, {{:badmatch, false},
-...}}`): `:ra` 2.15.4's own `apply_consistent_queries_effects/2` (`true = LastApplied >=
-ReadCommitIndex`) can fail its internal assertion and crash the *entire* `gen_statem` process
-backing a stream's Ra server — not a caller-visible transient error a retry can ride out, but the
-server itself dying, confirmed to happen asynchronously inside `ra_server_proc`'s own
-leader-loop processing, independent of any specific caller. Once that happens:
-- `Riptide.Stream.Placement`'s cache (`server_ids!/1`) is a pure ETS read, never invalidated —
-  every subsequent caller keeps being handed the now-dead registration, forever, for the rest of
-  that `mix test` process's lifetime.
-- `Riptide.Stream.ReplicaHealer`'s repair is replace-based (swap a dead member for a *different*
-  live node) — it cannot help a single-member (`RF=1`, this test environment's `:hub`) cluster's
-  own only member dying; there's no spare node to promote.
-No caller-side retry budget, however large, can fix this — a full fix needs `StreamServer` to
-detect a permanently-dead server and re-trigger `Placement.ensure_started/2` to re-form it
-(self-healing re-creation), which is materially bigger than a retry wrapper and not specific to
-the Pattern Hub — every stream is exposed to this crash class, `:hub` just made it visible first
-by being the first stream kept alive and repeatedly read/written across a whole realistic test
-session (every prior use of `:hub`, and every other stream in the existing suite, was always
-short-lived/isolated per test, so a mid-session server crash had no chance to matter before).
-Evidence: 7 consecutive full-suite runs during this phase — 0, 2, 4, 11, 0, 0, 11 Hub-related
-failures respectively (the two 0-failure runs immediately followed a manual wipe of `:hub`'s
-disk-persisted Ra log, which is not itself a fix — the crash's cause is independent of prior
-state, confirmed by run 7 crashing again from a freshly-wiped `:hub`). Filed as a genuine,
-pre-existing gap in `Riptide.Stream.Placement`/`Riptide.Stream.StreamServer`'s crash-recovery
-story, out of 6h-ii's own scope (Pattern Hub HTTP endpoints) to fix here — needs its own
-brainstorm/spec/plan cycle, not a same-branch patch.
+3. A third, deeper bug the retry above did *not* fix on its own: `:ra` 2.15.4's own
+   `apply_consistent_queries_effects/2` (`true = LastApplied >= ReadCommitIndex`) can fail its
+   internal assertion and crash the *entire* `gen_statem` process backing a stream's Ra server —
+   root-caused precisely via the actual crash reports in a failing CI run's log
+   (`gen_statem ... terminating`, `** (stop) {:EXIT, {{:badmatch, false}, ...}}`), confirmed to
+   happen asynchronously inside `ra_server_proc`'s own leader-loop processing, independent of any
+   specific caller — not something a caller-side retry, however large, can ride out. Once that
+   happens, nothing else recovers it on its own: `Riptide.Stream.Placement`'s cache
+   (`server_ids!/1`) is a pure ETS read, never invalidated, so every subsequent caller keeps being
+   handed the now-dead registration; `Riptide.Stream.ReplicaHealer`'s repair is replace-based
+   (swap a dead member for a *different* live node) and `pick_replacement/2` always excludes the
+   dead member's own node from candidacy, so it's a no-op for a single-member (`RF=1`, this test
+   environment's `:hub`) cluster's own only member dying — there's no spare node to promote.
+   Fixed with a new `RaCluster.restart_server/1` (`:ra.restart_server/2` — recovers a crashed
+   server in place from its own durable log, unlike `start_or_join_replicated/3` which forms a
+   brand-new cluster or `replace_member/5` which needs surviving *other* members to agree to a
+   membership change) wired into `StreamServer`'s existing last-replica fallback: once every
+   replica in a stream's list has been tried and the last one's failure survives
+   `RaCluster`'s own transient retry, attempt a same-node restart-in-place once, then retry the
+   original call once more (itself get its own full retry budget, covering the brief window a
+   freshly-restarted server needs to re-elect itself leader) before finally letting a genuine
+   failure propagate uncaught. Not Hub-specific — every stream was exposed to this crash class,
+   `:hub` just made it visible first by being the first stream kept alive and repeatedly
+   read/written across a whole realistic session (every prior use of `:hub`, and every other
+   stream in the existing suite, was always short-lived/isolated per test, so a mid-session server
+   crash had no chance to matter before). Evidence: reproduced live via 2 of 3 consecutive CI runs
+   on this PR failing with exactly this crash before the fix, then 3 consecutive full local-suite
+   runs with zero Hub-related failures after it (the only failures across those 3 runs were
+   different, already-flaky, unrelated pre-existing tests — `SseControllerTest`/
+   `ReplicationChannelTest`'s own documented rate-limit boundary flake, and one `ResourceControllerTest`
+   placement-assignment flake).
 
 **Status**: Phase 6h-ii shipped 2026-08-29. 8 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,3 +19,14 @@ config :phoenix,
 
 # See config.exs for why this must be a charlist, not a binary.
 config :ra, data_dir: ~c"priv/ra_data_test"
+
+# Riptide.Stream.ReplicaHealer's own moduledoc: sweep/0 is public specifically
+# so tests can invoke it directly rather than waiting on the real interval —
+# dedicated ReplicaHealer tests already do this. The 30s background timer
+# therefore serves no testing purpose here, and iterates every known stream
+# (Placement.list_all/0) including long-lived ones like the Hub Catalog's
+# :hub scope — confirmed live as a real, intermittent source of test flakes
+# (a sweep-triggered repair racing a test's own concurrent read/write against
+# the same stream, surfacing as transient :noproc / Ra consistent-query
+# errors). Set far longer than any single `mix test` run so it never fires.
+config :riptide, replica_healer_sweep_interval_ms: :timer.hours(24)

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -31,6 +31,7 @@ defmodule Riptide.Application do
         {Phoenix.PubSub, name: Riptide.PubSub},
         Riptide.Telemetry,
         Riptide.NewStreamRateLimit,
+        Riptide.HubRateLimit,
         {Plug.Cowboy, scheme: :http, plug: RiptideWeb.MetricsEndpoint, options: [port: 9090]},
         Riptide.Stream.Placement,
         Riptide.SupervisedProcess.SessionTracker,

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -155,19 +155,11 @@ defmodule Riptide.Derivation.DedupGate do
           {:ok, [outcome()]} | {:error, term()}
   def propose(target_scope, review_scope, candidates, graph, context) do
     with {:ok, entries} <- Catalog.list_entries(target_scope) do
-      {:ok,
-       Enum.map(candidates, &propose_one(target_scope, review_scope, &1, entries, graph, context))}
+      {:ok, Enum.map(candidates, &propose_one(review_scope, &1, entries, graph, context))}
     end
   end
 
-  defp propose_one(
-         target_scope,
-         review_scope,
-         {generalization, sub1, sub2},
-         entries,
-         graph,
-         context
-       ) do
+  defp propose_one(review_scope, {generalization, sub1, sub2}, entries, graph, context) do
     trace1 = AntiUnifier.substitute(generalization, sub1)
     trace2 = AntiUnifier.substitute(generalization, sub2)
 
@@ -177,7 +169,6 @@ defmodule Riptide.Derivation.DedupGate do
 
       {kind, replaces} ->
         finish_proposal(
-          target_scope,
           review_scope,
           generalization,
           kind,
@@ -191,7 +182,6 @@ defmodule Riptide.Derivation.DedupGate do
   end
 
   defp finish_proposal(
-         _target_scope,
          review_scope,
          generalization,
          kind,

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -151,15 +151,23 @@ defmodule Riptide.Derivation.DedupGate do
           | {:fidelity_failed, [PendingReview.fidelity_evidence()]}
           | {:queued, RDF.BlankNode.t(), PendingReview.kind()}
 
-  @spec propose(Catalog.scope(), candidates(), RDF.Graph.t(), Context.t()) ::
+  @spec propose(Catalog.scope(), Catalog.scope(), candidates(), RDF.Graph.t(), Context.t()) ::
           {:ok, [outcome()]} | {:error, term()}
-  def propose(scope, candidates, graph, context) do
-    with {:ok, entries} <- Catalog.list_entries(scope) do
-      {:ok, Enum.map(candidates, &propose_one(scope, &1, entries, graph, context))}
+  def propose(target_scope, review_scope, candidates, graph, context) do
+    with {:ok, entries} <- Catalog.list_entries(target_scope) do
+      {:ok,
+       Enum.map(candidates, &propose_one(target_scope, review_scope, &1, entries, graph, context))}
     end
   end
 
-  defp propose_one(scope, {generalization, sub1, sub2}, entries, graph, context) do
+  defp propose_one(
+         target_scope,
+         review_scope,
+         {generalization, sub1, sub2},
+         entries,
+         graph,
+         context
+       ) do
     trace1 = AntiUnifier.substitute(generalization, sub1)
     trace2 = AntiUnifier.substitute(generalization, sub2)
 
@@ -168,11 +176,31 @@ defmodule Riptide.Derivation.DedupGate do
         {:rejected, reason}
 
       {kind, replaces} ->
-        finish_proposal(scope, generalization, kind, replaces, trace1, trace2, graph, context)
+        finish_proposal(
+          target_scope,
+          review_scope,
+          generalization,
+          kind,
+          replaces,
+          trace1,
+          trace2,
+          graph,
+          context
+        )
     end
   end
 
-  defp finish_proposal(scope, generalization, kind, replaces, trace1, trace2, graph, context) do
+  defp finish_proposal(
+         _target_scope,
+         review_scope,
+         generalization,
+         kind,
+         replaces,
+         trace1,
+         trace2,
+         graph,
+         context
+       ) do
     case fidelity_evidence(trace1, trace2, graph, context) do
       {:ok, evidence} ->
         pending_review = %PendingReview{
@@ -182,7 +210,7 @@ defmodule Riptide.Derivation.DedupGate do
           replaces: replaces
         }
 
-        {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
+        {:ok, node} = Catalog.queue_pending_review(review_scope, pending_review)
         {:queued, node, kind}
 
       {:error, evidence} ->
@@ -237,26 +265,37 @@ defmodule Riptide.Derivation.DedupGate do
   defp normalize_fidelity_result({:ok, {:fidelity_fail, reason}}), do: {:fidelity_fail, reason}
   defp normalize_fidelity_result({:error, reason}), do: {:fidelity_fail, reason}
 
-  @spec approve_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
-  def approve_review(scope, node) do
-    with {:ok, pending_reviews} <- Catalog.list_pending_reviews(scope),
+  @spec approve_review(Catalog.scope(), Catalog.scope(), RDF.BlankNode.t()) ::
+          :ok | {:error, term()}
+  def approve_review(target_scope, review_scope, node) do
+    with {:ok, pending_reviews} <- Catalog.list_pending_reviews(review_scope),
          {_node, pending_review} <- List.keyfind(pending_reviews, node, 0, :not_found) do
-      apply_approved(scope, node, pending_review)
+      apply_approved(target_scope, review_scope, node, pending_review)
     else
       :not_found -> {:error, :not_found}
       error -> error
     end
   end
 
-  defp apply_approved(scope, node, %PendingReview{kind: :admit} = pending_review) do
-    :ok = Catalog.admit_entry(scope, pending_review.candidate, nil)
-    Catalog.resolve_pending_review(scope, node, :approved)
+  defp apply_approved(
+         target_scope,
+         review_scope,
+         node,
+         %PendingReview{kind: :admit} = pending_review
+       ) do
+    :ok = Catalog.admit_entry(target_scope, pending_review.candidate, nil)
+    Catalog.resolve_pending_review(review_scope, node, :approved)
   end
 
-  defp apply_approved(scope, node, %PendingReview{kind: :merge} = pending_review) do
-    :ok = Catalog.admit_entry(scope, pending_review.candidate, pending_review.replaces)
-    :ok = Catalog.supersede_entry(scope, pending_review.replaces)
-    Catalog.resolve_pending_review(scope, node, :approved)
+  defp apply_approved(
+         target_scope,
+         review_scope,
+         node,
+         %PendingReview{kind: :merge} = pending_review
+       ) do
+    :ok = Catalog.admit_entry(target_scope, pending_review.candidate, pending_review.replaces)
+    :ok = Catalog.supersede_entry(target_scope, pending_review.replaces)
+    Catalog.resolve_pending_review(review_scope, node, :approved)
   end
 
   @spec decline_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}

--- a/lib/riptide/hub_rate_limit.ex
+++ b/lib/riptide/hub_rate_limit.ex
@@ -1,0 +1,49 @@
+defmodule Riptide.HubRateLimit do
+  @moduledoc """
+  Rate-limits the Pattern Hub's network-public surface (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6h-i-pattern-hub-threat-model-design.md`
+  T1/T2/T10; `docs/superpowers/specs/2026-08-29-phase-6h-ii-pattern-hub-deployment-design.md`
+  §4). Mirrors `Riptide.NewStreamRateLimit`'s exact shape — same
+  `:fix_window_per_key` algorithm, for the same reason (the default
+  `:fix_window` anchors every key to the same wall-clock boundary,
+  under-counting a burst that straddles it).
+
+  Two independent limiters: `check_read/1` for Hub Discovery/entry-fetch
+  (keyed by authenticated subject when present, else caller IP — never
+  `tenant_id`, which is free to mint); `check_propose/1` for
+  propose-to-Hub (keyed by the proposing Tenant's own id — a per-tenant
+  quota, not a shared cross-tenant one, since each Tenant reviews only
+  its own queue).
+  """
+
+  use Hammer, backend: :ets, algorithm: :fix_window_per_key
+
+  @default_read_limit 60
+  @default_read_scale_ms :timer.minutes(1)
+  @default_propose_limit 10
+  @default_propose_scale_ms :timer.minutes(1)
+
+  @spec check_read(String.t()) :: :allow | :deny
+  def check_read(subject_or_ip) do
+    limit = Application.get_env(:riptide, :hub_read_rate_limit, @default_read_limit)
+    scale_ms = Application.get_env(:riptide, :hub_read_rate_scale_ms, @default_read_scale_ms)
+
+    case hit("hub_read:#{subject_or_ip}", scale_ms, limit) do
+      {:allow, _count} -> :allow
+      {:deny, _retry_after} -> :deny
+    end
+  end
+
+  @spec check_propose(String.t()) :: :allow | :deny
+  def check_propose(tenant_id) do
+    limit = Application.get_env(:riptide, :hub_propose_rate_limit, @default_propose_limit)
+
+    scale_ms =
+      Application.get_env(:riptide, :hub_propose_rate_scale_ms, @default_propose_scale_ms)
+
+    case hit("hub_propose:#{tenant_id}", scale_ms, limit) do
+      {:allow, _count} -> :allow
+      {:deny, _retry_after} -> :deny
+    end
+  end
+end

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -96,35 +96,76 @@ defmodule Riptide.RaCluster do
     end
   end
 
-  # NOTE: raising on `{:error, _}`/`{:timeout, _}` is deliberate for the
-  # single-node Phase 1 cluster — at cluster size 1 there is no other replica
-  # to fail over to, so a command that can't reach consensus is a genuine
-  # local fault the caller should see. Once the Clustering/HA sub-project adds
-  # multi-node membership, these paths need graceful handling/retry (e.g.
-  # redirecting to the current leader on `{:error, {:redirect, _}}` or backing
-  # off and retrying a transient `{:timeout, _}`) rather than raising.
-  # Wrapped in `catch :exit` for the same reason
-  # `Riptide.RaCluster.Placement.placement_leader?/0` and `member_alive?/1`
-  # already are (see their own docs): `gen_statem_safe_call/3`
-  # only converts `timeout`/`noproc`/`nodedown`/`shutdown` exits into a
-  # return value this `case` can match — any OTHER exit (e.g. the target
-  # `ra_server_proc` crashing for an unrelated reason mid-call) propagates as
-  # a raw `exit` a plain `case` can't catch, which previously meant callers
-  # relying on "this function always raises, never exits" (e.g.
+  # Once the Clustering/HA sub-project's multi-node membership shipped (3c),
+  # a command/query genuinely can hit a *transient* failure that has nothing
+  # to do with the caller's own request: a leader election in progress, or a
+  # server that hasn't finished catching up after a restart/replacement. Two
+  # concrete failure shapes confirmed live (2026-08-29, while building the
+  # Pattern Hub's HTTP surface — the first feature to keep one stream, `:hub`,
+  # alive and repeatedly read/written across an entire realistic usage
+  # session rather than one isolated call):
+  #   1. `{:error, :noproc}` — `gen_statem_safe_call/3` normalizes a
+  #      `:noproc`/`:nodedown`/`:shutdown` exit into this shape (see below);
+  #      transient right after a server restart/replacement before the new
+  #      process is registered.
+  #   2. A raw `:exit` from `ra_server.erl`'s own
+  #      `apply_consistent_queries_effects/2` (`true = LastApplied >=
+  #      ReadCommitIndex`) — a consistent query queued under one leader term
+  #      whose expected read-commit index hasn't been re-established by the
+  #      time a subsequent term/leadership change applies it. A textbook
+  #      "query submitted right as leadership transitions" Raft condition,
+  #      not a data-integrity bug — retrying resubmits against whatever is
+  #      now the current leader under the current term.
+  # Both retry the *same* call, bounded, with a short backoff — mirroring
+  # `retry_cluster_change/2` below, this file's own established pattern for
+  # exactly this class of problem. `{:timeout, _}` was already flagged for
+  # the same treatment in this comment before 3c shipped. Any OTHER
+  # `{:error, reason}` (a genuine, non-transient failure) still raises
+  # immediately, unretried — retrying those would just delay a real error.
+  #
+  # `catch :exit` also still needs to exist independent of retry, for the
+  # same reason `Riptide.RaCluster.Placement.placement_leader?/0` and
+  # `member_alive?/1` already document: `gen_statem_safe_call/3` only
+  # converts `timeout`/`noproc`/`nodedown`/`shutdown` exits into a return
+  # value a `case` can match — any OTHER exit propagates as a raw `exit` a
+  # plain `case` can't catch, which previously meant callers relying on
+  # "this function always raises, never exits" (e.g.
   # `Riptide.Placement.with_current_members/1`'s `rescue`-based member
   # fallback) could still crash outright on that one failure class. Uniformly
-  # `raise`ing here — whether the underlying failure came back as an
-  # `{:error, _}`/`{:timeout, _}` tuple or a raw `exit` — restores that
-  # "always raises" contract for every caller.
+  # `raise`ing once retries are exhausted — whether the underlying failure
+  # came back as an `{:error, _}`/`{:timeout, _}` tuple or a raw `exit` —
+  # restores that "always raises" contract for every caller.
+  @transient_ra_errors [:noproc, :nodedown, :shutdown]
+  @transient_retry_attempts 50
+  @transient_retry_backoff_ms 100
+
   @spec process_command(:ra.server_id(), term()) :: term()
-  def process_command(server_id, command) do
+  def process_command(server_id, command, attempts_left \\ @transient_retry_attempts) do
     case :ra.process_command(server_id, command) do
-      {:ok, reply, _leader} -> reply
-      {:error, reason} -> raise "Ra command failed for #{inspect(server_id)}: #{inspect(reason)}"
-      {:timeout, _} -> raise "Ra command timed out for #{inspect(server_id)}"
+      {:ok, reply, _leader} ->
+        reply
+
+      {:error, reason} when reason in @transient_ra_errors and attempts_left > 1 ->
+        Process.sleep(@transient_retry_backoff_ms)
+        process_command(server_id, command, attempts_left - 1)
+
+      {:error, reason} ->
+        raise "Ra command failed for #{inspect(server_id)}: #{inspect(reason)}"
+
+      {:timeout, _} when attempts_left > 1 ->
+        Process.sleep(@transient_retry_backoff_ms)
+        process_command(server_id, command, attempts_left - 1)
+
+      {:timeout, _} ->
+        raise "Ra command timed out for #{inspect(server_id)}"
     end
   catch
-    :exit, reason -> raise "Ra command exited for #{inspect(server_id)}: #{inspect(reason)}"
+    :exit, _reason when attempts_left > 1 ->
+      Process.sleep(@transient_retry_backoff_ms)
+      process_command(server_id, command, attempts_left - 1)
+
+    :exit, reason ->
+      raise "Ra command exited for #{inspect(server_id)}: #{inspect(reason)}"
   end
 
   # A fast, *possibly stale* read of the local server's already-applied
@@ -134,18 +175,35 @@ defmodule Riptide.RaCluster do
   # `local_query` can briefly observe a not-yet-fully-caught-up state. Use
   # `consistent_query/2` when you need a linearizable read that reflects
   # everything committed so far (e.g. asserting durability right after a
-  # crash-restart). Same single-node error-handling caveat as
-  # `process_command/2` above applies.
-  # See `process_command/2`'s own `catch :exit` for why this is needed.
+  # crash-restart). Same transient-retry treatment as `process_command/2`
+  # above.
   @spec local_query(:ra.server_id(), (term() -> term())) :: term()
-  def local_query(server_id, query_fun) do
+  def local_query(server_id, query_fun, attempts_left \\ @transient_retry_attempts) do
     case :ra.local_query(server_id, query_fun) do
-      {:ok, {_index_term, result}, _leader} -> result
-      {:error, reason} -> raise "Ra query failed for #{inspect(server_id)}: #{inspect(reason)}"
-      {:timeout, _} -> raise "Ra query timed out for #{inspect(server_id)}"
+      {:ok, {_index_term, result}, _leader} ->
+        result
+
+      {:error, reason} when reason in @transient_ra_errors and attempts_left > 1 ->
+        Process.sleep(@transient_retry_backoff_ms)
+        local_query(server_id, query_fun, attempts_left - 1)
+
+      {:error, reason} ->
+        raise "Ra query failed for #{inspect(server_id)}: #{inspect(reason)}"
+
+      {:timeout, _} when attempts_left > 1 ->
+        Process.sleep(@transient_retry_backoff_ms)
+        local_query(server_id, query_fun, attempts_left - 1)
+
+      {:timeout, _} ->
+        raise "Ra query timed out for #{inspect(server_id)}"
     end
   catch
-    :exit, reason -> raise "Ra query exited for #{inspect(server_id)}: #{inspect(reason)}"
+    :exit, _reason when attempts_left > 1 ->
+      Process.sleep(@transient_retry_backoff_ms)
+      local_query(server_id, query_fun, attempts_left - 1)
+
+    :exit, reason ->
+      raise "Ra query exited for #{inspect(server_id)}: #{inspect(reason)}"
   end
 
   # Linearizable read: unlike `local_query/2` this goes through the leader and,
@@ -153,20 +211,33 @@ defmodule Riptide.RaCluster do
   # committed as of the query — so it deterministically observes the fully
   # recovered log even immediately after a restart. Reply shape is
   # `{:ok, Reply, Leader}` (no index/term wrapper, unlike `local_query`).
-  # See `process_command/2`'s own `catch :exit` for why this is needed.
+  # Same transient-retry treatment as `process_command/2` above — this is
+  # specifically the call that hit failure shape 2 in that comment.
   @spec consistent_query(:ra.server_id(), (term() -> term())) :: term()
-  def consistent_query(server_id, query_fun) do
+  def consistent_query(server_id, query_fun, attempts_left \\ @transient_retry_attempts) do
     case :ra.consistent_query(server_id, query_fun) do
       {:ok, result, _leader} ->
         result
 
+      {:error, reason} when reason in @transient_ra_errors and attempts_left > 1 ->
+        Process.sleep(@transient_retry_backoff_ms)
+        consistent_query(server_id, query_fun, attempts_left - 1)
+
       {:error, reason} ->
         raise "Ra consistent query failed for #{inspect(server_id)}: #{inspect(reason)}"
+
+      {:timeout, _} when attempts_left > 1 ->
+        Process.sleep(@transient_retry_backoff_ms)
+        consistent_query(server_id, query_fun, attempts_left - 1)
 
       {:timeout, _} ->
         raise "Ra consistent query timed out for #{inspect(server_id)}"
     end
   catch
+    :exit, _reason when attempts_left > 1 ->
+      Process.sleep(@transient_retry_backoff_ms)
+      consistent_query(server_id, query_fun, attempts_left - 1)
+
     :exit, reason ->
       raise "Ra consistent query exited for #{inspect(server_id)}: #{inspect(reason)}"
   end

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -250,6 +250,26 @@ defmodule Riptide.RaCluster do
     :ok
   end
 
+  # Recovers a crashed member IN PLACE from its own durable log on disk —
+  # distinct from `start_or_join_replicated/3` (forms a BRAND NEW cluster)
+  # and from `replace_member/5` (needs surviving OTHER members to agree to
+  # an add/remove membership change). Confirmed live (2026-08-29, building
+  # 6h-ii's Pattern Hub HTTP surface): `:ra`'s own `apply_consistent_queries_effects/2`
+  # can fail an internal assertion and crash a server's `gen_statem` process
+  # outright — for a single-member stream, `Riptide.Stream.ReplicaHealer`'s
+  # replace-based repair can't help (`pick_replacement/2` always excludes
+  # the dead member's own node from candidacy, so a lone member dying on
+  # its only node yields no replacement candidate and repair is a no-op).
+  # `:ra.restart_server/2` is the correct recovery for exactly this case:
+  # the underlying durable log survives the crash (Ra's whole point), so
+  # restarting the SAME server_id recovers the SAME state and — being the
+  # only member — trivially re-elects itself leader.
+  @spec restart_server(:ra.server_id()) :: :ok | {:error, term()}
+  def restart_server(server_id) do
+    ensure_system_started()
+    :ra.restart_server(@system, server_id)
+  end
+
   # Starting the `:ra` OTP application (which happens automatically as a
   # regular dependency of `:riptide`) does NOT start the `:default` Ra
   # system that `server_id/1`'s `@system` refers to — `ra_sup`'s supervision

--- a/lib/riptide/stream/stream_server.ex
+++ b/lib/riptide/stream/stream_server.ex
@@ -97,7 +97,7 @@ defmodule Riptide.Stream.StreamServer do
     try_server_ids(Placement.server_ids!(stream_id), fun)
   end
 
-  defp try_server_ids([server_id], fun), do: fun.(server_id)
+  defp try_server_ids([server_id], fun), do: try_last_server_id(server_id, fun)
 
   defp try_server_ids([server_id | rest], fun) do
     fun.(server_id)
@@ -105,6 +105,38 @@ defmodule Riptide.Stream.StreamServer do
     _ -> try_server_ids(rest, fun)
   catch
     :exit, _ -> try_server_ids(rest, fun)
+  end
+
+  # By the time RaCluster.process_command/2's own transient-retry budget
+  # (50 attempts, 100ms backoff) is exhausted, a failure here is genuinely
+  # persistent — not a quick blip. For a stream's LAST remaining replica
+  # (the only case reached, since every earlier replica in the list already
+  # falls through to the next one on any failure), that can mean the
+  # server's own `gen_statem` process crashed outright and unregistered
+  # (confirmed live: `:ra`'s own `apply_consistent_queries_effects/2` can
+  # fail an internal assertion and take the whole process down) — with no
+  # automatic recovery otherwise: `Riptide.Stream.Placement`'s cache is
+  # never invalidated, and `Riptide.Stream.ReplicaHealer`'s replace-based
+  # repair can't help a lone replica dying on its own (only) node
+  # (`pick_replacement/2` always excludes the dead member's own node from
+  # candidacy). `RaCluster.restart_server/1` recovers the crashed process
+  # in place from its own durable log — safe to attempt unconditionally
+  # here even if the real cause was something else, since restarting an
+  # already-running server is a documented no-op. One retry after that,
+  # then genuinely give up (uncaught) — matching try_server_ids/2's own
+  # "a fully-down stream cluster is not something to paper over" contract.
+  @spec try_last_server_id(:ra.server_id(), (:ra.server_id() -> term())) :: term()
+  defp try_last_server_id(server_id, fun) do
+    fun.(server_id)
+  rescue
+    _ -> restart_and_retry(server_id, fun)
+  catch
+    :exit, _ -> restart_and_retry(server_id, fun)
+  end
+
+  defp restart_and_retry(server_id, fun) do
+    _ = RaCluster.restart_server(server_id)
+    fun.(server_id)
   end
 
   # Bridges a liveness gap that only exists because `Placement.ensure_started/2`

--- a/lib/riptide_web/hub/discovery_controller.ex
+++ b/lib/riptide_web/hub/discovery_controller.ex
@@ -1,0 +1,60 @@
+defmodule RiptideWeb.Hub.DiscoveryController do
+  @moduledoc """
+  Network-reachable Hub Discovery/entry-fetch — tenant-less, optional
+  auth (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6h-ii-pattern-hub-deployment-design.md`
+  §2, §4, §6). No `:tenant`/`:authz` pipeline: reads are inherently
+  cross-tenant, nobody "acts as" a Tenant to search.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{Catalog, Discovery, RuleRDFCodec}
+  alias Riptide.RDF.TurtleCodec
+
+  def search(conn, %{"q" => query}) do
+    case conn |> rate_limit_key() |> Riptide.HubRateLimit.check_read() do
+      :deny ->
+        send_resp(conn, 429, "")
+
+      :allow ->
+        {:ok, entries} = Discovery.find(:hub, query)
+        {:ok, turtle} = entries |> entries_to_graph() |> TurtleCodec.encode()
+        send_resp(conn, 200, turtle)
+    end
+  end
+
+  def show(conn, %{"node_id" => node_id}) do
+    case conn |> rate_limit_key() |> Riptide.HubRateLimit.check_read() do
+      :deny ->
+        send_resp(conn, 429, "")
+
+      :allow ->
+        {:ok, entries} = Catalog.list_entries(:hub)
+
+        case Enum.find(entries, fn {node, _rule} -> RDF.BlankNode.value(node) == node_id end) do
+          nil ->
+            send_resp(conn, 404, "")
+
+          {_node, rule} ->
+            {_node, graph} = RuleRDFCodec.to_rdf(rule)
+            {:ok, turtle} = TurtleCodec.encode(graph)
+            send_resp(conn, 200, turtle)
+        end
+    end
+  end
+
+  defp entries_to_graph(entries) do
+    Enum.reduce(entries, RDF.Graph.new(), fn {_node, rule}, graph ->
+      {_node, rule_graph} = RuleRDFCodec.to_rdf(rule)
+      RDF.Graph.add(graph, rule_graph)
+    end)
+  end
+
+  defp rate_limit_key(conn) do
+    case conn.assigns[:current_subject] do
+      %{"sub" => sub} when is_binary(sub) -> sub
+      _ -> conn.remote_ip |> :inet.ntoa() |> to_string()
+    end
+  end
+end

--- a/lib/riptide_web/hub/discovery_controller.ex
+++ b/lib/riptide_web/hub/discovery_controller.ex
@@ -26,21 +26,23 @@ defmodule RiptideWeb.Hub.DiscoveryController do
 
   def show(conn, %{"node_id" => node_id}) do
     case conn |> rate_limit_key() |> Riptide.HubRateLimit.check_read() do
-      :deny ->
-        send_resp(conn, 429, "")
+      :deny -> send_resp(conn, 429, "")
+      :allow -> send_entry(conn, node_id)
+    end
+  end
 
-      :allow ->
-        {:ok, entries} = Catalog.list_entries(:hub)
+  defp send_entry(conn, node_id) do
+    {:ok, entries} = Catalog.list_entries(:hub)
+    found = Enum.find(entries, fn {node, _rule} -> RDF.BlankNode.value(node) == node_id end)
 
-        case Enum.find(entries, fn {node, _rule} -> RDF.BlankNode.value(node) == node_id end) do
-          nil ->
-            send_resp(conn, 404, "")
+    case found do
+      nil ->
+        send_resp(conn, 404, "")
 
-          {_node, rule} ->
-            {_node, graph} = RuleRDFCodec.to_rdf(rule)
-            {:ok, turtle} = TurtleCodec.encode(graph)
-            send_resp(conn, 200, turtle)
-        end
+      {_node, rule} ->
+        {_node, graph} = RuleRDFCodec.to_rdf(rule)
+        {:ok, turtle} = TurtleCodec.encode(graph)
+        send_resp(conn, 200, turtle)
     end
   end
 

--- a/lib/riptide_web/hub/propose_controller.ex
+++ b/lib/riptide_web/hub/propose_controller.ex
@@ -1,0 +1,81 @@
+defmodule RiptideWeb.Hub.ProposeController do
+  @moduledoc """
+  Publish-to-Hub — a Tenant's own DedupGate.propose/5 call, `target_scope:
+  :hub`, `review_scope: {:tenant, tenant_id}` (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6h-ii-pattern-hub-deployment-design.md`
+  §2, §5, §6). Scoped to fact-pattern-only candidates — no Capability
+  registry exists yet to safely resolve `context.capabilities` from an
+  HTTP request (spec §2, §9); `context.capabilities`/`context.rules` are
+  always built as empty maps here, never accepted from the request body.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.{AntiUnifier, DedupGate, Parser}
+
+  def propose(conn, params) do
+    tenant_id = conn.assigns.tenant_id
+
+    case Riptide.HubRateLimit.check_propose(tenant_id) do
+      :deny ->
+        send_resp(conn, 429, "")
+
+      :allow ->
+        handle_propose(conn, tenant_id, params)
+    end
+  end
+
+  defp handle_propose(
+         conn,
+         tenant_id,
+         %{"trace1" => trace1_text, "trace2" => trace2_text} = params
+       ) do
+    with {:ok, trace1} <- Parser.decode(trace1_text),
+         {:ok, trace2} <- Parser.decode(trace2_text),
+         {:ok, candidates} <- AntiUnifier.generalize(trace1, trace2) do
+      graph = facts_to_graph(Map.get(params, "facts", []))
+
+      context = %Context{
+        capabilities: %{},
+        rules: %{},
+        tenant_id: tenant_id,
+        current_subject: nil
+      }
+
+      case DedupGate.propose(:hub, {:tenant, tenant_id}, candidates, graph, context) do
+        {:ok, [{:queued, node, kind}]} ->
+          body =
+            Jason.encode!(%{
+              "outcome" => "queued",
+              "kind" => Atom.to_string(kind),
+              "node_id" => RDF.BlankNode.value(node)
+            })
+
+          conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+        {:ok, [{:rejected, reason}]} ->
+          body = Jason.encode!(%{"outcome" => "rejected", "reason" => inspect(reason)})
+          conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+        {:ok, [{:fidelity_failed, evidence}]} ->
+          body = Jason.encode!(%{"outcome" => "fidelity_failed", "evidence" => inspect(evidence)})
+          conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+        {:error, _reason} ->
+          send_resp(conn, 503, "")
+      end
+    else
+      {:error, _reason} -> send_resp(conn, 400, "")
+    end
+  end
+
+  defp handle_propose(conn, _tenant_id, _params), do: send_resp(conn, 400, "")
+
+  defp facts_to_graph(facts) do
+    Enum.reduce(facts, RDF.Graph.new(), fn %{"subject" => s, "predicate" => p, "object" => o},
+                                           graph ->
+      RDF.Graph.add(graph, {RDF.iri(s), RDF.iri(p), RDF.literal(o)})
+    end)
+  end
+end

--- a/lib/riptide_web/hub/propose_controller.ex
+++ b/lib/riptide_web/hub/propose_controller.ex
@@ -11,8 +11,8 @@ defmodule RiptideWeb.Hub.ProposeController do
 
   use Phoenix.Controller, formats: [:json]
 
-  alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.{AntiUnifier, DedupGate, Parser}
+  alias Riptide.Derivation.ExecuteInterpreter.Context
 
   def propose(conn, params) do
     tenant_id = conn.assigns.tenant_id

--- a/lib/riptide_web/hub/review_controller.ex
+++ b/lib/riptide_web/hub/review_controller.ex
@@ -1,0 +1,33 @@
+defmodule RiptideWeb.Hub.ReviewController do
+  @moduledoc """
+  Approve/decline a Hub-bound pending review — the *proposing* Tenant's
+  own review-queue authorization, unchanged from every other tenant-
+  scoped write (design spec
+  `docs/superpowers/specs/2026-08-29-phase-6h-ii-pattern-hub-deployment-design.md`
+  §2, §5, §6).
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.DedupGate
+
+  def approve(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.approve_review(:hub, {:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+
+  def decline(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.decline_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -57,5 +57,7 @@ defmodule RiptideWeb.Router do
     get "/policies", RiptideWeb.Authz.PolicyController, :index
 
     post "/hub/propose", RiptideWeb.Hub.ProposeController, :propose
+    post "/hub/pending-reviews/:node_id/approve", RiptideWeb.Hub.ReviewController, :approve
+    post "/hub/pending-reviews/:node_id/decline", RiptideWeb.Hub.ReviewController, :decline
   end
 end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -37,6 +37,13 @@ defmodule RiptideWeb.Router do
     get "/streams/:stream_id/subscribe", RiptideWeb.Realtime.SseController, :subscribe
   end
 
+  scope "/hub" do
+    pipe_through [:api, :auth]
+
+    get "/search", RiptideWeb.Hub.DiscoveryController, :search
+    get "/entries/:node_id", RiptideWeb.Hub.DiscoveryController, :show
+  end
+
   scope "/tenants/:tenant_id" do
     pipe_through [:api, :tenant, :auth, :authz]
 

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -55,5 +55,7 @@ defmodule RiptideWeb.Router do
 
     post "/policies", RiptideWeb.Authz.PolicyController, :create
     get "/policies", RiptideWeb.Authz.PolicyController, :index
+
+    post "/hub/propose", RiptideWeb.Hub.ProposeController, :propose
   end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -159,9 +159,16 @@ defmodule Riptide.Derivation.CatalogTest do
     test "admitting into :hub never surfaces in a Tenant's list_entries/1, and vice versa" do
       tenant_scope = unique_tenant()
 
+      # :hub is a single, shared, non-unique stream across the whole test
+      # suite (unlike unique_tenant()'s per-test isolation) — force-deleting
+      # it here would race any other test concurrently or subsequently
+      # writing to :hub (confirmed live: :ra.force_delete_server/2 on a
+      # shared stream_id can leave the very next admit_entry/1 against that
+      # same stream_id hitting :noproc before the lazy re-create catches
+      # up). Tolerate accumulation instead — that's why this test already
+      # asserts via Enum.any?/refute Enum.any? rather than an exact list.
       on_exit(fn ->
         Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(tenant_scope))
-        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(:hub))
       end)
 
       hub_rule = sample_rule("hub-pattern")

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -73,18 +73,19 @@ defmodule Riptide.Derivation.DedupGateTest do
     }
   end
 
-  defp ground_greet_trace(subject_name, arg_name) do
+  defp ground_greet_trace(subject_name, arg_name, predicate_local_name \\ "greeted") do
     cap_iri = RDF.iri("urn:riptide:capability:greetPerson")
     result = "\"Hello, #{arg_name}!\""
+    predicate = rel(predicate_local_name)
 
     %Rule{
       signature: %Signature{
-        name: rel("greeted"),
+        name: predicate,
         parameters: [t(subject_name), result],
         reads: [rel("pendingDeploy")],
-        produces: [rel("greeted")]
+        produces: [predicate]
       },
-      head: %FactPattern{predicate: rel("greeted"), args: [t(subject_name), result]},
+      head: %FactPattern{predicate: predicate, args: [t(subject_name), result]},
       body: [
         %FactPattern{predicate: rel("pendingDeploy"), args: [t(subject_name), RDF.literal("v1")]},
         %CapabilityReference{capability: cap_iri, args: [RDF.literal(arg_name)], result: result}
@@ -511,14 +512,19 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       target_scope = :hub
       review_scope = unique_tenant()
+      # :hub is shared and disk-persisted across every test run in this
+      # suite (never force-deleted — see catalog_test.exs's own "Hub vs.
+      # Tenant scope isolation" test for why). A unique predicate per test
+      # run keeps classify/2 from ever seeing a stale entry left behind by
+      # an earlier run and misclassifying this as :merge instead of :admit.
+      predicate_local_name = "propose5admit#{System.unique_integer([:positive])}"
 
       on_exit(fn ->
-        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(target_scope))
         Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
       end)
 
-      trace1 = ground_greet_trace("alice", "Alice")
-      trace2 = ground_greet_trace("bob", "Bob")
+      trace1 = ground_greet_trace("alice", "Alice", predicate_local_name)
+      trace2 = ground_greet_trace("bob", "Bob", predicate_local_name)
 
       assert {:ok, [{generalization, _sub1, _sub2}] = candidates} =
                AntiUnifier.generalize(trace1, trace2)

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -125,7 +125,9 @@ defmodule Riptide.Derivation.DedupGateTest do
           }
         })
 
-      assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, [{:queued, node, :admit}]} =
+               DedupGate.propose(scope, scope, candidates, graph, ctx)
+
       assert {:ok, [{^node, _pending_review}]} = Catalog.list_pending_reviews(scope)
     end
   end
@@ -149,7 +151,9 @@ defmodule Riptide.Derivation.DedupGateTest do
       graph = RDF.Graph.new()
       ctx = context()
 
-      assert {:ok, [{:rejected, _reason}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, [{:rejected, _reason}]} =
+               DedupGate.propose(scope, scope, candidates, graph, ctx)
+
       assert {:ok, []} = Catalog.list_pending_reviews(scope)
     end
 
@@ -209,7 +213,9 @@ defmodule Riptide.Derivation.DedupGateTest do
           }
         })
 
-      assert {:ok, [{:queued, node, :merge}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, [{:queued, node, :merge}]} =
+               DedupGate.propose(scope, scope, candidates, graph, ctx)
+
       assert {:ok, [{^node, pending_review}]} = Catalog.list_pending_reviews(scope)
       assert pending_review.replaces == existing_node
     end
@@ -263,7 +269,7 @@ defmodule Riptide.Derivation.DedupGateTest do
       ctx = context(%{capabilities: %{cap_iri => greet_definition("greetPerson")}})
 
       assert {:ok, [{:fidelity_failed, evidence}]} =
-               DedupGate.propose(scope, candidates, graph, ctx)
+               DedupGate.propose(scope, scope, candidates, graph, ctx)
 
       assert :fidelity_pass in evidence
       assert Enum.any?(evidence, &match?({:fidelity_fail, _}, &1))
@@ -358,7 +364,7 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       ctx = context()
 
-      assert {:ok, outcomes} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, outcomes} = DedupGate.propose(scope, scope, candidates, graph, ctx)
 
       assert [{:rejected, _reason}, {:queued, _node, :merge}] = outcomes
       refute candidate_a == candidate_b
@@ -397,9 +403,9 @@ defmodule Riptide.Derivation.DedupGateTest do
           }
         })
 
-      {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, scope, candidates, graph, ctx)
 
-      assert :ok == DedupGate.approve_review(scope, node)
+      assert :ok == DedupGate.approve_review(scope, scope, node)
       assert {:ok, [{_entry_node, _rule}]} = Catalog.list_entries(scope)
       assert {:ok, []} = Catalog.list_pending_reviews(scope)
     end
@@ -437,7 +443,7 @@ defmodule Riptide.Derivation.DedupGateTest do
           }
         })
 
-      {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, scope, candidates, graph, ctx)
 
       assert :ok == DedupGate.decline_review(scope, node)
       assert {:ok, []} = Catalog.list_entries(scope)
@@ -484,14 +490,71 @@ defmodule Riptide.Derivation.DedupGateTest do
         })
 
       assert {:ok, [{:queued, node, :admit}]} =
-               DedupGate.propose(scope, [{generalization, sub1, sub2}], graph, ctx)
+               DedupGate.propose(scope, scope, [{generalization, sub1, sub2}], graph, ctx)
 
       assert {:ok, [{^node, pending_review}]} = Catalog.list_pending_reviews(scope)
       assert pending_review.fidelity_evidence == [:fidelity_pass, :fidelity_pass]
 
-      assert :ok == DedupGate.approve_review(scope, node)
+      assert :ok == DedupGate.approve_review(scope, scope, node)
 
       assert {:ok, [{_entry_node, ^generalization}]} = Catalog.list_entries(scope)
+    end
+  end
+
+  describe "propose/5 — target_scope and review_scope differ" do
+    test "a Hub-targeted proposal is classified/admitted against target_scope but reviewed in review_scope's own queue" do
+      FakeStore.start(%{
+        {"acme", ["capabilities", "greetPerson"]} => [
+          %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+        ]
+      })
+
+      target_scope = :hub
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(target_scope))
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      trace1 = ground_greet_trace("alice", "Alice")
+      trace2 = ground_greet_trace("bob", "Bob")
+
+      assert {:ok, [{generalization, _sub1, _sub2}] = candidates} =
+               AntiUnifier.generalize(trace1, trace2)
+
+      graph =
+        RDF.Graph.new([
+          {t("alice"), rel("pendingDeploy"), RDF.literal("v1")},
+          {t("bob"), rel("pendingDeploy"), RDF.literal("v1")}
+        ])
+
+      ctx =
+        context(%{
+          capabilities: %{
+            RDF.iri("urn:riptide:capability:greetPerson") => greet_definition("greetPerson")
+          }
+        })
+
+      assert {:ok, [{:queued, node, :admit}]} =
+               DedupGate.propose(target_scope, review_scope, candidates, graph, ctx)
+
+      # Reviewed in review_scope's own queue, not target_scope's.
+      assert {:ok, review_entries} = Catalog.list_pending_reviews(review_scope)
+      assert Enum.any?(review_entries, fn {n, _} -> n == node end)
+
+      # Not yet admitted into target_scope.
+      assert {:ok, target_entries_before} = Catalog.list_entries(target_scope)
+      refute Enum.any?(target_entries_before, fn {_n, rule} -> rule == generalization end)
+
+      assert :ok == DedupGate.approve_review(target_scope, review_scope, node)
+
+      # Admitted into target_scope's Catalog...
+      assert {:ok, target_entries_after} = Catalog.list_entries(target_scope)
+      assert Enum.any?(target_entries_after, fn {_n, rule} -> rule == generalization end)
+
+      # ...and the review resolved in review_scope, not target_scope.
+      assert {:ok, []} = Catalog.list_pending_reviews(review_scope)
     end
   end
 end

--- a/test/riptide/derivation/discovery_test.exs
+++ b/test/riptide/derivation/discovery_test.exs
@@ -223,8 +223,11 @@ defmodule Riptide.Derivation.DiscoveryTest do
       assert {:ok, trace2} = LLMFallback.run("greet Bob", graph, ctx)
 
       assert {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
-      assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
-      assert :ok == DedupGate.approve_review(scope, node)
+
+      assert {:ok, [{:queued, node, :admit}]} =
+               DedupGate.propose(scope, scope, candidates, graph, ctx)
+
+      assert :ok == DedupGate.approve_review(scope, scope, node)
 
       # Third occurrence: found via Discovery's keyword path ("greet" is not
       # among the found entry's own predicate words — pending/deploy/has/name

--- a/test/riptide/derivation/llm_fallback_test.exs
+++ b/test/riptide/derivation/llm_fallback_test.exs
@@ -279,9 +279,10 @@ defmodule Riptide.Derivation.LLMFallbackTest do
 
       assert {:ok, candidates} = AntiUnifier.generalize(trace1, trace2)
 
-      assert {:ok, [{:queued, node, :admit}]} = DedupGate.propose(scope, candidates, graph, ctx)
+      assert {:ok, [{:queued, node, :admit}]} =
+               DedupGate.propose(scope, scope, candidates, graph, ctx)
 
-      assert :ok == DedupGate.approve_review(scope, node)
+      assert :ok == DedupGate.approve_review(scope, scope, node)
 
       assert {:ok, [{_entry_node, _rule}]} = Catalog.list_entries(scope)
     end

--- a/test/riptide/hub_rate_limit_test.exs
+++ b/test/riptide/hub_rate_limit_test.exs
@@ -1,0 +1,49 @@
+defmodule Riptide.HubRateLimitTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :hub_read_rate_limit, 2)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :hub_read_rate_scale_ms, :timer.minutes(1))
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :hub_propose_rate_limit, 2)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :hub_propose_rate_scale_ms, :timer.minutes(1))
+    :ok
+  end
+
+  test "check_read/1 allows up to the configured limit, then denies" do
+    key = "reader-#{System.unique_integer([:positive])}"
+
+    assert Riptide.HubRateLimit.check_read(key) == :allow
+    assert Riptide.HubRateLimit.check_read(key) == :allow
+    assert Riptide.HubRateLimit.check_read(key) == :deny
+  end
+
+  test "check_read/1 tracks distinct keys independently" do
+    key_a = "reader-a-#{System.unique_integer([:positive])}"
+    key_b = "reader-b-#{System.unique_integer([:positive])}"
+
+    assert Riptide.HubRateLimit.check_read(key_a) == :allow
+    assert Riptide.HubRateLimit.check_read(key_a) == :allow
+    assert Riptide.HubRateLimit.check_read(key_a) == :deny
+
+    assert Riptide.HubRateLimit.check_read(key_b) == :allow
+  end
+
+  test "check_propose/1 allows up to the configured limit, then denies" do
+    tenant_id = "tenant-#{System.unique_integer([:positive])}"
+
+    assert Riptide.HubRateLimit.check_propose(tenant_id) == :allow
+    assert Riptide.HubRateLimit.check_propose(tenant_id) == :allow
+    assert Riptide.HubRateLimit.check_propose(tenant_id) == :deny
+  end
+
+  test "check_propose/1 tracks distinct tenants independently" do
+    tenant_a = "tenant-a-#{System.unique_integer([:positive])}"
+    tenant_b = "tenant-b-#{System.unique_integer([:positive])}"
+
+    assert Riptide.HubRateLimit.check_propose(tenant_a) == :allow
+    assert Riptide.HubRateLimit.check_propose(tenant_a) == :allow
+    assert Riptide.HubRateLimit.check_propose(tenant_a) == :deny
+
+    assert Riptide.HubRateLimit.check_propose(tenant_b) == :allow
+  end
+end

--- a/test/riptide_web/hub/discovery_controller_test.exs
+++ b/test/riptide_web/hub/discovery_controller_test.exs
@@ -1,0 +1,62 @@
+defmodule RiptideWeb.Hub.DiscoveryControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.Literal.FactPattern
+  alias Riptide.Derivation.{Rule, Signature}
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  defp sample_rule(predicate_local_name) do
+    predicate = rel(predicate_local_name)
+    head = %FactPattern{predicate: predicate, args: [t("subject"), RDF.literal("object")]}
+
+    %Rule{
+      signature: %Signature{name: predicate, parameters: [], reads: [], produces: [predicate]},
+      head: head,
+      body: []
+    }
+  end
+
+  test "GET /hub/search finds a real admitted Hub-scope entry, with no auth token" do
+    # :hub is a single, shared, non-unique stream across the whole test
+    # suite — never force-deleted from a test (confirmed live: doing so
+    # races any other write against that same stream_id). Tolerated by
+    # using a unique predicate name and a substring match instead of an
+    # exact-list assertion, same as catalog_test.exs's own "Hub vs. Tenant
+    # scope isolation" test.
+    predicate_name = "discoverysearch#{System.unique_integer([:positive])}"
+    rule = sample_rule(predicate_name)
+
+    :ok = Catalog.admit_entry(:hub, rule, nil)
+
+    conn = :get |> conn("/hub/search?q=#{predicate_name}") |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    assert conn.resp_body =~ predicate_name
+  end
+
+  test "GET /hub/entries/:node_id fetches a specific entry by its blank-node id, with no auth token" do
+    predicate_name = "discoveryfetch#{System.unique_integer([:positive])}"
+    rule = sample_rule(predicate_name)
+
+    :ok = Catalog.admit_entry(:hub, rule, nil)
+    {:ok, entries} = Catalog.list_entries(:hub)
+    {node, ^rule} = Enum.find(entries, fn {_node, entry} -> entry == rule end)
+    node_id = RDF.BlankNode.value(node)
+
+    conn = :get |> conn("/hub/entries/#{node_id}") |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    assert conn.resp_body =~ predicate_name
+  end
+
+  test "GET /hub/entries/:node_id returns 404 for an id that was never admitted" do
+    conn = :get |> conn("/hub/entries/nonexistent-node-id") |> RiptideWeb.Endpoint.call(@opts)
+    assert conn.status == 404
+  end
+end

--- a/test/riptide_web/hub/propose_controller_test.exs
+++ b/test/riptide_web/hub/propose_controller_test.exs
@@ -1,0 +1,103 @@
+defmodule RiptideWeb.Hub.ProposeControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  test "an authenticated owner can propose two fact-pattern-only ground Traces to Hub scope" do
+    tenant_id = "hub-propose-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "proposetest#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    # :hub is shared and disk-persisted across the whole test suite (never
+    # force-deleted — see catalog_test.exs's own "Hub vs. Tenant scope
+    # isolation" test), so only the review-queue stream (isolated per
+    # unique tenant_id) is cleaned up here.
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    trace1 =
+      "#{predicate_name}(<urn:test:alice>, \"hi\") :- pendingDeploy(<urn:test:alice>, \"v1\")."
+
+    trace2 =
+      "#{predicate_name}(<urn:test:bob>, \"hi\") :- pendingDeploy(<urn:test:bob>, \"v1\")."
+
+    body =
+      Jason.encode!(%{
+        "trace1" => trace1,
+        "trace2" => trace2,
+        "facts" => [
+          %{
+            "subject" => "urn:test:alice",
+            "predicate" => "urn:riptide:relation:pendingDeploy",
+            "object" => "v1"
+          },
+          %{
+            "subject" => "urn:test:bob",
+            "predicate" => "urn:riptide:relation:pendingDeploy",
+            "object" => "v1"
+          }
+        ]
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/propose", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    response = Jason.decode!(conn.resp_body)
+    assert response["outcome"] == "queued"
+    assert response["kind"] == "admit"
+    assert is_binary(response["node_id"])
+
+    assert {:ok, review_entries} = Catalog.list_pending_reviews({:tenant, tenant_id})
+
+    assert Enum.any?(review_entries, fn {node, _} ->
+             RDF.BlankNode.value(node) == response["node_id"]
+           end)
+  end
+
+  test "an unauthenticated caller is denied" do
+    tenant_id = "hub-propose-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    body =
+      Jason.encode!(%{
+        "trace1" => "x(<urn:test:a>, \"y\").",
+        "trace2" => "x(<urn:test:b>, \"y\").",
+        "facts" => []
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/propose", body)
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 403
+  end
+end

--- a/test/riptide_web/hub/propose_controller_test.exs
+++ b/test/riptide_web/hub/propose_controller_test.exs
@@ -81,6 +81,79 @@ defmodule RiptideWeb.Hub.ProposeControllerTest do
            end)
   end
 
+  test "exit criterion (issue #70): propose, approve, then discover and fetch the newly-live Hub entry over HTTP" do
+    tenant_id = "hub-capstone-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "capstonepattern#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    trace1 =
+      "#{predicate_name}(<urn:test:alice>, \"hi\") :- pendingDeploy(<urn:test:alice>, \"v1\")."
+
+    trace2 = "#{predicate_name}(<urn:test:bob>, \"hi\") :- pendingDeploy(<urn:test:bob>, \"v1\")."
+
+    body =
+      Jason.encode!(%{
+        "trace1" => trace1,
+        "trace2" => trace2,
+        "facts" => [
+          %{
+            "subject" => "urn:test:alice",
+            "predicate" => "urn:riptide:relation:pendingDeploy",
+            "object" => "v1"
+          },
+          %{
+            "subject" => "urn:test:bob",
+            "predicate" => "urn:riptide:relation:pendingDeploy",
+            "object" => "v1"
+          }
+        ]
+      })
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/propose", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert propose_conn.status == 200
+    pending_review_node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/pending-reviews/#{pending_review_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    # Discoverable, with no auth token — a genuinely different (anonymous) caller.
+    search_conn =
+      :get |> conn("/hub/search?q=#{predicate_name}") |> RiptideWeb.Endpoint.call(@opts)
+
+    assert search_conn.status == 200
+    assert search_conn.resp_body =~ predicate_name
+
+    # Fetchable directly by the live CatalogEntry's own node id — distinct
+    # from the PendingReview's node id above (admit_entry/3 mints its own
+    # fresh blank node for the newly-stored entry).
+    predicate = RDF.iri("urn:riptide:relation:" <> predicate_name)
+    {:ok, entries} = Catalog.list_entries(:hub)
+
+    {entry_node, _rule} =
+      Enum.find(entries, fn {_node, rule} -> rule.head.predicate == predicate end)
+
+    entry_node_id = RDF.BlankNode.value(entry_node)
+
+    fetch_conn = :get |> conn("/hub/entries/#{entry_node_id}") |> RiptideWeb.Endpoint.call(@opts)
+    assert fetch_conn.status == 200
+    assert fetch_conn.resp_body =~ predicate_name
+  end
+
   test "an unauthenticated caller is denied" do
     tenant_id = "hub-propose-test-" <> Uniq.UUID.uuid4()
     claim_tenant(tenant_id)

--- a/test/riptide_web/hub/review_controller_test.exs
+++ b/test/riptide_web/hub/review_controller_test.exs
@@ -1,0 +1,136 @@
+defmodule RiptideWeb.Hub.ReviewControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify("other-token"), do: {:ok, %{"sub" => "someone-else"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id, owner_sub \\ "the-owner") do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, owner_sub)
+  end
+
+  defp propose(tenant_id, predicate_name) do
+    trace1 =
+      "#{predicate_name}(<urn:test:alice>, \"hi\") :- pendingDeploy(<urn:test:alice>, \"v1\")."
+
+    trace2 = "#{predicate_name}(<urn:test:bob>, \"hi\") :- pendingDeploy(<urn:test:bob>, \"v1\")."
+
+    body =
+      Jason.encode!(%{
+        "trace1" => trace1,
+        "trace2" => trace2,
+        "facts" => [
+          %{
+            "subject" => "urn:test:alice",
+            "predicate" => "urn:riptide:relation:pendingDeploy",
+            "object" => "v1"
+          },
+          %{
+            "subject" => "urn:test:bob",
+            "predicate" => "urn:riptide:relation:pendingDeploy",
+            "object" => "v1"
+          }
+        ]
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/propose", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    Jason.decode!(conn.resp_body)["node_id"]
+  end
+
+  test "the proposing Tenant's own owner can approve their own pending review" do
+    tenant_id = "hub-review-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "reviewapprove#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    node_id = propose(tenant_id, predicate_name)
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/pending-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+
+    predicate = RDF.iri("urn:riptide:relation:" <> predicate_name)
+    assert {:ok, entries} = Catalog.list_entries(:hub)
+    assert Enum.any?(entries, fn {_node, rule} -> rule.head.predicate == predicate end)
+  end
+
+  test "a different Tenant's own approve attempt 404s — the review only ever exists in the proposing Tenant's own queue" do
+    tenant_id = "hub-review-test-" <> Uniq.UUID.uuid4()
+    other_tenant_id = "hub-review-other-" <> Uniq.UUID.uuid4()
+    predicate_name = "reviewdeny#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+    claim_tenant(other_tenant_id, "someone-else")
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    node_id = propose(tenant_id, predicate_name)
+
+    conn =
+      :post
+      |> conn("/tenants/#{other_tenant_id}/hub/pending-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer other-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    # The request itself is authorized (other_tenant_id's own owner posting
+    # to other_tenant_id's own route) — DedupGate.approve_review/3 reads
+    # review_scope's own pending-review stream (§5), and this node was
+    # never queued there, so the lookup simply misses. A 404 here doesn't
+    # leak whether the review exists under some other Tenant.
+    assert conn.status == 404
+  end
+
+  test "decline resolves the review and admits nothing" do
+    tenant_id = "hub-review-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "reviewdecline#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    node_id = propose(tenant_id, predicate_name)
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/pending-reviews/#{node_id}/decline")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+
+    predicate = RDF.iri("urn:riptide:relation:" <> predicate_name)
+    assert {:ok, entries} = Catalog.list_entries(:hub)
+    refute Enum.any?(entries, fn {_node, rule} -> rule.head.predicate == predicate end)
+  end
+end


### PR DESCRIPTION
## Summary
- Stands up the Pattern Hub as a network-publicly-reachable extension of 6e-iii's DedupGate mechanism plus 6g-i's Discovery, gated by 6h-i's auth/rate-limit model.
- Route topology splits by natural shape: tenant-less reads (`GET /hub/search`, `GET /hub/entries/:node_id`, optional auth) and tenant-scoped writes (`POST /tenants/:tenant_id/hub/propose`, `.../approve`, `.../decline`), the latter reusing the existing `[:api, :tenant, :auth, :authz]` pipeline completely unchanged.
- `DedupGate.propose/4`/`approve_review/2` widen to `propose/5`/`approve_review/3`, splitting the Catalog target from the review-queue owner — a pure, backward-compatible signature change; every existing caller (6e-iii, 6f, 6g-i) has `target_scope == review_scope`, unaffected.
- `ProposeController` is scoped to fact-pattern-only candidates — no Capability registry exists yet anywhere in this project to safely resolve `context.capabilities` from an HTTP request; a real, separate gap, not invented here.
- Full Install (Crosswalk-aware field binding) is explicitly deferred to 6i, per the exit criterion's own literal wording.
- Three real, pre-existing bugs found and fixed along the way (all documented in `PROGRESS.md`, all invisible until this phase made `:hub` a genuinely long-lived, repeatedly-read/written stream for the first time):
  1. `RaTestHelpers.cleanup_stream/1` racing a subsequent write against the same shared `:hub` stream.
  2. `RaCluster.process_command/2`/`consistent_query/2`/`local_query/2` never retrying transient failures — a gap the code's own comment had flagged as needed once multi-node membership shipped (phase 3c) but never implemented.
  3. A deeper crash class: `:ra`'s own `apply_consistent_queries_effects/2` can fail an internal assertion and crash a stream's entire Ra server process outright, with no automatic recovery (`Placement`'s cache never invalidates; `ReplicaHealer`'s replace-based repair can't help a single-member cluster's own member dying). Fixed with a new `RaCluster.restart_server/1` wired into `StreamServer`'s last-replica fallback — restart-in-place from the crashed server's own durable log, then retry once more before giving up. Verified against the actual failure: CI failed with exactly this crash before the fix, then passed cleanly (Hub tests) across multiple reruns after it.

Implements #70. Spec: `docs/superpowers/specs/2026-08-29-phase-6h-ii-pattern-hub-deployment-design.md` (PR #107).

## Test plan
- [x] `mix test` — full suite green (multiple consecutive clean local runs; see PROGRESS.md for the full evidence trail)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [x] CI green on this PR