### PR TITLE
Draft: Resolve: "6c-ii — Recursion and fixpoint evaluation"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Riptide — Production Readiness Roadmap
 
-**Last updated:** 2026-08-28
+**Last updated:** 2026-08-30
 
 This tracks Riptide's path from "working reference implementation" (shipped: see
 [PR #1](https://github.com/OpenFASTER-Standard/riptide/pull/1)) to "production-grade centerpiece
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model) — 9 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6c-ii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; recursion and fixpoint evaluation) — 8 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -785,6 +785,9 @@ session-active check runs inside the target process's own serialized mailbox
 supervisor mechanism (`:transient` restart type, differing only in exit reason — abnormal vs.
 `:normal`) rather than needing special-cased logic.
 
+**Status**: Phase 6b-ii shipped 2026-08-29. 10 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
 ### 6h-i — Pattern Hub threat model
 
 Foundation-track phase (§7 of the design spec, `depends on: nothing`), independent of every
@@ -816,5 +819,36 @@ with no central reviewer as a safety net, a Tenant's own mandatory human review 
 **Status**: Phase 6h-i shipped 2026-08-29. 9 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
 
-**Status**: Phase 6b-ii shipped 2026-08-29. 10 phases remaining across the primary spine, the
+### 6c-ii — Recursion and fixpoint evaluation
+
+Track B's first link (§7 of the design spec) — pure query capability, parallel to Track A's
+spine and left completely untouched until this phase. **Shipped 2026-08-30** — see
+`docs/superpowers/specs/2026-08-30-phase-6c-ii-recursion-fixpoint-design.md`.
+
+New `Riptide.Derivation.QueryInterpreter.evaluate/3` — naive bottom-up fixpoint evaluation over
+a ruleset (a list of Rules, e.g. a base clause plus a recursive clause sharing one head
+predicate), the first piece of "QueryInterpretation proper" beyond `Matcher` (whose own
+moduledoc already called itself "the fact-pattern-only fragment of QueryInterpretation").
+`Matcher.evaluate/2` stays completely unchanged; `QueryInterpreter` composes it once per round,
+merging newly-derived triples into the graph until a round adds nothing new. Semi-naive
+evaluation (Soufflé's delta-restricted-join technique, design spec §8.8) was explicitly deferred
+as a future optimization — naive evaluation is simpler, more directly provably correct via the
+classical Van Emden–Kowalski least-fixpoint construction, and sufficient for this phase's own
+correctness-focused exit criterion. The exit criterion's own "documented stratification/
+termination discipline" turned out to be mostly a documentation exercise rather than new code:
+no literal type in this codebase expresses negation (`FactPattern`, `CapabilityReference`,
+`RuleReference` — none of them), so every rule is monotonic by construction and a single
+evaluation stratum always suffices, with nothing to validate at runtime; termination is
+guaranteed by a finite Herbrand universe, since fact-pattern-only rules never synthesize new
+constants. A configurable `max_iterations`/`max_fact_count` safety bound (via
+`Application.get_env(:riptide, :query_interpreter_max_iterations/:query_interpreter_max_fact_count, ...)`,
+mirroring `Riptide.NewStreamRateLimit`'s own config-with-default-fallback shape) guards against a
+large or adversarial ruleset as defense-in-depth on top of that classical guarantee. Verified
+against a transitive-closure ruleset (the exit criterion's own example) and, separately, a
+mutual-recursion ruleset across two distinct head predicates (even/odd via a successor chain),
+proving the algorithm generalizes to any ruleset shape rather than just single-predicate
+self-recursion — both non-trivial numeric traces confirmed directly via real evaluation before
+being written into the test suite, not just reasoned about.
+
+**Status**: Phase 6c-ii shipped 2026-08-30. 8 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/query_interpreter.ex
+++ b/lib/riptide/derivation/query_interpreter.ex
@@ -17,7 +17,7 @@ defmodule Riptide.Derivation.QueryInterpreter do
   @default_max_iterations 10_000
   @default_max_fact_count 1_000_000
 
-  @spec evaluate([Rule.t()], RDF.Graph.t()) ::
+  @spec evaluate([Rule.t()], RDF.Graph.t(), keyword()) ::
           {:ok, RDF.Graph.t()}
           | {:error,
              :too_many_variables
@@ -25,8 +25,22 @@ defmodule Riptide.Derivation.QueryInterpreter do
              | {:unsafe_rule, Var.t()}
              | :iteration_limit_exceeded
              | :fact_limit_exceeded}
-  def evaluate(rules, %RDF.Graph{} = graph) when is_list(rules) do
-    loop(rules, graph, 0, @default_max_iterations, @default_max_fact_count)
+  def evaluate(rules, %RDF.Graph{} = graph, opts \\ []) when is_list(rules) do
+    max_iterations =
+      Keyword.get(
+        opts,
+        :max_iterations,
+        Application.get_env(:riptide, :query_interpreter_max_iterations, @default_max_iterations)
+      )
+
+    max_fact_count =
+      Keyword.get(
+        opts,
+        :max_fact_count,
+        Application.get_env(:riptide, :query_interpreter_max_fact_count, @default_max_fact_count)
+      )
+
+    loop(rules, graph, 0, max_iterations, max_fact_count)
   end
 
   defp loop(_rules, _graph, round, max_iterations, _max_fact_count)

--- a/lib/riptide/derivation/query_interpreter.ex
+++ b/lib/riptide/derivation/query_interpreter.ex
@@ -1,0 +1,62 @@
+defmodule Riptide.Derivation.QueryInterpreter do
+  @moduledoc """
+  QueryInterpretation's own module — a fixpoint evaluator over a ruleset
+  (a list of Rules, e.g. a base clause plus a recursive clause sharing one
+  head predicate). Iterates `Riptide.Derivation.Matcher.evaluate/2` per
+  rule each round, merging newly-derived triples into the graph, until a
+  round adds nothing new (the least fixpoint). See design spec
+  `docs/superpowers/specs/2026-08-30-phase-6c-ii-recursion-fixpoint-design.md`
+  §5 for why this always terminates and needs no stratification: no
+  literal type in this codebase expresses negation, so every rule is
+  monotonic by construction, and fact-pattern-only rules never synthesize
+  new constants, so the Herbrand universe is finite.
+  """
+
+  alias Riptide.Derivation.{Matcher, Rule, Var}
+
+  @default_max_iterations 10_000
+  @default_max_fact_count 1_000_000
+
+  @spec evaluate([Rule.t()], RDF.Graph.t()) ::
+          {:ok, RDF.Graph.t()}
+          | {:error,
+             :too_many_variables
+             | {:unsupported_literal, Rule.literal()}
+             | {:unsafe_rule, Var.t()}
+             | :iteration_limit_exceeded
+             | :fact_limit_exceeded}
+  def evaluate(rules, %RDF.Graph{} = graph) when is_list(rules) do
+    loop(rules, graph, 0, @default_max_iterations, @default_max_fact_count)
+  end
+
+  defp loop(_rules, _graph, round, max_iterations, _max_fact_count)
+       when round >= max_iterations do
+    {:error, :iteration_limit_exceeded}
+  end
+
+  defp loop(rules, graph, round, max_iterations, max_fact_count) do
+    with {:ok, new_triples} <- evaluate_all_rules(rules, graph) do
+      next_graph = RDF.Graph.add(graph, new_triples)
+
+      cond do
+        RDF.Graph.triple_count(next_graph) > max_fact_count ->
+          {:error, :fact_limit_exceeded}
+
+        RDF.Graph.triple_count(next_graph) == RDF.Graph.triple_count(graph) ->
+          {:ok, next_graph}
+
+        true ->
+          loop(rules, next_graph, round + 1, max_iterations, max_fact_count)
+      end
+    end
+  end
+
+  defp evaluate_all_rules(rules, graph) do
+    Enum.reduce_while(rules, {:ok, []}, fn rule, {:ok, acc} ->
+      case Matcher.evaluate(rule, graph) do
+        {:ok, triples} -> {:cont, {:ok, acc ++ triples}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+end

--- a/test/riptide/derivation/query_interpreter_test.exs
+++ b/test/riptide/derivation/query_interpreter_test.exs
@@ -44,9 +44,9 @@ defmodule Riptide.Derivation.QueryInterpreterTest do
 
   describe "evaluate/2 — mutual recursion across two predicates" do
     test "even/odd via a successor chain, proving the algorithm isn't limited to self-recursion" do
-      {:ok, even_base} = Parser.decode("even(X, \"yes\") :- zeroMarker(X, \"yes\").")
-      {:ok, even_step} = Parser.decode("even(X, \"yes\") :- succ(Y, X), odd(Y, \"yes\").")
-      {:ok, odd_step} = Parser.decode("odd(X, \"yes\") :- succ(Y, X), even(Y, \"yes\").")
+      {:ok, even_base} = Parser.decode(~s|even(X, "yes") :- zeroMarker(X, "yes").|)
+      {:ok, even_step} = Parser.decode(~s|even(X, "yes") :- succ(Y, X), odd(Y, "yes").|)
+      {:ok, odd_step} = Parser.decode(~s|odd(X, "yes") :- succ(Y, X), even(Y, "yes").|)
 
       graph =
         RDF.Graph.new([
@@ -87,6 +87,103 @@ defmodule Riptide.Derivation.QueryInterpreterTest do
 
       assert {:ok, result} = QueryInterpreter.evaluate([base, recursive], graph)
       assert RDF.Graph.triple_count(result) == 0
+    end
+  end
+
+  describe "evaluate/3 — safety bounds" do
+    test "max_iterations tripping via opts returns :iteration_limit_exceeded" do
+      {:ok, base} = Parser.decode("ancestor(X, Y) :- parent(X, Y).")
+      {:ok, recursive} = Parser.decode("ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).")
+
+      graph =
+        RDF.Graph.new([
+          {t("a"), rel("parent"), t("b")},
+          {t("b"), rel("parent"), t("c")},
+          {t("c"), rel("parent"), t("d")}
+        ])
+
+      assert QueryInterpreter.evaluate([base, recursive], graph, max_iterations: 1) ==
+               {:error, :iteration_limit_exceeded}
+    end
+
+    test "max_fact_count tripping via opts returns :fact_limit_exceeded" do
+      {:ok, base} = Parser.decode("ancestor(X, Y) :- parent(X, Y).")
+      {:ok, recursive} = Parser.decode("ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).")
+
+      graph =
+        RDF.Graph.new([
+          {t("a"), rel("parent"), t("b")},
+          {t("b"), rel("parent"), t("c")},
+          {t("c"), rel("parent"), t("d")}
+        ])
+
+      # The full closure needs 3 parent + 6 ancestor = 9 triples (the
+      # transitive-closure test above). Round 1 alone already adds the 3
+      # base ancestor facts (a-b, b-c, c-d — derivable straight from the
+      # 3 parent facts, no recursion needed yet), taking the graph to 6
+      # triples — verified directly via a real Matcher.evaluate/2 call
+      # against this exact fixture. 6 > 5, so this trips at the end of
+      # round 1, before the recursive clause ever produces anything.
+      assert QueryInterpreter.evaluate([base, recursive], graph, max_fact_count: 5) ==
+               {:error, :fact_limit_exceeded}
+    end
+
+    test "max_iterations from Application config trips the same way as an explicit opt" do
+      Riptide.AppEnvTestHelpers.put_env(:riptide, :query_interpreter_max_iterations, 1)
+
+      {:ok, base} = Parser.decode("ancestor(X, Y) :- parent(X, Y).")
+      {:ok, recursive} = Parser.decode("ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).")
+
+      graph =
+        RDF.Graph.new([
+          {t("a"), rel("parent"), t("b")},
+          {t("b"), rel("parent"), t("c")},
+          {t("c"), rel("parent"), t("d")}
+        ])
+
+      assert QueryInterpreter.evaluate([base, recursive], graph) ==
+               {:error, :iteration_limit_exceeded}
+    end
+  end
+
+  describe "evaluate/3 — Matcher's own errors propagate unchanged" do
+    test "an unsafe rule (Head variable absent from the Body) is rejected the same way Matcher.evaluate/2 rejects it" do
+      alias Riptide.Derivation.Literal.FactPattern
+      alias Riptide.Derivation.{Rule, Signature, Var}
+
+      head = %FactPattern{predicate: rel("bad"), args: [%Var{name: "X"}, %Var{name: "Unbound"}]}
+      body = [%FactPattern{predicate: rel("f"), args: [%Var{name: "X"}, %Var{name: "X"}]}]
+
+      rule = %Rule{
+        signature: %Signature{
+          name: head.predicate,
+          parameters: head.args,
+          reads: [],
+          produces: [head.predicate]
+        },
+        head: head,
+        body: body
+      }
+
+      assert QueryInterpreter.evaluate([rule], RDF.Graph.new()) ==
+               {:error, {:unsafe_rule, %Var{name: "Unbound"}}}
+    end
+
+    test "a Body containing a capability(...) literal is rejected the same way Matcher.evaluate/2 rejects it" do
+      alias Riptide.Derivation.Literal.CapabilityReference
+
+      # Head vars (Svc, Target) are both bound by the fact-pattern literal
+      # alone, so this Rule is safe — isolating the scope-check failure
+      # from the safety check (Outcome is body-only, irrelevant to safety).
+      # Matches test/riptide/derivation/matcher_test.exs's own identical
+      # fixture for this exact scenario.
+      {:ok, rule} =
+        Parser.decode(
+          "deployed(Svc, Target) :- pendingDeploy(Svc, Target), capability(deployService, Svc, Target, Outcome)."
+        )
+
+      assert {:error, {:unsupported_literal, %CapabilityReference{}}} =
+               QueryInterpreter.evaluate([rule], RDF.Graph.new())
     end
   end
 end

--- a/test/riptide/derivation/query_interpreter_test.exs
+++ b/test/riptide/derivation/query_interpreter_test.exs
@@ -1,0 +1,92 @@
+defmodule Riptide.Derivation.QueryInterpreterTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.{Parser, QueryInterpreter}
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  describe "evaluate/2 — transitive closure" do
+    test "a base clause plus a recursive clause reach the correct least fixpoint" do
+      {:ok, base} = Parser.decode("ancestor(X, Y) :- parent(X, Y).")
+      {:ok, recursive} = Parser.decode("ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).")
+
+      graph =
+        RDF.Graph.new([
+          {t("a"), rel("parent"), t("b")},
+          {t("b"), rel("parent"), t("c")},
+          {t("c"), rel("parent"), t("d")}
+        ])
+
+      assert {:ok, result} = QueryInterpreter.evaluate([base, recursive], graph)
+
+      ancestor_pairs =
+        result
+        |> RDF.Graph.triples()
+        |> Enum.filter(fn {_s, p, _o} -> p == rel("ancestor") end)
+        |> Enum.map(fn {s, _p, o} -> {s, o} end)
+        |> MapSet.new()
+
+      assert ancestor_pairs ==
+               MapSet.new([
+                 {t("a"), t("b")},
+                 {t("a"), t("c")},
+                 {t("a"), t("d")},
+                 {t("b"), t("c")},
+                 {t("b"), t("d")},
+                 {t("c"), t("d")}
+               ])
+
+      # The original EDB is still present — evaluate/2 returns EDB ∪ IDB, not just the delta.
+      assert RDF.Graph.include?(result, {t("a"), rel("parent"), t("b")})
+    end
+  end
+
+  describe "evaluate/2 — mutual recursion across two predicates" do
+    test "even/odd via a successor chain, proving the algorithm isn't limited to self-recursion" do
+      {:ok, even_base} = Parser.decode("even(X, \"yes\") :- zeroMarker(X, \"yes\").")
+      {:ok, even_step} = Parser.decode("even(X, \"yes\") :- succ(Y, X), odd(Y, \"yes\").")
+      {:ok, odd_step} = Parser.decode("odd(X, \"yes\") :- succ(Y, X), even(Y, \"yes\").")
+
+      graph =
+        RDF.Graph.new([
+          {t("zero"), rel("zeroMarker"), RDF.literal("yes")},
+          {t("zero"), rel("succ"), t("one")},
+          {t("one"), rel("succ"), t("two")},
+          {t("two"), rel("succ"), t("three")},
+          {t("three"), rel("succ"), t("four")}
+        ])
+
+      assert {:ok, result} = QueryInterpreter.evaluate([even_base, even_step, odd_step], graph)
+
+      even_subjects =
+        result
+        |> RDF.Graph.triples()
+        |> Enum.filter(fn {_s, p, _o} -> p == rel("even") end)
+        |> Enum.map(fn {s, _p, _o} -> s end)
+        |> MapSet.new()
+
+      odd_subjects =
+        result
+        |> RDF.Graph.triples()
+        |> Enum.filter(fn {_s, p, _o} -> p == rel("odd") end)
+        |> Enum.map(fn {s, _p, _o} -> s end)
+        |> MapSet.new()
+
+      assert even_subjects == MapSet.new([t("zero"), t("two"), t("four")])
+      assert odd_subjects == MapSet.new([t("one"), t("three")])
+    end
+  end
+
+  describe "evaluate/2 — immediate fixpoint" do
+    test "an EDB with no matching facts reaches fixpoint on the first round, unchanged" do
+      {:ok, base} = Parser.decode("ancestor(X, Y) :- parent(X, Y).")
+      {:ok, recursive} = Parser.decode("ancestor(X, Z) :- parent(X, Y), ancestor(Y, Z).")
+
+      graph = RDF.Graph.new()
+
+      assert {:ok, result} = QueryInterpreter.evaluate([base, recursive], graph)
+      assert RDF.Graph.triple_count(result) == 0
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `Riptide.Derivation.QueryInterpreter.evaluate/3` — naive bottom-up fixpoint evaluation over a ruleset (list of Rules), the first piece of Track B and of "QueryInterpretation proper" beyond `Matcher`.
- `Matcher.evaluate/2` stays completely unchanged; `QueryInterpreter` composes it per round.
- Stratification documented as trivially satisfied (no negation exists anywhere in the Literal type system) rather than implemented; termination documented via the finite-Herbrand-universe argument, backed by a configurable `max_iterations`/`max_fact_count` safety bound as defense-in-depth.
- Semi-naive evaluation explicitly deferred as a future optimization — not needed for this phase's own correctness-focused exit criterion.
- Verified against transitive closure (the exit criterion's own example) and mutual recursion across two distinct predicates (even/odd via a successor chain) — proving the algorithm generalizes beyond single-predicate self-recursion.

Implements #62. Spec: `docs/superpowers/specs/2026-08-30-phase-6c-ii-recursion-fixpoint-design.md` (PR #109).

## Test plan
- [x] `mix test` — full suite green
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [x] CI green on the PR