### PR TITLE
Draft: Resolve: "6i — Ontology Crosswalks and Installation"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation) — 7 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation) — 6 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -935,4 +935,67 @@ self-recursion — both non-trivial numeric traces confirmed directly via real e
 being written into the test suite, not just reasoned about.
 
 **Status**: Phase 6c-ii shipped 2026-08-30. 7 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6i — Ontology Crosswalks and Installation
+
+Track A's final link — completes the walking-skeleton-to-Hub arc (6h-i → 6h-ii → 6i). **Shipped
+2026-08-30** — see
+`docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`.
+
+Brainstorming for this phase surfaced a genuine, previously-unaddressed gap: the parent spec's §5
+calls `Provenance` "mandatory" for every Generalization, but no shipped phase (6e-i's
+`AntiUnifier`, 6e-ii's fidelity harness, 6e-iii's DedupGate, 6f's LLM fallback, 6g-i's Discovery)
+had ever actually implemented it as concrete data — closed here generally, not narrowly scoped to
+Install: new `Riptide.Derivation.Provenance` (`origin :: {:generalized_from, Rule.t(), Rule.t()}
+| {:installed_from, source_entry, field_bindings}`), threaded through `Rule.t()` and
+`RuleRDFCodec`, retrofitted into `AntiUnifier.generalize/2` (stamps `:generalized_from`) with a
+matching fix to `substitute/2` (now explicitly clears `provenance: nil` on its reconstructed
+output — the struct-update syntax would otherwise have silently carried the *generalization's*
+own provenance onto the *reconstructed trace*).
+
+New `Riptide.Derivation.Crosswalk` — an SSSOM-shaped `{subject_predicate, object_predicate,
+match_type}` mapping between two predicate IRIs, always Hub-scope, reviewed through the exact same
+`DedupGate`/`PendingCrosswalkReview` authority as any other Hub content (a deliberately simpler
+sibling of `PendingReview` — no Reject/Merge/Admit classification, no fidelity evidence).
+
+`Riptide.Derivation.Install.tenant_vocabulary/1` observes (never declares) a Tenant's vocabulary
+as the union of `reads`/`produces` across that Tenant's own admitted Catalog entries.
+`Install.install/3` rewrites a Hub pattern's `FactPattern` predicates through existing Crosswalks
+into the target Tenant's vocabulary where a mapping exists, leaves anything unmatched in the
+pattern's own native form, and stamps `:installed_from` Provenance recording exactly which fields
+were bound how. `DedupGate.propose_install/3` reuses `classify/2` (Reject/Merge/Admit, unchanged)
+but skips fidelity-replay-testing entirely — not an optimization or a redundancy call, but the
+correct behavior for a structural reason found during brainstorming: 6e-ii's fidelity testing only
+ever re-invokes `CapabilityReference` literals or trusts an `ObserveCapability`'s own recorded
+result; it never inspects `FactPattern` predicates, which is the *only* thing Crosswalk rewriting
+touches. Fidelity-replay-testing was never the right tool for this risk in the first place — the
+installing Tenant's own human review (already mandatory for every Admit/Merge) is the correct and
+sufficient safeguard, so `PendingReview.fidelity_evidence` widens to `[fidelity_evidence()] |
+:not_applicable` rather than gaining a parallel, redundant check.
+
+New HTTP surface mirrors 6h-ii's exact `[:api, :tenant, :auth, :authz]` pipeline and JSON response
+shape: `POST /hub/install`, `POST /hub/crosswalks`, plus **dedicated** approve/decline routes for
+both (`/hub/install-reviews/...`, `/hub/crosswalk-reviews/...`) rather than reusing the existing
+`/hub/pending-reviews/...` routes — a design correction made mid-implementation, after the
+capstone test caught that `ReviewController.approve/2` hardcodes `target_scope: :hub` (correct for
+6h-ii's propose-to-Hub, where target_scope is always `:hub`), which would have silently admitted
+an installed, possibly Crosswalk-rewritten, per-Tenant Rule into the *global* Hub Catalog instead
+of the installing Tenant's own; the spec's own §9 was corrected to match before merging.
+
+Two other latent bugs found and fixed along the way, both exposed only because Provenance now
+makes previously-unreachable data shapes reachable: (1) `CrosswalkRDFCodec`'s match-type
+encode/decode relied on `Atom.to_string/1`/`String.to_existing_atom/1` against atoms that appeared
+nowhere as literals in `lib/` (only in `Crosswalk`'s own `@type`, which typespecs don't reliably
+intern at runtime) — a process that never happened to load a test file mentioning those atoms
+would have hit `not_an_existing_atom` on its very first real decode; fixed with explicit
+case-based encode/decode instead, matching `PendingReview`'s own established pattern. (2) A
+pre-existing `dedup_gate_test.exs` fixture (`ground_greet_trace/3`) stored a `CapabilityReference`
+result as a raw Elixir binary rather than an `RDF.Literal` — harmless while Traces were only ever
+compared in-memory, but once Provenance embeds real ground Traces into Catalog-admitted Rules,
+RDF's lack of a distinct "raw string" primitive meant the round-tripped entry no longer matched
+the original by `==`; fixed by round-tripping the test's own expectation through the same codec
+Catalog itself uses, rather than comparing against the pre-storage struct.
+
+**Status**: Phase 6i shipped 2026-08-30. 6 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/anti_unifier.ex
+++ b/lib/riptide/derivation/anti_unifier.ex
@@ -12,7 +12,7 @@ defmodule Riptide.Derivation.AntiUnifier do
   """
 
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
-  alias Riptide.Derivation.{Rule, Signature, Var}
+  alias Riptide.Derivation.{Provenance, Rule, Signature, Var}
 
   @max_body_length 32
 
@@ -32,7 +32,12 @@ defmodule Riptide.Derivation.AntiUnifier do
         |> alignments(rule2.body)
         |> Enum.map(&build_candidate(rule1.head, rule2.head, &1, existing_var_names))
 
-      {:ok, narrow_by_variable_count(candidates)}
+      provenance = %Provenance{origin: {:generalized_from, rule1, rule2}}
+
+      {:ok,
+       candidates
+       |> narrow_by_variable_count()
+       |> Enum.map(fn {rule, sub1, sub2} -> {%{rule | provenance: provenance}, sub1, sub2} end)}
     end
   end
 
@@ -259,7 +264,8 @@ defmodule Riptide.Derivation.AntiUnifier do
         signature: %{
           signature
           | parameters: Enum.map(signature.parameters, &substitute_term(&1, substitution))
-        }
+        },
+        provenance: nil
     }
   end
 

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -8,7 +8,16 @@ defmodule Riptide.Derivation.Catalog do
   §4.
   """
 
-  alias Riptide.Derivation.{DedupGate, Matcher, Rule, RuleRDFCodec, Var}
+  alias Riptide.Derivation.{
+    Crosswalk,
+    CrosswalkRDFCodec,
+    DedupGate,
+    Matcher,
+    Rule,
+    RuleRDFCodec,
+    Var
+  }
+
   alias Riptide.Derivation.Literal.FactPattern
   alias Riptide.Event
   alias Riptide.Placement
@@ -20,6 +29,7 @@ defmodule Riptide.Derivation.Catalog do
   @riptide_catalog_entry RDF.iri("urn:riptide:vocab:CatalogEntry")
   @riptide_superseded_catalog_entry RDF.iri("urn:riptide:vocab:SupersededCatalogEntry")
   @riptide_supersedes RDF.iri("urn:riptide:vocab:supersedes")
+  @riptide_crosswalk RDF.iri("urn:riptide:vocab:Crosswalk")
 
   @type scope :: {:tenant, String.t()} | :hub
 
@@ -31,6 +41,9 @@ defmodule Riptide.Derivation.Catalog do
 
   @spec pending_review_stream_id(scope()) :: String.t()
   def pending_review_stream_id(scope), do: catalog_stream_id(scope) <> "/pending-review"
+
+  @spec crosswalk_stream_id() :: String.t()
+  def crosswalk_stream_id, do: catalog_stream_id(:hub) <> "/crosswalks"
 
   @spec list_entries(scope()) :: {:ok, [{RDF.BlankNode.t(), Rule.t()}]} | {:error, :not_ready}
   def list_entries(scope) do
@@ -64,6 +77,20 @@ defmodule Riptide.Derivation.Catalog do
       [{node, @rdf_type, @riptide_superseded_catalog_entry}],
       [{node, @rdf_type, @riptide_catalog_entry}]
     )
+  end
+
+  @spec admit_crosswalk(Crosswalk.t()) :: :ok | {:error, :not_ready}
+  def admit_crosswalk(%Crosswalk{} = crosswalk) do
+    {_node, crosswalk_graph} = CrosswalkRDFCodec.to_rdf(crosswalk)
+    write_patch(crosswalk_stream_id(), RDF.Graph.triples(crosswalk_graph), [])
+  end
+
+  @spec list_crosswalks() :: {:ok, [{RDF.BlankNode.t(), Crosswalk.t()}]} | {:error, :not_ready}
+  def list_crosswalks do
+    with {:ok, graph} <- read_graph(crosswalk_stream_id()) do
+      nodes = nodes_of_type(graph, @riptide_crosswalk)
+      {:ok, Enum.map(nodes, &{&1, CrosswalkRDFCodec.from_rdf(&1, graph)})}
+    end
   end
 
   defp nodes_of_type(graph, type_iri) do

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -30,6 +30,10 @@ defmodule Riptide.Derivation.Catalog do
   @riptide_superseded_catalog_entry RDF.iri("urn:riptide:vocab:SupersededCatalogEntry")
   @riptide_supersedes RDF.iri("urn:riptide:vocab:supersedes")
   @riptide_crosswalk RDF.iri("urn:riptide:vocab:Crosswalk")
+  @riptide_pending_crosswalk_review RDF.iri("urn:riptide:vocab:PendingCrosswalkReview")
+  @riptide_resolved_pending_crosswalk_review RDF.iri(
+                                               "urn:riptide:vocab:ResolvedPendingCrosswalkReview"
+                                             )
 
   @type scope :: {:tenant, String.t()} | :hub
 
@@ -91,6 +95,36 @@ defmodule Riptide.Derivation.Catalog do
       nodes = nodes_of_type(graph, @riptide_crosswalk)
       {:ok, Enum.map(nodes, &{&1, CrosswalkRDFCodec.from_rdf(&1, graph)})}
     end
+  end
+
+  @spec queue_crosswalk_review(scope(), DedupGate.PendingCrosswalkReview.t()) ::
+          {:ok, RDF.BlankNode.t()} | {:error, :not_ready}
+  def queue_crosswalk_review(scope, %DedupGate.PendingCrosswalkReview{} = pending) do
+    {node, graph} = DedupGate.PendingCrosswalkReview.to_rdf(pending)
+
+    case write_patch(pending_review_stream_id(scope), RDF.Graph.triples(graph), []) do
+      :ok -> {:ok, node}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec list_crosswalk_pending_reviews(scope()) ::
+          {:ok, [{RDF.BlankNode.t(), DedupGate.PendingCrosswalkReview.t()}]}
+          | {:error, :not_ready}
+  def list_crosswalk_pending_reviews(scope) do
+    with {:ok, graph} <- read_graph(pending_review_stream_id(scope)) do
+      nodes = nodes_of_type(graph, @riptide_pending_crosswalk_review)
+      {:ok, Enum.map(nodes, &{&1, DedupGate.PendingCrosswalkReview.from_rdf(&1, graph)})}
+    end
+  end
+
+  @spec resolve_crosswalk_review(scope(), RDF.BlankNode.t()) :: :ok | {:error, :not_ready}
+  def resolve_crosswalk_review(scope, node) do
+    write_patch(
+      pending_review_stream_id(scope),
+      [{node, @rdf_type, @riptide_resolved_pending_crosswalk_review}],
+      [{node, @rdf_type, @riptide_pending_crosswalk_review}]
+    )
   end
 
   defp nodes_of_type(graph, type_iri) do

--- a/lib/riptide/derivation/crosswalk.ex
+++ b/lib/riptide/derivation/crosswalk.ex
@@ -1,0 +1,21 @@
+defmodule Riptide.Derivation.Crosswalk do
+  @moduledoc """
+  An SSSOM-shaped mapping between two predicate IRIs (design spec
+  `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
+  §6). Same-Dialect signature-morphism translation only — see that
+  spec's own §3 for why cross-Dialect comorphisms are out of scope.
+  Always Hub-scope content (§6.5): a Crosswalk has no `scope()` of its
+  own anywhere in this module's API.
+  """
+
+  @type match_type :: :exact_match | :close_match | :broad_match | :narrow_match | :related_match
+
+  @enforce_keys [:subject_predicate, :object_predicate, :match_type]
+  defstruct [:subject_predicate, :object_predicate, :match_type]
+
+  @type t :: %__MODULE__{
+          subject_predicate: RDF.IRI.t(),
+          object_predicate: RDF.IRI.t(),
+          match_type: match_type()
+        }
+end

--- a/lib/riptide/derivation/crosswalk_rdf_codec.ex
+++ b/lib/riptide/derivation/crosswalk_rdf_codec.ex
@@ -23,26 +23,41 @@ defmodule Riptide.Derivation.CrosswalkRDFCodec do
       |> RDF.Graph.add({node, @riptide_subject_predicate, crosswalk.subject_predicate})
       |> RDF.Graph.add({node, @riptide_object_predicate, crosswalk.object_predicate})
       |> RDF.Graph.add(
-        {node, @riptide_match_type, RDF.literal(Atom.to_string(crosswalk.match_type))}
+        {node, @riptide_match_type, RDF.literal(encode_match_type(crosswalk.match_type))}
       )
 
     {node, graph}
   end
 
+  # Explicit case matching, not Atom.to_string/String.to_existing_atom: the
+  # 5 match-type atoms otherwise appear nowhere as literals in `lib/` (only
+  # in `Crosswalk`'s own `@type`, which typespecs don't reliably intern at
+  # runtime) — a process that never happens to load a test file mentioning
+  # them would hit `String.to_existing_atom/1: not an already existing atom`
+  # on the very first decode. Writing the atoms as literals directly in this
+  # module's own compiled code guarantees they exist whenever this module
+  # does.
+  defp encode_match_type(:exact_match), do: "exact_match"
+  defp encode_match_type(:close_match), do: "close_match"
+  defp encode_match_type(:broad_match), do: "broad_match"
+  defp encode_match_type(:narrow_match), do: "narrow_match"
+  defp encode_match_type(:related_match), do: "related_match"
+
+  defp decode_match_type("exact_match"), do: :exact_match
+  defp decode_match_type("close_match"), do: :close_match
+  defp decode_match_type("broad_match"), do: :broad_match
+  defp decode_match_type("narrow_match"), do: :narrow_match
+  defp decode_match_type("related_match"), do: :related_match
+
   @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: Crosswalk.t()
   def from_rdf(node, graph) do
     description = RDF.Graph.get(graph, node)
 
-    # Safe: the 5 SSSOM match-type strings are the only values `to_rdf/1`
-    # ever writes, and all 5 atoms already exist in the atom table from
-    # this module's own `@type match_type` usage — never derived from
-    # untrusted input (mirrors PendingReview.from_rdf/2's identical
-    # `String.to_existing_atom/1` safety argument).
     match_type =
       description
       |> RDF.Description.first(@riptide_match_type)
       |> RDF.Literal.value()
-      |> String.to_existing_atom()
+      |> decode_match_type()
 
     %Crosswalk{
       subject_predicate: RDF.Description.first(description, @riptide_subject_predicate),

--- a/lib/riptide/derivation/crosswalk_rdf_codec.ex
+++ b/lib/riptide/derivation/crosswalk_rdf_codec.ex
@@ -1,0 +1,53 @@
+defmodule Riptide.Derivation.CrosswalkRDFCodec do
+  @moduledoc """
+  Reifies a `Riptide.Derivation.Crosswalk` as RDF triples and reads it
+  back, following the exact same reification style
+  `Riptide.Derivation.RuleRDFCodec` already established.
+  """
+
+  alias Riptide.Derivation.Crosswalk
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_crosswalk RDF.iri("urn:riptide:vocab:Crosswalk")
+  @riptide_subject_predicate RDF.iri("urn:riptide:vocab:subjectPredicate")
+  @riptide_object_predicate RDF.iri("urn:riptide:vocab:objectPredicate")
+  @riptide_match_type RDF.iri("urn:riptide:vocab:matchType")
+
+  @spec to_rdf(Crosswalk.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%Crosswalk{} = crosswalk) do
+    node = RDF.BlankNode.new()
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add({node, @rdf_type, @riptide_crosswalk})
+      |> RDF.Graph.add({node, @riptide_subject_predicate, crosswalk.subject_predicate})
+      |> RDF.Graph.add({node, @riptide_object_predicate, crosswalk.object_predicate})
+      |> RDF.Graph.add(
+        {node, @riptide_match_type, RDF.literal(Atom.to_string(crosswalk.match_type))}
+      )
+
+    {node, graph}
+  end
+
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: Crosswalk.t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+
+    # Safe: the 5 SSSOM match-type strings are the only values `to_rdf/1`
+    # ever writes, and all 5 atoms already exist in the atom table from
+    # this module's own `@type match_type` usage — never derived from
+    # untrusted input (mirrors PendingReview.from_rdf/2's identical
+    # `String.to_existing_atom/1` safety argument).
+    match_type =
+      description
+      |> RDF.Description.first(@riptide_match_type)
+      |> RDF.Literal.value()
+      |> String.to_existing_atom()
+
+    %Crosswalk{
+      subject_predicate: RDF.Description.first(description, @riptide_subject_predicate),
+      object_predicate: RDF.Description.first(description, @riptide_object_predicate),
+      match_type: match_type
+    }
+  end
+end

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -17,7 +17,7 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
   @type t :: %__MODULE__{
           kind: kind(),
           candidate: Rule.t(),
-          fidelity_evidence: [fidelity_evidence()],
+          fidelity_evidence: [fidelity_evidence()] | :not_applicable,
           replaces: RDF.BlankNode.t() | nil
         }
 
@@ -26,6 +26,7 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
   @riptide_kind RDF.iri("urn:riptide:vocab:kind")
   @riptide_candidate RDF.iri("urn:riptide:vocab:candidate")
   @riptide_fidelity_evidence RDF.iri("urn:riptide:vocab:fidelityEvidence")
+  @riptide_fidelity_not_applicable RDF.iri("urn:riptide:vocab:FidelityNotApplicable")
   @riptide_fidelity_status RDF.iri("urn:riptide:vocab:fidelityStatus")
   @riptide_fidelity_reason RDF.iri("urn:riptide:vocab:fidelityReason")
   @riptide_replaces RDF.iri("urn:riptide:vocab:replaces")
@@ -54,6 +55,11 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
 
   defp maybe_add_replaces(graph, node, replaces),
     do: RDF.Graph.add(graph, {node, @riptide_replaces, replaces})
+
+  defp encode_evidence(:not_applicable) do
+    node = RDF.BlankNode.new()
+    {node, RDF.Graph.new() |> RDF.Graph.add({node, @rdf_type, @riptide_fidelity_not_applicable})}
+  end
 
   defp encode_evidence(evidence_list) do
     {nodes, graph} =
@@ -101,11 +107,7 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
     candidate_node = RDF.Description.first(description, @riptide_candidate)
     candidate = RuleRDFCodec.from_rdf(candidate_node, graph)
     evidence_head = RDF.Description.first(description, @riptide_fidelity_evidence)
-
-    fidelity_evidence =
-      RDF.List.new(evidence_head, graph)
-      |> RDF.List.values()
-      |> Enum.map(&decode_one_evidence(&1, graph))
+    fidelity_evidence = decode_evidence(evidence_head, graph)
 
     replaces = RDF.Description.first(description, @riptide_replaces)
 
@@ -115,6 +117,20 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
       fidelity_evidence: fidelity_evidence,
       replaces: replaces
     }
+  end
+
+  defp decode_evidence(node, graph) do
+    description = RDF.Graph.get(graph, node)
+
+    case RDF.Description.first(description, @rdf_type) do
+      @riptide_fidelity_not_applicable ->
+        :not_applicable
+
+      _other ->
+        RDF.List.new(node, graph)
+        |> RDF.List.values()
+        |> Enum.map(&decode_one_evidence(&1, graph))
+    end
   end
 
   defp decode_one_evidence(node, graph) do
@@ -205,6 +221,28 @@ defmodule Riptide.Derivation.DedupGate do
 
       {:error, evidence} ->
         {:fidelity_failed, evidence}
+    end
+  end
+
+  @spec propose_install(Catalog.scope(), Catalog.scope(), Rule.t()) ::
+          {:ok, outcome()} | {:error, term()}
+  def propose_install(target_scope, review_scope, %Rule{} = installed_rule) do
+    with {:ok, entries} <- Catalog.list_entries(target_scope) do
+      case classify(installed_rule, entries) do
+        {:reject, reason} ->
+          {:ok, {:rejected, reason}}
+
+        {kind, replaces} ->
+          pending_review = %PendingReview{
+            kind: kind,
+            candidate: installed_rule,
+            fidelity_evidence: :not_applicable,
+            replaces: replaces
+          }
+
+          {:ok, node} = Catalog.queue_pending_review(review_scope, pending_review)
+          {:ok, {:queued, node, kind}}
+      end
     end
   end
 

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -150,6 +150,49 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
   end
 end
 
+defmodule Riptide.Derivation.DedupGate.PendingCrosswalkReview do
+  @moduledoc """
+  A proposed Crosswalk awaiting the proposing Tenant's own review (design
+  spec `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
+  §6). Deliberately much simpler than `PendingReview` — a Crosswalk has no
+  `kind`/`replaces` (no Reject/Merge/Admit classification against existing
+  Crosswalks; out of scope, spec §3) and no fidelity evidence (never
+  applicable to a Crosswalk in the first place, same reasoning as
+  `PendingReview.fidelity_evidence`'s own `:not_applicable` case).
+  """
+
+  alias Riptide.Derivation.{Crosswalk, CrosswalkRDFCodec}
+
+  @enforce_keys [:candidate]
+  defstruct [:candidate]
+
+  @type t :: %__MODULE__{candidate: Crosswalk.t()}
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_pending_crosswalk_review RDF.iri("urn:riptide:vocab:PendingCrosswalkReview")
+  @riptide_candidate RDF.iri("urn:riptide:vocab:candidate")
+
+  @spec to_rdf(t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%__MODULE__{candidate: candidate}) do
+    node = RDF.BlankNode.new()
+    {candidate_node, candidate_graph} = CrosswalkRDFCodec.to_rdf(candidate)
+
+    graph =
+      candidate_graph
+      |> RDF.Graph.add({node, @rdf_type, @riptide_pending_crosswalk_review})
+      |> RDF.Graph.add({node, @riptide_candidate, candidate_node})
+
+    {node, graph}
+  end
+
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+    candidate_node = RDF.Description.first(description, @riptide_candidate)
+    %__MODULE__{candidate: CrosswalkRDFCodec.from_rdf(candidate_node, graph)}
+  end
+end
+
 defmodule Riptide.Derivation.DedupGate do
   @moduledoc """
   Catalog lookup, the `Reject`/`Merge`/`Admit` decision, and the human
@@ -157,8 +200,8 @@ defmodule Riptide.Derivation.DedupGate do
   `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`.
   """
 
-  alias Riptide.Derivation.{AntiUnifier, Catalog, GeneralizationFidelity, Rule, Var}
-  alias Riptide.Derivation.DedupGate.PendingReview
+  alias Riptide.Derivation.{AntiUnifier, Catalog, Crosswalk, GeneralizationFidelity, Rule, Var}
+  alias Riptide.Derivation.DedupGate.{PendingCrosswalkReview, PendingReview}
   alias Riptide.Derivation.ExecuteInterpreter.Context
 
   @type candidates :: [{Rule.t(), AntiUnifier.substitution(), AntiUnifier.substitution()}]
@@ -245,6 +288,28 @@ defmodule Riptide.Derivation.DedupGate do
       end
     end
   end
+
+  @spec propose_crosswalk(Catalog.scope(), Crosswalk.t()) ::
+          {:ok, RDF.BlankNode.t()} | {:error, term()}
+  def propose_crosswalk(review_scope, %Crosswalk{} = crosswalk) do
+    Catalog.queue_crosswalk_review(review_scope, %PendingCrosswalkReview{candidate: crosswalk})
+  end
+
+  @spec approve_crosswalk_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
+  def approve_crosswalk_review(review_scope, node) do
+    with {:ok, pending_reviews} <- Catalog.list_crosswalk_pending_reviews(review_scope),
+         {_node, pending} <- List.keyfind(pending_reviews, node, 0, :not_found) do
+      :ok = Catalog.admit_crosswalk(pending.candidate)
+      Catalog.resolve_crosswalk_review(review_scope, node)
+    else
+      :not_found -> {:error, :not_found}
+      error -> error
+    end
+  end
+
+  @spec decline_crosswalk_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
+  def decline_crosswalk_review(review_scope, node),
+    do: Catalog.resolve_crosswalk_review(review_scope, node)
 
   defp classify(candidate, entries) do
     matching =

--- a/lib/riptide/derivation/install.ex
+++ b/lib/riptide/derivation/install.ex
@@ -1,0 +1,100 @@
+defmodule Riptide.Derivation.Install do
+  @moduledoc """
+  Installing a Hub Pattern into a Tenant with partial vocabulary overlap
+  (design spec
+  `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
+  §7, §8).
+  """
+
+  alias Riptide.Derivation.{Catalog, Provenance, Rule}
+  alias Riptide.Derivation.Literal.FactPattern
+
+  @doc """
+  A Tenant's vocabulary is observed, not declared (design spec §7,
+  parent spec §3.1) — the union of every predicate IRI already appearing
+  in `reads`/`produces` across that Tenant's own admitted Catalog
+  entries.
+  """
+  @spec tenant_vocabulary(String.t()) :: MapSet.t(RDF.IRI.t())
+  def tenant_vocabulary(tenant_id) do
+    {:ok, entries} = Catalog.list_entries({:tenant, tenant_id})
+
+    entries
+    |> Enum.flat_map(fn {_node, rule} -> rule.signature.reads ++ rule.signature.produces end)
+    |> MapSet.new()
+  end
+
+  @doc """
+  Rewrites `pattern`'s predicates through existing Crosswalks into
+  `tenant_id`'s own vocabulary where possible, leaving anything
+  unmatched in the pattern's own native form, and stamps `:installed_from`
+  Provenance recording exactly which fields were bound how (design spec
+  §8).
+  """
+  @spec install(RDF.BlankNode.t(), Rule.t(), String.t()) ::
+          {Rule.t(), [Provenance.field_binding()]}
+  def install(hub_entry_node, %Rule{} = pattern, tenant_id) do
+    vocabulary = tenant_vocabulary(tenant_id)
+    {:ok, crosswalks} = Catalog.list_crosswalks()
+    predicates = pattern.signature.reads ++ pattern.signature.produces
+
+    {rewrites, field_bindings} =
+      Enum.reduce(predicates, {%{}, []}, fn predicate, {rewrites, bindings} ->
+        cond do
+          MapSet.member?(vocabulary, predicate) ->
+            {rewrites, bindings}
+
+          match = find_crosswalk(crosswalks, predicate, vocabulary) ->
+            {crosswalk_node, target_predicate} = match
+
+            {Map.put(rewrites, predicate, target_predicate),
+             [%{predicate: predicate, binding: {:crosswalk, crosswalk_node}} | bindings]}
+
+          true ->
+            {rewrites, [%{predicate: predicate, binding: :manual} | bindings]}
+        end
+      end)
+
+    field_bindings = Enum.reverse(field_bindings)
+
+    installed_rule = %{
+      rewrite_predicates(pattern, rewrites)
+      | provenance: %Provenance{origin: {:installed_from, hub_entry_node, field_bindings}}
+    }
+
+    {installed_rule, field_bindings}
+  end
+
+  defp find_crosswalk(crosswalks, predicate, vocabulary) do
+    Enum.find_value(crosswalks, fn {node, crosswalk} ->
+      cond do
+        crosswalk.subject_predicate == predicate and
+            MapSet.member?(vocabulary, crosswalk.object_predicate) ->
+          {node, crosswalk.object_predicate}
+
+        crosswalk.object_predicate == predicate and
+            MapSet.member?(vocabulary, crosswalk.subject_predicate) ->
+          {node, crosswalk.subject_predicate}
+
+        true ->
+          nil
+      end
+    end)
+  end
+
+  defp rewrite_predicates(%Rule{} = rule, rewrites) when map_size(rewrites) == 0, do: rule
+
+  defp rewrite_predicates(%Rule{} = rule, rewrites) do
+    %{
+      rule
+      | head: rewrite_literal(rule.head, rewrites),
+        body: Enum.map(rule.body, &rewrite_literal(&1, rewrites))
+    }
+  end
+
+  defp rewrite_literal(%FactPattern{predicate: predicate} = literal, rewrites) do
+    %{literal | predicate: Map.get(rewrites, predicate, predicate)}
+  end
+
+  defp rewrite_literal(literal, _rewrites), do: literal
+end

--- a/lib/riptide/derivation/provenance.ex
+++ b/lib/riptide/derivation/provenance.ex
@@ -1,0 +1,28 @@
+defmodule Riptide.Derivation.Provenance do
+  @moduledoc """
+  The dependency edge back to what a Rule was generalized or installed
+  from (design spec `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md`
+  §5). A general, reusable concept from the start: `AntiUnifier.generalize/2`
+  stamps `:generalized_from`; Install (`Riptide.Derivation.Install`) stamps
+  `:installed_from`. See design spec
+  `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
+  §4 for why this lives directly on `Rule.t()` rather than a separate store.
+  """
+
+  alias Riptide.Derivation.Rule
+
+  @type field_binding :: %{
+          predicate: RDF.IRI.t(),
+          binding: {:crosswalk, crosswalk_node :: RDF.BlankNode.t()} | :manual
+        }
+
+  @type origin ::
+          {:generalized_from, source1 :: Rule.t(), source2 :: Rule.t()}
+          | {:installed_from, source_entry :: RDF.BlankNode.t(),
+             field_bindings :: [field_binding()]}
+
+  @enforce_keys [:origin]
+  defstruct [:origin]
+
+  @type t :: %__MODULE__{origin: origin()}
+end

--- a/lib/riptide/derivation/rule.ex
+++ b/lib/riptide/derivation/rule.ex
@@ -7,16 +7,17 @@ defmodule Riptide.Derivation.Rule do
   """
 
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
-  alias Riptide.Derivation.Signature
+  alias Riptide.Derivation.{Provenance, Signature}
 
   @enforce_keys [:signature, :head, :body]
-  defstruct [:signature, :head, :body]
+  defstruct [:signature, :head, :body, :provenance]
 
   @type literal :: FactPattern.t() | CapabilityReference.t() | RuleReference.t()
 
   @type t :: %__MODULE__{
           signature: Signature.t(),
           head: FactPattern.t(),
-          body: [literal()]
+          body: [literal()],
+          provenance: Provenance.t() | nil
         }
 end

--- a/lib/riptide/derivation/rule_rdf_codec.ex
+++ b/lib/riptide/derivation/rule_rdf_codec.ex
@@ -13,7 +13,7 @@ defmodule Riptide.Derivation.RuleRDFCodec do
   """
 
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
-  alias Riptide.Derivation.{Rule, Signature, Var}
+  alias Riptide.Derivation.{Provenance, Rule, Signature, Var}
 
   @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
   @sp_triple_pattern RDF.iri("http://spinrdf.org/sp#TriplePattern")
@@ -43,6 +43,18 @@ defmodule Riptide.Derivation.RuleRDFCodec do
   @riptide_name RDF.iri("urn:riptide:vocab:name")
   @riptide_parameters RDF.iri("urn:riptide:vocab:parameters")
 
+  @riptide_provenance RDF.iri("urn:riptide:vocab:provenance")
+  @riptide_generalized_from RDF.iri("urn:riptide:vocab:GeneralizedFrom")
+  @riptide_installed_from RDF.iri("urn:riptide:vocab:InstalledFrom")
+  @riptide_source1 RDF.iri("urn:riptide:vocab:source1")
+  @riptide_source2 RDF.iri("urn:riptide:vocab:source2")
+  @riptide_source_entry RDF.iri("urn:riptide:vocab:sourceEntry")
+  @riptide_field_bindings RDF.iri("urn:riptide:vocab:fieldBindings")
+  @riptide_field_binding RDF.iri("urn:riptide:vocab:FieldBinding")
+  @riptide_binding_predicate RDF.iri("urn:riptide:vocab:bindingPredicate")
+  @riptide_binding_kind RDF.iri("urn:riptide:vocab:bindingKind")
+  @riptide_binding_crosswalk RDF.iri("urn:riptide:vocab:bindingCrosswalk")
+
   @doc "See moduledoc. Returns the Rule's own (blank) node plus the graph fragment reifying it."
   @spec to_rdf(Rule.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
   def to_rdf(%Rule{} = rule) do
@@ -60,6 +72,80 @@ defmodule Riptide.Derivation.RuleRDFCodec do
       |> RDF.Graph.add({node, @riptide_signature, sig_node})
       |> RDF.Graph.add({node, @riptide_head, head_node})
       |> RDF.Graph.add({node, @riptide_body, body_head})
+      |> maybe_add_provenance(node, rule.provenance)
+
+    {node, graph}
+  end
+
+  defp maybe_add_provenance(graph, _node, nil), do: graph
+
+  defp maybe_add_provenance(graph, node, %Provenance{} = provenance) do
+    {prov_node, prov_graph} = encode_provenance(provenance)
+    graph |> RDF.Graph.add(prov_graph) |> RDF.Graph.add({node, @riptide_provenance, prov_node})
+  end
+
+  defp encode_provenance(%Provenance{origin: {:generalized_from, source1, source2}}) do
+    node = RDF.BlankNode.new()
+    {source1_node, source1_graph} = to_rdf(source1)
+    {source2_node, source2_graph} = to_rdf(source2)
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add(source1_graph)
+      |> RDF.Graph.add(source2_graph)
+      |> RDF.Graph.add({node, @rdf_type, @riptide_generalized_from})
+      |> RDF.Graph.add({node, @riptide_source1, source1_node})
+      |> RDF.Graph.add({node, @riptide_source2, source2_node})
+
+    {node, graph}
+  end
+
+  defp encode_provenance(%Provenance{origin: {:installed_from, source_entry, field_bindings}}) do
+    node = RDF.BlankNode.new()
+    {bindings_head, bindings_graph} = encode_field_bindings(field_bindings)
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add(bindings_graph)
+      |> RDF.Graph.add({node, @rdf_type, @riptide_installed_from})
+      |> RDF.Graph.add({node, @riptide_source_entry, source_entry})
+      |> RDF.Graph.add({node, @riptide_field_bindings, bindings_head})
+
+    {node, graph}
+  end
+
+  defp encode_field_bindings(field_bindings) do
+    {nodes, graph} =
+      Enum.reduce(field_bindings, {[], RDF.Graph.new()}, fn binding, {acc, graph} ->
+        {node, binding_graph} = encode_field_binding(binding)
+        {[node | acc], RDF.Graph.add(graph, binding_graph)}
+      end)
+
+    list = RDF.List.from(Enum.reverse(nodes))
+    {list.head, RDF.Graph.add(graph, list.graph)}
+  end
+
+  defp encode_field_binding(%{predicate: predicate, binding: :manual}) do
+    node = RDF.BlankNode.new()
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add({node, @rdf_type, @riptide_field_binding})
+      |> RDF.Graph.add({node, @riptide_binding_predicate, predicate})
+      |> RDF.Graph.add({node, @riptide_binding_kind, RDF.literal("manual")})
+
+    {node, graph}
+  end
+
+  defp encode_field_binding(%{predicate: predicate, binding: {:crosswalk, crosswalk_node}}) do
+    node = RDF.BlankNode.new()
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add({node, @rdf_type, @riptide_field_binding})
+      |> RDF.Graph.add({node, @riptide_binding_predicate, predicate})
+      |> RDF.Graph.add({node, @riptide_binding_kind, RDF.literal("crosswalk")})
+      |> RDF.Graph.add({node, @riptide_binding_crosswalk, crosswalk_node})
 
     {node, graph}
   end
@@ -221,8 +307,54 @@ defmodule Riptide.Derivation.RuleRDFCodec do
     %Rule{
       signature: decode_signature(sig_node, graph, head, body),
       head: head,
-      body: body
+      body: body,
+      provenance:
+        decode_provenance(RDF.Description.first(description, @riptide_provenance), graph)
     }
+  end
+
+  defp decode_provenance(nil, _graph), do: nil
+
+  defp decode_provenance(prov_node, graph) do
+    description = RDF.Graph.get(graph, prov_node)
+
+    origin =
+      case RDF.Description.first(description, @rdf_type) do
+        @riptide_generalized_from ->
+          source1 = from_rdf(RDF.Description.first(description, @riptide_source1), graph)
+          source2 = from_rdf(RDF.Description.first(description, @riptide_source2), graph)
+          {:generalized_from, source1, source2}
+
+        @riptide_installed_from ->
+          source_entry = RDF.Description.first(description, @riptide_source_entry)
+          bindings_head = RDF.Description.first(description, @riptide_field_bindings)
+
+          field_bindings =
+            RDF.List.new(bindings_head, graph)
+            |> RDF.List.values()
+            |> Enum.map(&decode_field_binding(&1, graph))
+
+          {:installed_from, source_entry, field_bindings}
+      end
+
+    %Provenance{origin: origin}
+  end
+
+  defp decode_field_binding(node, graph) do
+    description = RDF.Graph.get(graph, node)
+    predicate = RDF.Description.first(description, @riptide_binding_predicate)
+    kind = description |> RDF.Description.first(@riptide_binding_kind) |> RDF.Literal.value()
+
+    binding =
+      case kind do
+        "manual" ->
+          :manual
+
+        "crosswalk" ->
+          {:crosswalk, RDF.Description.first(description, @riptide_binding_crosswalk)}
+      end
+
+    %{predicate: predicate, binding: binding}
   end
 
   # `reads`/`produces` are re-derived from the already-decoded `head`/`body`

--- a/lib/riptide_web/hub/crosswalk_controller.ex
+++ b/lib/riptide_web/hub/crosswalk_controller.ex
@@ -1,0 +1,89 @@
+defmodule RiptideWeb.Hub.CrosswalkController do
+  @moduledoc """
+  Propose a Crosswalk and approve/decline it, mirroring
+  `RiptideWeb.Hub.ProposeController`/`ReviewController`'s exact shape
+  (design spec
+  `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
+  §9).
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{Crosswalk, DedupGate}
+
+  def propose(conn, params) do
+    tenant_id = conn.assigns.tenant_id
+
+    case Riptide.HubRateLimit.check_propose(tenant_id) do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_propose(conn, tenant_id, params)
+    end
+  end
+
+  defp handle_propose(
+         conn,
+         tenant_id,
+         %{
+           "subject_predicate" => subject_predicate,
+           "object_predicate" => object_predicate,
+           "match_type" => match_type_string
+         }
+       ) do
+    case parse_match_type(match_type_string) do
+      nil ->
+        send_resp(conn, 400, "")
+
+      match_type ->
+        crosswalk = %Crosswalk{
+          subject_predicate: RDF.iri(subject_predicate),
+          object_predicate: RDF.iri(object_predicate),
+          match_type: match_type
+        }
+
+        case DedupGate.propose_crosswalk({:tenant, tenant_id}, crosswalk) do
+          {:ok, node} ->
+            body =
+              Jason.encode!(%{"outcome" => "queued", "node_id" => RDF.BlankNode.value(node)})
+
+            conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+          {:error, _reason} ->
+            send_resp(conn, 503, "")
+        end
+    end
+  end
+
+  defp handle_propose(conn, _tenant_id, _params), do: send_resp(conn, 400, "")
+
+  # Explicit case matching, not String.to_existing_atom/1: these atoms
+  # otherwise appear nowhere as literals in `lib/` (only in `Crosswalk`'s
+  # own `@type`, which typespecs don't reliably intern at runtime) — see
+  # `CrosswalkRDFCodec`'s identical `decode_match_type/1` for the full
+  # reasoning.
+  defp parse_match_type("exact_match"), do: :exact_match
+  defp parse_match_type("close_match"), do: :close_match
+  defp parse_match_type("broad_match"), do: :broad_match
+  defp parse_match_type("narrow_match"), do: :narrow_match
+  defp parse_match_type("related_match"), do: :related_match
+  defp parse_match_type(_other), do: nil
+
+  def approve(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.approve_crosswalk_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+
+  def decline(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.decline_crosswalk_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+end

--- a/lib/riptide_web/hub/install_controller.ex
+++ b/lib/riptide_web/hub/install_controller.ex
@@ -1,0 +1,93 @@
+defmodule RiptideWeb.Hub.InstallController do
+  @moduledoc """
+  Install a Hub entry into the requesting Tenant's own Catalog (design
+  spec
+  `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
+  §9). `target_scope`/`review_scope` are always the same
+  `{:tenant, tenant_id}` — installation writes into and is reviewed by
+  the installing Tenant's own Catalog, never `:hub`. Approval/decline
+  live on this controller too (`/hub/install-reviews/:node_id/...`), not
+  `RiptideWeb.Hub.ReviewController` — see `approve/2`'s own doc for why.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{Catalog, DedupGate, Install}
+
+  def install(conn, %{"hub_node_id" => hub_node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case Riptide.HubRateLimit.check_propose(tenant_id) do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_install(conn, tenant_id, hub_node_id)
+    end
+  end
+
+  def install(conn, _params), do: send_resp(conn, 400, "")
+
+  @doc """
+  Approve/decline an install-created pending review. Deliberately a
+  *separate* route from `RiptideWeb.Hub.ReviewController`'s
+  `/hub/pending-reviews/:node_id/approve` — that controller hardcodes
+  `target_scope: :hub` (correct for 6h-ii's Hub-propose flow, where
+  target_scope is always `:hub` regardless of review_scope), which would
+  silently admit an installed, possibly Crosswalk-rewritten, per-Tenant
+  Rule into the *global* Hub catalog instead of the installing Tenant's
+  own — Install's target_scope is always `{:tenant, tenant_id}` (§9).
+  """
+  def approve(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+    scope = {:tenant, tenant_id}
+
+    case DedupGate.approve_review(scope, scope, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+
+  def decline(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.decline_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+
+  defp handle_install(conn, tenant_id, hub_node_id) do
+    {:ok, hub_entries} = Catalog.list_entries(:hub)
+
+    found =
+      Enum.find(hub_entries, fn {node, _rule} -> RDF.BlankNode.value(node) == hub_node_id end)
+
+    case found do
+      nil ->
+        send_resp(conn, 404, "")
+
+      {hub_node, pattern} ->
+        {installed_rule, _field_bindings} = Install.install(hub_node, pattern, tenant_id)
+        scope = {:tenant, tenant_id}
+
+        case DedupGate.propose_install(scope, scope, installed_rule) do
+          {:ok, {:queued, node, kind}} ->
+            body =
+              Jason.encode!(%{
+                "outcome" => "queued",
+                "kind" => Atom.to_string(kind),
+                "node_id" => RDF.BlankNode.value(node)
+              })
+
+            conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+          {:ok, {:rejected, reason}} ->
+            body = Jason.encode!(%{"outcome" => "rejected", "reason" => inspect(reason)})
+            conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+          {:error, _reason} ->
+            send_resp(conn, 503, "")
+        end
+    end
+  end
+end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -59,5 +59,12 @@ defmodule RiptideWeb.Router do
     post "/hub/propose", RiptideWeb.Hub.ProposeController, :propose
     post "/hub/pending-reviews/:node_id/approve", RiptideWeb.Hub.ReviewController, :approve
     post "/hub/pending-reviews/:node_id/decline", RiptideWeb.Hub.ReviewController, :decline
+
+    post "/hub/install", RiptideWeb.Hub.InstallController, :install
+    post "/hub/install-reviews/:node_id/approve", RiptideWeb.Hub.InstallController, :approve
+    post "/hub/install-reviews/:node_id/decline", RiptideWeb.Hub.InstallController, :decline
+    post "/hub/crosswalks", RiptideWeb.Hub.CrosswalkController, :propose
+    post "/hub/crosswalk-reviews/:node_id/approve", RiptideWeb.Hub.CrosswalkController, :approve
+    post "/hub/crosswalk-reviews/:node_id/decline", RiptideWeb.Hub.CrosswalkController, :decline
   end
 end

--- a/test/riptide/derivation/anti_unifier_test.exs
+++ b/test/riptide/derivation/anti_unifier_test.exs
@@ -3,7 +3,7 @@ defmodule Riptide.Derivation.AntiUnifierTest do
 
   alias Riptide.Derivation.AntiUnifier
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
-  alias Riptide.Derivation.{Rule, Signature, Var}
+  alias Riptide.Derivation.{Provenance, Rule, Signature, Var}
 
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
   defp cap(name), do: RDF.iri("urn:riptide:capability:" <> name)
@@ -177,5 +177,27 @@ defmodule Riptide.Derivation.AntiUnifierTest do
     # each other (not two copies of the same generalization).
     [{gen1, _, _}, {gen2, _, _}] = candidates
     refute gen1.body == gen2.body
+  end
+
+  describe "provenance" do
+    test "every generalized candidate carries :generalized_from provenance pointing at both sources" do
+      rule1 =
+        rule(
+          %FactPattern{
+            predicate: rel("greeted"),
+            args: [RDF.literal("alice"), RDF.literal("hi")]
+          },
+          []
+        )
+
+      rule2 =
+        rule(
+          %FactPattern{predicate: rel("greeted"), args: [RDF.literal("bob"), RDF.literal("hi")]},
+          []
+        )
+
+      assert {:ok, [{generalization, _sub1, _sub2}]} = AntiUnifier.generalize(rule1, rule2)
+      assert generalization.provenance == %Provenance{origin: {:generalized_from, rule1, rule2}}
+    end
   end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -2,6 +2,7 @@ defmodule Riptide.Derivation.CatalogTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.Crosswalk
   alias Riptide.Derivation.DedupGate.PendingReview
   alias Riptide.Derivation.Literal.FactPattern
   alias Riptide.Derivation.{Rule, Signature}
@@ -181,6 +182,23 @@ defmodule Riptide.Derivation.CatalogTest do
       assert {:ok, hub_entries} = Catalog.list_entries(:hub)
       assert Enum.any?(hub_entries, fn {_node, rule} -> rule == hub_rule end)
       refute Enum.any?(hub_entries, fn {_node, rule} -> rule == tenant_rule end)
+    end
+  end
+
+  describe "admit_crosswalk/1 + list_crosswalks/0 — real round-trip" do
+    test "an admitted Crosswalk is found live by list_crosswalks/0" do
+      crosswalk = %Crosswalk{
+        subject_predicate:
+          rel("crosswalktest-pendingDeploy#{System.unique_integer([:positive])}"),
+        object_predicate:
+          rel("crosswalktest-deploymentQueued#{System.unique_integer([:positive])}"),
+        match_type: :exact_match
+      }
+
+      :ok = Catalog.admit_crosswalk(crosswalk)
+
+      assert {:ok, entries} = Catalog.list_crosswalks()
+      assert Enum.any?(entries, fn {_node, entry} -> entry == crosswalk end)
     end
   end
 end

--- a/test/riptide/derivation/crosswalk_rdf_codec_test.exs
+++ b/test/riptide/derivation/crosswalk_rdf_codec_test.exs
@@ -1,0 +1,31 @@
+defmodule Riptide.Derivation.CrosswalkRDFCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.{Crosswalk, CrosswalkRDFCodec}
+
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+
+  test "a Crosswalk round-trips through to_rdf/1 and from_rdf/2" do
+    crosswalk = %Crosswalk{
+      subject_predicate: rel("pendingDeploy"),
+      object_predicate: rel("deploymentQueued"),
+      match_type: :exact_match
+    }
+
+    {node, graph} = CrosswalkRDFCodec.to_rdf(crosswalk)
+    assert CrosswalkRDFCodec.from_rdf(node, graph) == crosswalk
+  end
+
+  test "each SSSOM match_type round-trips correctly" do
+    for match_type <- [:exact_match, :close_match, :broad_match, :narrow_match, :related_match] do
+      crosswalk = %Crosswalk{
+        subject_predicate: rel("a"),
+        object_predicate: rel("b"),
+        match_type: match_type
+      }
+
+      {node, graph} = CrosswalkRDFCodec.to_rdf(crosswalk)
+      assert CrosswalkRDFCodec.from_rdf(node, graph).match_type == match_type
+    end
+  end
+end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -2,7 +2,7 @@ defmodule Riptide.Derivation.DedupGateTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Capability.Definition
-  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Rule, Signature}
+  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Rule, RuleRDFCodec, Signature}
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
 
@@ -10,6 +10,20 @@ defmodule Riptide.Derivation.DedupGateTest do
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
 
   defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+  # A ground CapabilityReference's `result` is a raw Elixir string by this
+  # codebase's own established convention (matches `Capability.invoke/4`'s
+  # real return type — see `generalization_fidelity_test.exs`'s identical
+  # fixtures). RDF has no primitive distinct from Literal, so once such a
+  # raw string is embedded (via Provenance) in a Rule admitted through the
+  # RDF-backed Catalog, it comes back out as an `RDF.Literal`. Comparing a
+  # post-admission entry against the exact pre-admission in-memory struct
+  # therefore requires round-tripping the expectation through the same
+  # codec Catalog itself uses, not comparing raw structs directly.
+  defp rdf_round_trip(%Rule{} = rule) do
+    {node, graph} = RuleRDFCodec.to_rdf(rule)
+    RuleRDFCodec.from_rdf(node, graph)
+  end
 
   defp context(overrides \\ %{}) do
     Map.merge(
@@ -498,7 +512,8 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       assert :ok == DedupGate.approve_review(scope, scope, node)
 
-      assert {:ok, [{_entry_node, ^generalization}]} = Catalog.list_entries(scope)
+      assert {:ok, [{_entry_node, entry}]} = Catalog.list_entries(scope)
+      assert entry == rdf_round_trip(generalization)
     end
   end
 
@@ -556,8 +571,9 @@ defmodule Riptide.Derivation.DedupGateTest do
       assert :ok == DedupGate.approve_review(target_scope, review_scope, node)
 
       # Admitted into target_scope's Catalog...
+      expected_entry = rdf_round_trip(generalization)
       assert {:ok, target_entries_after} = Catalog.list_entries(target_scope)
-      assert Enum.any?(target_entries_after, fn {_n, rule} -> rule == generalization end)
+      assert Enum.any?(target_entries_after, fn {_n, rule} -> rule == expected_entry end)
 
       # ...and the review resolved in review_scope, not target_scope.
       assert {:ok, []} = Catalog.list_pending_reviews(review_scope)

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -2,7 +2,18 @@ defmodule Riptide.Derivation.DedupGateTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Capability.Definition
-  alias Riptide.Derivation.{AntiUnifier, Catalog, DedupGate, Rule, RuleRDFCodec, Signature}
+
+  alias Riptide.Derivation.{
+    AntiUnifier,
+    Catalog,
+    DedupGate,
+    Provenance,
+    Rule,
+    RuleRDFCodec,
+    Signature
+  }
+
+  alias Riptide.Derivation.DedupGate.PendingReview
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
 
@@ -84,6 +95,20 @@ defmodule Riptide.Derivation.DedupGateTest do
         max_instances: nil,
         max_tables: nil
       }
+    }
+  end
+
+  defp sample_install_candidate do
+    %Rule{
+      signature: %Signature{
+        name: rel("installed"),
+        parameters: [],
+        reads: [],
+        produces: [rel("installed")]
+      },
+      head: %FactPattern{predicate: rel("installed"), args: [t("alice"), RDF.literal("hi")]},
+      body: [],
+      provenance: %Provenance{origin: {:installed_from, RDF.BlankNode.new("hub-entry"), []}}
     }
   end
 
@@ -577,6 +602,60 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       # ...and the review resolved in review_scope, not target_scope.
       assert {:ok, []} = Catalog.list_pending_reviews(review_scope)
+    end
+  end
+
+  describe "PendingReview — :not_applicable fidelity_evidence" do
+    test "round-trips through Catalog.queue_pending_review/2 + list_pending_reviews/1" do
+      scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(scope))
+      end)
+
+      pending_review = %PendingReview{
+        kind: :admit,
+        candidate: sample_install_candidate(),
+        fidelity_evidence: :not_applicable,
+        replaces: nil
+      }
+
+      {:ok, node} = Catalog.queue_pending_review(scope, pending_review)
+      assert {:ok, [{^node, ^pending_review}]} = Catalog.list_pending_reviews(scope)
+    end
+  end
+
+  describe "propose_install/3" do
+    test "an install candidate against an empty target Catalog is queued as :admit with :not_applicable evidence" do
+      target_scope = unique_tenant()
+      review_scope = target_scope
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      installed_rule = sample_install_candidate()
+
+      assert {:ok, {:queued, node, :admit}} =
+               DedupGate.propose_install(target_scope, review_scope, installed_rule)
+
+      assert {:ok, [{^node, pending_review}]} = Catalog.list_pending_reviews(review_scope)
+      assert pending_review.fidelity_evidence == :not_applicable
+      assert pending_review.candidate == installed_rule
+    end
+
+    test "an install candidate already covered by an existing entry is Rejected, no review queued" do
+      target_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(target_scope))
+      end)
+
+      installed_rule = sample_install_candidate()
+      :ok = Catalog.admit_entry(target_scope, installed_rule, nil)
+
+      assert {:ok, {:rejected, :already_covered}} =
+               DedupGate.propose_install(target_scope, target_scope, installed_rule)
     end
   end
 end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -6,6 +6,7 @@ defmodule Riptide.Derivation.DedupGateTest do
   alias Riptide.Derivation.{
     AntiUnifier,
     Catalog,
+    Crosswalk,
     DedupGate,
     Provenance,
     Rule,
@@ -13,7 +14,7 @@ defmodule Riptide.Derivation.DedupGateTest do
     Signature
   }
 
-  alias Riptide.Derivation.DedupGate.PendingReview
+  alias Riptide.Derivation.DedupGate.{PendingCrosswalkReview, PendingReview}
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
 
@@ -656,6 +657,72 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       assert {:ok, {:rejected, :already_covered}} =
                DedupGate.propose_install(target_scope, target_scope, installed_rule)
+    end
+  end
+
+  describe "PendingCrosswalkReview round-trip" do
+    test "round-trips through Catalog.queue_crosswalk_review/1 + list_crosswalk_pending_reviews/0" do
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      pending = %PendingCrosswalkReview{
+        candidate: %Crosswalk{
+          subject_predicate: rel("crosswalkreview-a#{System.unique_integer([:positive])}"),
+          object_predicate: rel("crosswalkreview-b#{System.unique_integer([:positive])}"),
+          match_type: :exact_match
+        }
+      }
+
+      {:ok, node} = Catalog.queue_crosswalk_review(review_scope, pending)
+      assert {:ok, entries} = Catalog.list_crosswalk_pending_reviews(review_scope)
+      assert Enum.any?(entries, fn {n, p} -> n == node and p == pending end)
+    end
+  end
+
+  describe "propose_crosswalk/2 + approve_crosswalk_review/1 + decline_crosswalk_review/1" do
+    test "a proposed Crosswalk is queued, then approval admits it to the Hub crosswalk catalog" do
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      crosswalk = %Crosswalk{
+        subject_predicate: rel("crosswalkpropose-a#{System.unique_integer([:positive])}"),
+        object_predicate: rel("crosswalkpropose-b#{System.unique_integer([:positive])}"),
+        match_type: :close_match
+      }
+
+      assert {:ok, node} = DedupGate.propose_crosswalk(review_scope, crosswalk)
+      assert :ok == DedupGate.approve_crosswalk_review(review_scope, node)
+
+      assert {:ok, entries} = Catalog.list_crosswalks()
+      assert Enum.any?(entries, fn {_n, c} -> c == crosswalk end)
+
+      assert {:ok, []} = Catalog.list_crosswalk_pending_reviews(review_scope)
+    end
+
+    test "declining a proposed Crosswalk resolves the review and admits nothing" do
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      crosswalk = %Crosswalk{
+        subject_predicate: rel("crosswalkdecline-a#{System.unique_integer([:positive])}"),
+        object_predicate: rel("crosswalkdecline-b#{System.unique_integer([:positive])}"),
+        match_type: :broad_match
+      }
+
+      {:ok, node} = DedupGate.propose_crosswalk(review_scope, crosswalk)
+      assert :ok == DedupGate.decline_crosswalk_review(review_scope, node)
+
+      assert {:ok, entries} = Catalog.list_crosswalks()
+      refute Enum.any?(entries, fn {_n, c} -> c == crosswalk end)
     end
   end
 end

--- a/test/riptide/derivation/install_test.exs
+++ b/test/riptide/derivation/install_test.exs
@@ -1,0 +1,165 @@
+defmodule Riptide.Derivation.InstallTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.{Crosswalk, Install, Provenance, Rule, Signature}
+  alias Riptide.Derivation.Literal.FactPattern
+
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp unique_tenant, do: "acme-#{System.unique_integer([:positive])}"
+
+  defp sample_rule(predicate_name, reads) do
+    predicate = rel(predicate_name)
+
+    %Rule{
+      signature: %Signature{name: predicate, parameters: [], reads: reads, produces: [predicate]},
+      head: %FactPattern{predicate: predicate, args: [t("x"), RDF.literal("y")]},
+      body: Enum.map(reads, &%FactPattern{predicate: &1, args: [t("x"), RDF.literal("y")]}),
+      provenance: nil
+    }
+  end
+
+  describe "tenant_vocabulary/1" do
+    test "returns the union of reads/produces across a Tenant's own admitted Catalog entries" do
+      tenant_id = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+      end)
+
+      :ok =
+        Catalog.admit_entry({:tenant, tenant_id}, sample_rule("produced1", [rel("read1")]), nil)
+
+      :ok =
+        Catalog.admit_entry({:tenant, tenant_id}, sample_rule("produced2", [rel("read2")]), nil)
+
+      vocabulary = Install.tenant_vocabulary(tenant_id)
+
+      assert MapSet.subset?(
+               MapSet.new([rel("produced1"), rel("read1"), rel("produced2"), rel("read2")]),
+               vocabulary
+             )
+    end
+
+    test "an unregistered Tenant has an empty vocabulary" do
+      assert Install.tenant_vocabulary(unique_tenant()) == MapSet.new()
+    end
+  end
+
+  describe "install/3" do
+    test "a predicate already in the Tenant's vocabulary is left unchanged, no field binding recorded" do
+      tenant_id = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+      end)
+
+      shared_predicate = rel("shared#{System.unique_integer([:positive])}")
+      pattern_predicate_name = "pattern#{System.unique_integer([:positive])}"
+      pattern_predicate = rel(pattern_predicate_name)
+
+      :ok =
+        Catalog.admit_entry(
+          {:tenant, tenant_id},
+          sample_rule("existing", [shared_predicate]),
+          nil
+        )
+
+      :ok =
+        Catalog.admit_entry({:tenant, tenant_id}, sample_rule(pattern_predicate_name, []), nil)
+
+      pattern = %Rule{
+        signature: %Signature{
+          name: pattern_predicate,
+          parameters: [],
+          reads: [shared_predicate],
+          produces: [pattern_predicate]
+        },
+        head: %FactPattern{predicate: pattern_predicate, args: [t("x"), RDF.literal("y")]},
+        body: [%FactPattern{predicate: shared_predicate, args: [t("x"), RDF.literal("y")]}],
+        provenance: nil
+      }
+
+      hub_entry_node = RDF.BlankNode.new("hub-entry")
+      {installed_rule, field_bindings} = Install.install(hub_entry_node, pattern, tenant_id)
+
+      assert field_bindings == []
+      assert installed_rule.body == pattern.body
+
+      assert installed_rule.provenance == %Provenance{
+               origin: {:installed_from, hub_entry_node, []}
+             }
+    end
+
+    test "a predicate mapped by an existing Crosswalk is rewritten; an unmatched predicate is left native" do
+      tenant_id = unique_tenant()
+
+      # crosswalk_stream_id() is a single, shared, non-unique stream across
+      # the whole test suite (like :hub's own catalog — see
+      # catalog_test.exs's "Hub vs. Tenant scope isolation" test) — never
+      # force-deleted here, since that can leave the very next writer
+      # hitting :noproc before the lazy re-create catches up (confirmed
+      # live: this table needed force-deletion here previously caused a
+      # separate, unrelated dedup_gate_test.exs crosswalk test elsewhere in
+      # the suite to fail with exactly that). Tolerate accumulation instead.
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+      end)
+
+      source_predicate = rel("pendingDeploy#{System.unique_integer([:positive])}")
+      target_predicate = rel("deploymentQueued#{System.unique_integer([:positive])}")
+      unmatched_predicate = rel("notifyChannel#{System.unique_integer([:positive])}")
+
+      :ok =
+        Catalog.admit_entry(
+          {:tenant, tenant_id},
+          sample_rule("existing", [target_predicate]),
+          nil
+        )
+
+      crosswalk = %Crosswalk{
+        subject_predicate: source_predicate,
+        object_predicate: target_predicate,
+        match_type: :exact_match
+      }
+
+      :ok = Catalog.admit_crosswalk(crosswalk)
+      {:ok, crosswalks} = Catalog.list_crosswalks()
+      {crosswalk_node, ^crosswalk} = Enum.find(crosswalks, fn {_node, c} -> c == crosswalk end)
+
+      pattern = %Rule{
+        signature: %Signature{
+          name: rel("pattern"),
+          parameters: [],
+          reads: [source_predicate, unmatched_predicate],
+          produces: [rel("pattern")]
+        },
+        head: %FactPattern{predicate: rel("pattern"), args: [t("x"), RDF.literal("y")]},
+        body: [
+          %FactPattern{predicate: source_predicate, args: [t("x"), RDF.literal("y")]},
+          %FactPattern{predicate: unmatched_predicate, args: [t("x"), RDF.literal("y")]}
+        ],
+        provenance: nil
+      }
+
+      hub_entry_node = RDF.BlankNode.new("hub-entry")
+      {installed_rule, field_bindings} = Install.install(hub_entry_node, pattern, tenant_id)
+
+      rewritten_predicates = Enum.map(installed_rule.body, & &1.predicate)
+      assert target_predicate in rewritten_predicates
+      assert unmatched_predicate in rewritten_predicates
+      refute source_predicate in rewritten_predicates
+
+      assert Enum.any?(field_bindings, fn
+               %{predicate: ^source_predicate, binding: {:crosswalk, ^crosswalk_node}} -> true
+               _other -> false
+             end)
+
+      assert Enum.any?(field_bindings, fn
+               %{predicate: ^unmatched_predicate, binding: :manual} -> true
+               _other -> false
+             end)
+    end
+  end
+end

--- a/test/riptide/derivation/rule_rdf_codec_test.exs
+++ b/test/riptide/derivation/rule_rdf_codec_test.exs
@@ -1,7 +1,7 @@
 defmodule Riptide.Derivation.RuleRDFCodecTest do
   use ExUnit.Case, async: true
 
-  alias Riptide.Derivation.{Parser, RuleRDFCodec}
+  alias Riptide.Derivation.{Parser, Provenance, RuleRDFCodec}
 
   @sp_triple_pattern RDF.iri("http://spinrdf.org/sp#TriplePattern")
   @sp_subject RDF.iri("http://spinrdf.org/sp#subject")
@@ -204,6 +204,51 @@ defmodule Riptide.Derivation.RuleRDFCodecTest do
 
       assert decoded.signature.reads == rule.signature.reads
       assert decoded == rule
+    end
+  end
+
+  describe "provenance round-trip" do
+    test "a Rule with nil provenance round-trips with nil provenance" do
+      {:ok, rule} = Parser.decode("deployed(Svc, Result) :- pendingDeploy(Svc, Result).")
+      assert rule.provenance == nil
+
+      {node, graph} = RuleRDFCodec.to_rdf(rule)
+      assert RuleRDFCodec.from_rdf(node, graph) == rule
+    end
+
+    test "a Rule with :generalized_from provenance round-trips, including its embedded sources" do
+      {:ok, source1} = Parser.decode("a(X, Y) :- f(X, Y).")
+      {:ok, source2} = Parser.decode("a(X, Y) :- g(X, Y).")
+      {:ok, base_rule} = Parser.decode("deployed(Svc, Result) :- pendingDeploy(Svc, Result).")
+
+      rule = %{base_rule | provenance: %Provenance{origin: {:generalized_from, source1, source2}}}
+
+      {node, graph} = RuleRDFCodec.to_rdf(rule)
+      assert RuleRDFCodec.from_rdf(node, graph) == rule
+    end
+
+    test "a Rule with :installed_from provenance round-trips, including field bindings" do
+      {:ok, base_rule} = Parser.decode("deployed(Svc, Result) :- pendingDeploy(Svc, Result).")
+      source_entry = RDF.BlankNode.new("hub-entry-1")
+      crosswalk_node = RDF.BlankNode.new("crosswalk-1")
+
+      rule = %{
+        base_rule
+        | provenance: %Provenance{
+            origin:
+              {:installed_from, source_entry,
+               [
+                 %{
+                   predicate: RDF.iri("urn:riptide:relation:pendingDeploy"),
+                   binding: {:crosswalk, crosswalk_node}
+                 },
+                 %{predicate: RDF.iri("urn:riptide:relation:notifyChannel"), binding: :manual}
+               ]}
+          }
+      }
+
+      {node, graph} = RuleRDFCodec.to_rdf(rule)
+      assert RuleRDFCodec.from_rdf(node, graph) == rule
     end
   end
 end

--- a/test/riptide_web/hub/crosswalk_controller_test.exs
+++ b/test/riptide_web/hub/crosswalk_controller_test.exs
@@ -1,0 +1,72 @@
+defmodule RiptideWeb.Hub.CrosswalkControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  defp rel(name), do: "urn:riptide:relation:" <> name
+
+  test "propose a Crosswalk, then approve it — it becomes live in the Hub crosswalk catalog" do
+    tenant_id = "crosswalk-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    subject = rel("crosswalkhttp-a#{System.unique_integer([:positive])}")
+    object = rel("crosswalkhttp-b#{System.unique_integer([:positive])}")
+
+    body =
+      Jason.encode!(%{
+        "subject_predicate" => subject,
+        "object_predicate" => object,
+        "match_type" => "exact_match"
+      })
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/crosswalks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert propose_conn.status == 200
+    node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+    assert is_binary(node_id)
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/crosswalk-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    assert {:ok, entries} = Catalog.list_crosswalks()
+
+    assert Enum.any?(entries, fn {_n, c} ->
+             c.subject_predicate == RDF.iri(subject) and c.object_predicate == RDF.iri(object)
+           end)
+  end
+end

--- a/test/riptide_web/hub/install_controller_test.exs
+++ b/test/riptide_web/hub/install_controller_test.exs
@@ -1,0 +1,70 @@
+defmodule RiptideWeb.Hub.InstallControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.{Catalog, Parser}
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  test "install a Hub entry into a Tenant, then approve — it becomes live in the Tenant's own Catalog" do
+    tenant_id = "install-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "installhttp#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    hub_rule_text =
+      "#{predicate_name}(<urn:test:alice>, \"hi\") :- pendingDeploy(<urn:test:alice>, \"v1\")."
+
+    {:ok, hub_rule} = Parser.decode(hub_rule_text)
+    :ok = Catalog.admit_entry(:hub, hub_rule, nil)
+    {:ok, hub_entries} = Catalog.list_entries(:hub)
+    {hub_node, ^hub_rule} = Enum.find(hub_entries, fn {_n, r} -> r == hub_rule end)
+    hub_node_id = RDF.BlankNode.value(hub_node)
+
+    body = Jason.encode!(%{"hub_node_id" => hub_node_id})
+
+    install_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/install", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert install_conn.status == 200
+    review_node_id = Jason.decode!(install_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/install-reviews/#{review_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    predicate = RDF.iri("urn:riptide:relation:" <> predicate_name)
+    assert {:ok, entries} = Catalog.list_entries({:tenant, tenant_id})
+    assert Enum.any?(entries, fn {_n, r} -> r.head.predicate == predicate end)
+  end
+end

--- a/test/riptide_web/hub/install_controller_test.exs
+++ b/test/riptide_web/hub/install_controller_test.exs
@@ -3,7 +3,7 @@ defmodule RiptideWeb.Hub.InstallControllerTest do
   use Plug.Test
 
   alias Riptide.Authz.Store
-  alias Riptide.Derivation.{Catalog, Parser}
+  alias Riptide.Derivation.{Catalog, Parser, Provenance}
 
   @opts RiptideWeb.Endpoint.init([])
 
@@ -66,5 +66,119 @@ defmodule RiptideWeb.Hub.InstallControllerTest do
     predicate = RDF.iri("urn:riptide:relation:" <> predicate_name)
     assert {:ok, entries} = Catalog.list_entries({:tenant, tenant_id})
     assert Enum.any?(entries, fn {_n, r} -> r.head.predicate == predicate end)
+  end
+
+  test "exit criterion (issue #71): install with partial vocabulary overlap binds matched fields through a Crosswalk and records manually-originated Provenance for unmatched fields" do
+    installing_tenant = "install-capstone-" <> Uniq.UUID.uuid4()
+    claim_tenant(installing_tenant)
+
+    source_predicate_name = "pendingDeployCapstone#{System.unique_integer([:positive])}"
+    target_predicate_name = "deploymentQueuedCapstone#{System.unique_integer([:positive])}"
+    unmatched_predicate_name = "notifyChannelCapstone#{System.unique_integer([:positive])}"
+    pattern_predicate_name = "deployNotifyCapstone#{System.unique_integer([:positive])}"
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(
+        Catalog.catalog_stream_id({:tenant, installing_tenant})
+      )
+
+      Riptide.RaTestHelpers.cleanup_stream(
+        Catalog.pending_review_stream_id({:tenant, installing_tenant})
+      )
+    end)
+
+    # The installing Tenant already has an entry using its own vocabulary word.
+    existing_rule_text =
+      "existing#{pattern_predicate_name}(<urn:test:a>, \"hi\") :- #{target_predicate_name}(<urn:test:a>, \"v1\")."
+
+    {:ok, existing_rule} = Parser.decode(existing_rule_text)
+    :ok = Catalog.admit_entry({:tenant, installing_tenant}, existing_rule, nil)
+
+    # Propose and approve a Crosswalk from the Hub pattern's own predicate to
+    # the installing Tenant's.
+    crosswalk_body =
+      Jason.encode!(%{
+        "subject_predicate" => "urn:riptide:relation:#{source_predicate_name}",
+        "object_predicate" => "urn:riptide:relation:#{target_predicate_name}",
+        "match_type" => "exact_match"
+      })
+
+    crosswalk_propose_conn =
+      :post
+      |> conn("/tenants/#{installing_tenant}/hub/crosswalks", crosswalk_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert crosswalk_propose_conn.status == 200
+    crosswalk_node_id = Jason.decode!(crosswalk_propose_conn.resp_body)["node_id"]
+
+    crosswalk_approve_conn =
+      :post
+      |> conn("/tenants/#{installing_tenant}/hub/crosswalk-reviews/#{crosswalk_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert crosswalk_approve_conn.status == 200
+
+    # Publish the Hub pattern — two predicates: one has a Crosswalk to the
+    # installing Tenant's vocabulary, one doesn't.
+    hub_rule_text =
+      "#{pattern_predicate_name}(<urn:test:a>, \"hi\") :- " <>
+        "#{source_predicate_name}(<urn:test:a>, \"v1\"), #{unmatched_predicate_name}(<urn:test:a>, \"v1\")."
+
+    {:ok, hub_rule} = Parser.decode(hub_rule_text)
+    :ok = Catalog.admit_entry(:hub, hub_rule, nil)
+    {:ok, hub_entries} = Catalog.list_entries(:hub)
+    {hub_node, ^hub_rule} = Enum.find(hub_entries, fn {_n, r} -> r == hub_rule end)
+    hub_node_id = RDF.BlankNode.value(hub_node)
+
+    install_body = Jason.encode!(%{"hub_node_id" => hub_node_id})
+
+    install_conn =
+      :post
+      |> conn("/tenants/#{installing_tenant}/hub/install", install_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert install_conn.status == 200
+    install_node_id = Jason.decode!(install_conn.resp_body)["node_id"]
+
+    install_approve_conn =
+      :post
+      |> conn("/tenants/#{installing_tenant}/hub/install-reviews/#{install_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert install_approve_conn.status == 200
+
+    pattern_predicate = RDF.iri("urn:riptide:relation:#{pattern_predicate_name}")
+    target_predicate = RDF.iri("urn:riptide:relation:#{target_predicate_name}")
+    source_predicate = RDF.iri("urn:riptide:relation:#{source_predicate_name}")
+    unmatched_predicate = RDF.iri("urn:riptide:relation:#{unmatched_predicate_name}")
+
+    assert {:ok, entries} = Catalog.list_entries({:tenant, installing_tenant})
+
+    {_node, installed_rule} =
+      Enum.find(entries, fn {_n, r} -> r.head.predicate == pattern_predicate end)
+
+    body_predicates = Enum.map(installed_rule.body, & &1.predicate)
+    assert target_predicate in body_predicates
+    assert unmatched_predicate in body_predicates
+    refute source_predicate in body_predicates
+
+    assert %Provenance{origin: {:installed_from, ^hub_node, field_bindings}} =
+             installed_rule.provenance
+
+    assert Enum.any?(field_bindings, fn
+             %{predicate: ^source_predicate, binding: {:crosswalk, _crosswalk_node}} -> true
+             _other -> false
+           end)
+
+    assert Enum.any?(field_bindings, fn
+             %{predicate: ^unmatched_predicate, binding: :manual} -> true
+             _other -> false
+           end)
   end
 end


### PR DESCRIPTION
## Summary
- Closes Track A's Hub arc (6h-i → 6h-ii → 6i).
- `Provenance` defined generally and retrofitted into `AntiUnifier.generalize/2` — a real, previously-unaddressed gap (called "mandatory" in the parent spec's §5 since 6e-i, never actually implemented) closed everywhere in one pass, not deferred again.
- New `Crosswalk` (SSSOM-shaped predicate-IRI mappings), reviewed as Hub-scope content through the same DedupGate authority as any other Hub publication.
- Install rewrites a Hub pattern's predicates through existing Crosswalks into the target Tenant's own (observed, not declared) vocabulary, recording Provenance for whatever doesn't match.
- Fidelity-replay-testing is explicitly not reused for Install review — it only ever re-invokes Capabilities, never inspects the fact-pattern predicates Crosswalk rewriting actually touches. The installing Tenant's own human review is the correct and sufficient safeguard.
- New HTTP endpoints mirroring 6h-ii's exact existing route/pipeline shape; dedicated approve/decline routes for install and crosswalk reviews (not the existing `/hub/pending-reviews/...`, which hardcodes `target_scope: :hub` — a design correction made mid-implementation and reflected back into the spec).

Implements #71. Spec: `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md` (PR #111).

## Test plan
- [x] `mix test` — full suite green (485 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR