### PR TITLE
Draft: Resolve: "6j — Large Object (Blob) Storage"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ riptide-*.tar
 priv/ra_data/
 priv/ra_data_test/
 
+# Riptide.BlobStore's on-disk content-addressed storage (default path when
+# RIPTIDE_BLOB_DATA_DIR/:blob_data_dir isn't overridden — see Phase 6j).
+priv/blob_data/
+
 # Ra's on-disk data directories for the real-:peer-spawned nodes in
 # multi_node_connectivity_test.exs: those bare peer nodes don't load
 # config/test.exs (no Mix config in a plain `:peer`-started node), so

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation) — 6 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage) — 5 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -998,4 +998,52 @@ the original by `==`; fixed by round-tripping the test's own expectation through
 Catalog itself uses, rather than comparing against the pre-storage struct.
 
 **Status**: Phase 6i shipped 2026-08-30. 6 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6j — Large Object (Blob) Storage
+
+**Shipped 2026-08-31** — see
+`docs/superpowers/specs/2026-08-30-phase-6j-large-object-blob-storage-design.md`.
+
+Motivated by a concrete gap found while investigating what dynamic Capability registration (future
+work) would actually require: `Riptide.Capability.invoke/4` shells out to the `wasmtime` CLI
+against `definition.component`, a literal local filesystem path — there is nowhere durable and
+fleet-reachable to put a Capability's own bytes yet. This phase closes that gap generally
+(content-addressed blob storage), not narrowly for Capability bytes alone; wiring a Capability's
+own `component` field to it stays future work, out of scope here.
+
+New `Riptide.BlobStore` — a privileged, zero-authorization instance of 6b-ii's
+`Riptide.SupervisedProcess` primitive (one well-known process per node, id `"blob_store"`;
+`session_active?/1` refuses a restart mid-write). `put/1` hashes with whole-blob SHA-256 (no
+content-defined chunking — deferred, per the spec's own scope), writes to local disk under a
+git-object-style two-level directory prefix, then replicates to RF-1 (default RF 3) other live
+nodes via direct `:rpc.call/5`, never through Ra consensus — immutable content-addressed bytes need
+no consensus to replicate safely, unlike an ordered Fact log. `get/1` verifies a local copy's hash
+before serving it (a mismatch is treated as corruption, never served silently) and falls back to
+other nodes listed in the location index on a local miss.
+
+New `Riptide.BlobStore.LocationIndex` — a dedicated, fixed-stream `hash -> [nodes]` index (RDF
+triples over the existing generic `StreamServer`/`Patch` mechanism, not a bespoke `:ra_machine`),
+deliberately not folded into the shared placement-metadata cluster. New
+`Riptide.BlobStore.Healer` mirrors `Riptide.Stream.ReplicaHealer`'s own periodic-sweep shape
+exactly, applied to blob replicas instead of Ra cluster membership — dropping dead locations and
+re-replicating anything under RF onto a deterministically-picked live node. Unlike
+`ReplicaHealer`'s own repair, no claim/consensus fencing is needed: over-replicating a blob briefly
+is harmless (extra disk, never correctness), unlike a Ra cluster's own membership.
+
+Garbage collection (a reference-counted manifest state machine, adapted from Riak CS) is fully
+specified in the design doc's §8 but explicitly not implemented this phase. Cross-tenant
+deduplication at the storage layer is an accepted design decision (spec §9) — content-addressing
+means two tenants writing identical bytes share one on-disk copy, with the resulting
+same-hash-implies-you-had-the-bytes side channel named as a residual, accepted risk rather than
+mitigated.
+
+Real multi-node integration testing (`test/riptide/blob_store_cluster_test.exs`) surfaced a design
+detail worth recording: `Riptide.PlacementMembership.target_size/0` defaults to 3 (odd, by
+construction), and both genesis formation and the ambient reconcile join loop cap membership at
+exactly that many nodes — a 4th fleet node never joins the placement cluster itself. `BlobStore`
+replication doesn't need it to: RF-replication and the healer both work over plain distributed-Erlang
+connectivity (`Node.list()`), entirely independent of placement-cluster membership.
+
+**Status**: Phase 6j shipped 2026-08-31. 5 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -38,6 +38,7 @@ defmodule Riptide.Application do
         {Registry, keys: :unique, name: Riptide.SupervisedProcess.Registry},
         {DynamicSupervisor,
          strategy: :one_for_one, name: Riptide.SupervisedProcess.DynamicSupervisor},
+        Riptide.BlobStore,
         {Cluster.Supervisor,
          [Application.get_env(:libcluster, :topologies, []), [name: Riptide.ClusterSupervisor]]}
       ] ++

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -77,7 +77,8 @@ defmodule Riptide.Application do
   defp placement_children do
     [
       Supervisor.child_spec(Riptide.PlacementMembership, shutdown: 10_000),
-      Riptide.Stream.ReplicaHealer
+      Riptide.Stream.ReplicaHealer,
+      Riptide.BlobStore.Healer
     ]
   end
 

--- a/lib/riptide/blob_store.ex
+++ b/lib/riptide/blob_store.ex
@@ -102,6 +102,31 @@ defmodule Riptide.BlobStore do
   defp do_get(hash) do
     case File.read(path_for(hash)) do
       {:ok, bytes} -> verify(bytes, hash)
+      {:error, _reason} -> fetch_remote(hash)
+    end
+  end
+
+  defp fetch_remote(hash) do
+    case LocationIndex.list_locations(hash) do
+      {:ok, nodes} -> try_remote_nodes(hash, nodes -- [node()])
+      {:error, :not_ready} -> {:error, :not_found}
+    end
+  end
+
+  defp try_remote_nodes(_hash, []), do: {:error, :not_found}
+
+  defp try_remote_nodes(hash, [n | rest]) do
+    case :rpc.call(n, __MODULE__, :receive_replica_bytes, [hash], 30_000) do
+      {:ok, bytes} -> verify(bytes, hash)
+      _other -> try_remote_nodes(hash, rest)
+    end
+  end
+
+  @doc false
+  @spec receive_replica_bytes(String.t()) :: {:ok, binary()} | {:error, :not_found}
+  def receive_replica_bytes(hash) do
+    case File.read(path_for(hash)) do
+      {:ok, bytes} -> verify(bytes, hash)
       {:error, _reason} -> {:error, :not_found}
     end
   end

--- a/lib/riptide/blob_store.ex
+++ b/lib/riptide/blob_store.ex
@@ -142,7 +142,12 @@ defmodule Riptide.BlobStore do
 
   # Two-level directory prefix (matching git's own object-store layout) so a
   # single directory never accumulates an unbounded number of entries.
-  defp path_for(hash) do
+  # Public (not private) solely so the multi-node corruption test can reach
+  # it via :erpc.call/4 — effectively private in spirit, just not enforced
+  # by the compiler, matching receive_replica/2's own @doc false treatment.
+  @doc false
+  @spec path_for(String.t()) :: String.t()
+  def path_for(hash) do
     <<prefix::binary-size(2), rest::binary>> = hash
     Path.join([data_dir(), prefix, rest])
   end

--- a/lib/riptide/blob_store.ex
+++ b/lib/riptide/blob_store.ex
@@ -3,13 +3,55 @@ defmodule Riptide.BlobStore do
   Privileged, content-addressed blob storage — see design spec
   `docs/superpowers/specs/2026-08-30-phase-6j-large-object-blob-storage-design.md`.
   Outside the WASI sandbox by design (§4/§9): performs no authorization of its
-  own, every caller is responsible for that. This module covers only
-  single-node local storage; cross-node replication is layered on top in
-  `put/1`'s own SupervisedProcess-wrapped `GenServer` (Task 3).
+  own, every caller is responsible for that. A single, well-known
+  `Riptide.SupervisedProcess` instance (id `"blob_store"`) per node — `put/1`'s
+  own write is real I/O (a blob can be >10MB), so `session_active?/1` refuses a
+  restart mid-write rather than risk a truncated local copy.
   """
 
+  @behaviour Riptide.SupervisedProcess
+  use GenServer
+
+  @id "blob_store"
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_arg), do: Riptide.SupervisedProcess.start(@id, __MODULE__, [])
+
   @spec put(binary()) :: {:ok, String.t()} | {:error, term()}
-  def put(bytes) when is_binary(bytes) do
+  def put(bytes) when is_binary(bytes), do: GenServer.call(pid!(), {:put, bytes}, :infinity)
+
+  @spec get(String.t()) :: {:ok, binary()} | {:error, :not_found}
+  def get(hash), do: GenServer.call(pid!(), {:get, hash})
+
+  # Mirrors Riptide.SupervisedProcess's own private `control/2` lookup
+  # exactly (Registry.lookup/2 -> match the registered {pid, module} pair
+  # -> call the pid directly) rather than reconstructing a `:via` tuple by
+  # hand for outbound calls too.
+  defp pid! do
+    [{pid, __MODULE__}] = Registry.lookup(Riptide.SupervisedProcess.Registry, @id)
+    pid
+  end
+
+  @impl GenServer
+  def init([]), do: {:ok, %{writing: false}}
+
+  @impl GenServer
+  def handle_call({:put, bytes}, _from, state) do
+    {:reply, do_put(bytes), state}
+  end
+
+  def handle_call({:get, hash}, _from, state) do
+    {:reply, do_get(hash), state}
+  end
+
+  def handle_call({:riptide_supervised_process, :stop_if_idle, reason}, from, state) do
+    Riptide.SupervisedProcess.handle_stop_if_idle(__MODULE__, state, reason, from)
+  end
+
+  @impl Riptide.SupervisedProcess
+  def session_active?(state), do: state.writing
+
+  defp do_put(bytes) do
     hash = hash_of(bytes)
     path = path_for(hash)
 
@@ -19,8 +61,7 @@ defmodule Riptide.BlobStore do
     end
   end
 
-  @spec get(String.t()) :: {:ok, binary()} | {:error, :not_found}
-  def get(hash) do
+  defp do_get(hash) do
     case File.read(path_for(hash)) do
       {:ok, bytes} -> verify(bytes, hash)
       {:error, _reason} -> {:error, :not_found}
@@ -30,11 +71,7 @@ defmodule Riptide.BlobStore do
   # A locally-stored blob whose bytes don't match their own claimed hash is
   # corruption, not a valid result (spec §5) — never served silently.
   defp verify(bytes, hash) do
-    if hash_of(bytes) == hash do
-      {:ok, bytes}
-    else
-      {:error, :not_found}
-    end
+    if hash_of(bytes) == hash, do: {:ok, bytes}, else: {:error, :not_found}
   end
 
   defp hash_of(bytes),

--- a/lib/riptide/blob_store.ex
+++ b/lib/riptide/blob_store.ex
@@ -12,6 +12,8 @@ defmodule Riptide.BlobStore do
   @behaviour Riptide.SupervisedProcess
   use GenServer
 
+  alias Riptide.BlobStore.LocationIndex
+
   @id "blob_store"
 
   @spec start_link(term()) :: GenServer.on_start()
@@ -37,7 +39,8 @@ defmodule Riptide.BlobStore do
 
   @impl GenServer
   def handle_call({:put, bytes}, _from, state) do
-    {:reply, do_put(bytes), state}
+    result = do_put(%{state | writing: true}, bytes)
+    {:reply, result, %{state | writing: false}}
   end
 
   def handle_call({:get, hash}, _from, state) do
@@ -51,13 +54,48 @@ defmodule Riptide.BlobStore do
   @impl Riptide.SupervisedProcess
   def session_active?(state), do: state.writing
 
-  defp do_put(bytes) do
+  defp do_put(_state, bytes) do
     hash = hash_of(bytes)
     path = path_for(hash)
 
     with :ok <- File.mkdir_p(Path.dirname(path)),
          :ok <- File.write(path, bytes) do
+      LocationIndex.add_location(hash, node())
+      replicate(hash, bytes, other_nodes())
       {:ok, hash}
+    end
+  end
+
+  # RF - 1 other nodes, deterministically picked (sorted, first N) so a
+  # concurrent put/1 for the same content from a different caller converges
+  # on the same replica set rather than scattering copies unnecessarily —
+  # mirrors Riptide.Stream.ReplicaHealer.pick_replacement/2's own
+  # determinism rationale.
+  defp other_nodes do
+    rf = Application.get_env(:riptide, :blob_replication_factor, 3)
+    Node.list() |> Enum.sort() |> Enum.take(rf - 1)
+  end
+
+  defp replicate(hash, bytes, nodes) do
+    Enum.each(nodes, fn n ->
+      case :rpc.call(n, __MODULE__, :receive_replica, [hash, bytes], 30_000) do
+        :ok -> LocationIndex.add_location(hash, n)
+        _other -> :ok
+      end
+    end)
+  end
+
+  @doc false
+  @spec receive_replica(String.t(), binary()) :: :ok | {:error, term()}
+  def receive_replica(hash, bytes) do
+    if hash_of(bytes) == hash do
+      path = path_for(hash)
+
+      with :ok <- File.mkdir_p(Path.dirname(path)) do
+        File.write(path, bytes)
+      end
+    else
+      {:error, :hash_mismatch}
     end
   end
 

--- a/lib/riptide/blob_store.ex
+++ b/lib/riptide/blob_store.ex
@@ -1,0 +1,54 @@
+defmodule Riptide.BlobStore do
+  @moduledoc """
+  Privileged, content-addressed blob storage — see design spec
+  `docs/superpowers/specs/2026-08-30-phase-6j-large-object-blob-storage-design.md`.
+  Outside the WASI sandbox by design (§4/§9): performs no authorization of its
+  own, every caller is responsible for that. This module covers only
+  single-node local storage; cross-node replication is layered on top in
+  `put/1`'s own SupervisedProcess-wrapped `GenServer` (Task 3).
+  """
+
+  @spec put(binary()) :: {:ok, String.t()} | {:error, term()}
+  def put(bytes) when is_binary(bytes) do
+    hash = hash_of(bytes)
+    path = path_for(hash)
+
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- File.write(path, bytes) do
+      {:ok, hash}
+    end
+  end
+
+  @spec get(String.t()) :: {:ok, binary()} | {:error, :not_found}
+  def get(hash) do
+    case File.read(path_for(hash)) do
+      {:ok, bytes} -> verify(bytes, hash)
+      {:error, _reason} -> {:error, :not_found}
+    end
+  end
+
+  # A locally-stored blob whose bytes don't match their own claimed hash is
+  # corruption, not a valid result (spec §5) — never served silently.
+  defp verify(bytes, hash) do
+    if hash_of(bytes) == hash do
+      {:ok, bytes}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  defp hash_of(bytes),
+    do: bytes |> then(&:crypto.hash(:sha256, &1)) |> Base.encode16(case: :lower)
+
+  # Two-level directory prefix (matching git's own object-store layout) so a
+  # single directory never accumulates an unbounded number of entries.
+  defp path_for(hash) do
+    <<prefix::binary-size(2), rest::binary>> = hash
+    Path.join([data_dir(), prefix, rest])
+  end
+
+  defp data_dir do
+    Application.get_env(:riptide, :blob_data_dir) || System.get_env("RIPTIDE_BLOB_DATA_DIR") ||
+      "priv/blob_data"
+  end
+end

--- a/lib/riptide/blob_store/healer.ex
+++ b/lib/riptide/blob_store/healer.ex
@@ -1,0 +1,109 @@
+defmodule Riptide.BlobStore.Healer do
+  @moduledoc """
+  Background repair for under-replicated blobs — mirrors
+  `Riptide.Stream.ReplicaHealer`'s exact shape (periodic sweep, no new
+  coordination primitive) applied to blob replicas instead of Ra cluster
+  membership (design spec §7). Runs on every fleet node; over-replicating a
+  blob briefly (two nodes both repairing the same under-replicated hash in
+  the same tick) is harmless — unlike a Ra cluster's own membership, extra
+  blob copies cost only a little disk, never correctness — so, unlike
+  `ReplicaHealer`'s own repair, no claim/consensus fencing is needed here.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Riptide.BlobStore
+  alias Riptide.BlobStore.LocationIndex
+
+  @sweep_interval_ms 30_000
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl GenServer
+  def init(:ok) do
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state) do
+    safe_sweep()
+    schedule_sweep()
+    {:noreply, state}
+  end
+
+  defp safe_sweep do
+    sweep()
+  rescue
+    e ->
+      Logger.warning(
+        "BlobStore.Healer sweep failed, skipping this tick (#{Exception.message(e)})"
+      )
+  catch
+    :exit, reason ->
+      Logger.warning("BlobStore.Healer sweep failed, skipping this tick (#{inspect(reason)})")
+  end
+
+  defp schedule_sweep do
+    interval = Application.get_env(:riptide, :blob_healer_sweep_interval_ms, @sweep_interval_ms)
+    Process.send_after(self(), :sweep, interval)
+  end
+
+  @doc "One full pass: drop dead locations, re-replicate anything under the configured factor."
+  @spec sweep() :: :ok
+  def sweep do
+    case LocationIndex.list_all() do
+      {:ok, entries} -> Enum.each(entries, &heal_entry/1)
+      {:error, :not_ready} -> :ok
+    end
+  end
+
+  defp heal_entry({hash, nodes}) do
+    {live, dead} = Enum.split_with(nodes, &node_alive?/1)
+    Enum.each(dead, &LocationIndex.remove_location(hash, &1))
+
+    rf = Application.get_env(:riptide, :blob_replication_factor, 3)
+    missing = rf - length(live)
+
+    if missing > 0 and live != [] do
+      # Computed here, not inside re_replicate/4, so a hash with no actual
+      # candidate node to repair onto (Node.list() has nothing new to
+      # offer) skips fetching its bytes entirely — re_replicate/4's own
+      # empty-candidates clause short-circuits before any disk read, so a
+      # sweep never wastes I/O re-reading every under-replicated blob's
+      # full bytes on every tick when there's nowhere to send them.
+      candidates = (Node.list() -- live) |> Enum.sort() |> Enum.take(missing)
+      re_replicate(hash, live, missing, candidates)
+    end
+  end
+
+  # Blob replicas are plain fleet nodes, not Ra cluster members — liveness
+  # is a plain distributed-Erlang connectivity check, not
+  # `RaCluster.member_alive?/1` (that function checks a specific named `:ra`
+  # server process, which no blob replica runs).
+  defp node_alive?(n) when n == node(), do: true
+  defp node_alive?(n), do: n in Node.list()
+
+  defp re_replicate(_hash, _live_nodes, _missing, [] = _candidates), do: :ok
+
+  defp re_replicate(hash, live_nodes, _missing, candidates) do
+    with [source | _] <- live_nodes,
+         {:ok, bytes} <- fetch_from(source, hash) do
+      Enum.each(candidates, &replicate_to(&1, hash, bytes))
+    end
+  end
+
+  defp replicate_to(target, hash, bytes) do
+    case :rpc.call(target, BlobStore, :receive_replica, [hash, bytes], 30_000) do
+      :ok -> LocationIndex.add_location(hash, target)
+      _other -> :ok
+    end
+  end
+
+  defp fetch_from(node, hash) when node == node(), do: BlobStore.receive_replica_bytes(hash)
+
+  defp fetch_from(node, hash),
+    do: :rpc.call(node, BlobStore, :receive_replica_bytes, [hash], 30_000)
+end

--- a/lib/riptide/blob_store/location_index.ex
+++ b/lib/riptide/blob_store/location_index.ex
@@ -1,0 +1,114 @@
+defmodule Riptide.BlobStore.LocationIndex do
+  @moduledoc """
+  Durable `hash → [nodes holding a verified copy]` tracking for
+  `Riptide.BlobStore` (design spec §7). One well-known, fixed stream — not
+  per-Tenant scoped, since blobs are inherently cross-tenant-shared at the
+  storage layer (spec §9) — reusing the same generic `StreamServer`/`Patch`
+  mechanism `Riptide.Derivation.Catalog` already uses for its own dedicated
+  streams, rather than a bespoke `:ra_machine`.
+  """
+
+  alias Riptide.Event
+  alias Riptide.Placement
+  alias Riptide.RDF.Patch
+  alias Riptide.Stream.{StreamServer, StreamSupervisor}
+
+  @stream_id "https://riptide.example/blob-location-index"
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_hash_entry RDF.iri("urn:riptide:vocab:BlobHashEntry")
+  @riptide_located_on RDF.iri("urn:riptide:vocab:locatedOn")
+  @hash_prefix "urn:riptide-blob:sha256:"
+  @node_prefix "urn:riptide:node:"
+
+  @spec stream_id() :: String.t()
+  def stream_id, do: @stream_id
+
+  @spec add_location(String.t(), node()) :: :ok | {:error, :not_ready}
+  def add_location(hash, node) do
+    hash_iri = hash_iri(hash)
+
+    write_patch(
+      [
+        {hash_iri, @rdf_type, @riptide_hash_entry},
+        {hash_iri, @riptide_located_on, node_iri(node)}
+      ],
+      []
+    )
+  end
+
+  @spec remove_location(String.t(), node()) :: :ok | {:error, :not_ready}
+  def remove_location(hash, node) do
+    write_patch([], [{hash_iri(hash), @riptide_located_on, node_iri(node)}])
+  end
+
+  @spec list_locations(String.t()) :: {:ok, [node()]} | {:error, :not_ready}
+  def list_locations(hash) do
+    with {:ok, graph} <- read_graph() do
+      nodes =
+        graph
+        |> RDF.Graph.get(hash_iri(hash))
+        |> then(fn
+          nil -> []
+          description -> RDF.Description.get(description, @riptide_located_on, [])
+        end)
+        |> Enum.map(&iri_to_node/1)
+
+      {:ok, nodes}
+    end
+  end
+
+  defp hash_iri(hash), do: RDF.iri(@hash_prefix <> hash)
+  defp node_iri(node), do: RDF.iri(@node_prefix <> Atom.to_string(node))
+
+  defp iri_to_node(iri) do
+    iri |> RDF.IRI.to_string() |> String.trim_leading(@node_prefix) |> String.to_atom()
+  end
+
+  defp write_patch(additions, removals) do
+    case @stream_id
+         |> StreamSupervisor.ensure_ready()
+         |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        StreamServer.append(
+          @stream_id,
+          Event.new(@stream_id, :patch, %Patch{additions: additions, removals: removals})
+        )
+
+        :ok
+
+      :error ->
+        {:error, :not_ready}
+    end
+  end
+
+  defp read_graph do
+    case Placement.lookup(@stream_id) do
+      nil -> {:ok, RDF.Graph.new()}
+      _nodes -> read_existing_graph()
+    end
+  end
+
+  defp read_existing_graph do
+    case @stream_id
+         |> StreamSupervisor.ensure_ready()
+         |> StreamSupervisor.ensure_ready_status() do
+      :ok -> read_events()
+      :error -> {:error, :not_ready}
+    end
+  end
+
+  defp read_events do
+    case StreamServer.get_since(@stream_id, 0) do
+      {:ok, events} -> {:ok, fold_events(events)}
+      {:gap, _oldest} -> {:ok, RDF.Graph.new()}
+    end
+  end
+
+  defp fold_events(events) do
+    Enum.reduce(events, RDF.Graph.new(), fn
+      %Event{operation: :patch, payload: %Patch{} = patch}, acc -> Patch.apply(acc, patch)
+      %Event{operation: :delete}, _acc -> RDF.Graph.new()
+      %Event{operation: :replace, payload: payload}, _acc -> payload
+    end)
+  end
+end

--- a/lib/riptide/blob_store/location_index.ex
+++ b/lib/riptide/blob_store/location_index.ex
@@ -57,6 +57,31 @@ defmodule Riptide.BlobStore.LocationIndex do
     end
   end
 
+  @spec list_all() :: {:ok, %{String.t() => [node()]}} | {:error, :not_ready}
+  def list_all do
+    with {:ok, graph} <- read_graph() do
+      entries =
+        graph
+        |> RDF.Graph.subjects()
+        |> Enum.filter(fn s ->
+          RDF.Graph.get(graph, s) |> RDF.Description.first(@rdf_type) == @riptide_hash_entry
+        end)
+        |> Map.new(fn hash_iri -> {hash_from_iri(hash_iri), locations_for(graph, hash_iri)} end)
+
+      {:ok, entries}
+    end
+  end
+
+  defp hash_from_iri(hash_iri),
+    do: hash_iri |> RDF.IRI.to_string() |> String.trim_leading(@hash_prefix)
+
+  defp locations_for(graph, hash_iri) do
+    graph
+    |> RDF.Graph.get(hash_iri)
+    |> RDF.Description.get(@riptide_located_on, [])
+    |> Enum.map(&iri_to_node/1)
+  end
+
   defp hash_iri(hash), do: RDF.iri(@hash_prefix <> hash)
   defp node_iri(node), do: RDF.iri(@node_prefix <> Atom.to_string(node))
 

--- a/test/riptide/blob_store/healer_test.exs
+++ b/test/riptide/blob_store/healer_test.exs
@@ -1,0 +1,30 @@
+defmodule Riptide.BlobStore.HealerTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.BlobStore
+  alias Riptide.BlobStore.{Healer, LocationIndex}
+
+  # LocationIndex's own stream is shared across the whole suite — never
+  # force-deleted here, matching LocationIndexTest's own established
+  # convention; both tests below use a hash unique to that one test.
+
+  test "sweep/0 is a no-op for a hash already at the configured replication factor" do
+    bytes = :crypto.strong_rand_bytes(1024)
+    {:ok, _hash} = BlobStore.put(bytes)
+
+    # Single-node test environment: put/1 already recorded exactly [node()],
+    # and the configured factor defaults to 3 — under-replicated in absolute
+    # terms, but with zero other live nodes to repair onto, sweep/0 must not
+    # raise or loop forever; it just can't do anything this tick.
+    assert :ok = Healer.sweep()
+  end
+
+  test "sweep/0 drops a location no longer reachable" do
+    hash = "deliberately-unreachable-#{System.unique_integer([:positive])}"
+    :ok = LocationIndex.add_location(hash, :"nonexistent@127.0.0.1")
+
+    :ok = Healer.sweep()
+
+    assert {:ok, []} = LocationIndex.list_locations(hash)
+  end
+end

--- a/test/riptide/blob_store/location_index_test.exs
+++ b/test/riptide/blob_store/location_index_test.exs
@@ -42,4 +42,15 @@ defmodule Riptide.BlobStore.LocationIndexTest do
 
     assert {:ok, [:"node_b@127.0.0.1"]} = LocationIndex.list_locations(hash)
   end
+
+  test "list_all/0 returns every tracked hash with its current node set" do
+    hash1 = unique_hash()
+    hash2 = unique_hash()
+    :ok = LocationIndex.add_location(hash1, :"node_a@127.0.0.1")
+    :ok = LocationIndex.add_location(hash2, :"node_b@127.0.0.1")
+
+    assert {:ok, all} = LocationIndex.list_all()
+    assert all[hash1] == [:"node_a@127.0.0.1"]
+    assert all[hash2] == [:"node_b@127.0.0.1"]
+  end
 end

--- a/test/riptide/blob_store/location_index_test.exs
+++ b/test/riptide/blob_store/location_index_test.exs
@@ -1,0 +1,45 @@
+defmodule Riptide.BlobStore.LocationIndexTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.BlobStore.LocationIndex
+
+  # LocationIndex's own stream is a single, shared stream across the whole
+  # test suite (like :hub's own catalog — see catalog_test.exs's "Hub vs.
+  # Tenant scope isolation" test for why) — never force-deleted here, since
+  # that can leave the very next writer hitting :noproc before the lazy
+  # re-create catches up. Every test below queries only its own unique
+  # hash, so accumulation across runs is harmless.
+  defp unique_hash, do: "hash#{System.unique_integer([:positive])}"
+
+  test "add_location/2 then list_locations/1 finds the node" do
+    hash = unique_hash()
+
+    :ok = LocationIndex.add_location(hash, :"node_a@127.0.0.1")
+
+    assert {:ok, [:"node_a@127.0.0.1"]} = LocationIndex.list_locations(hash)
+  end
+
+  test "a hash with no recorded location returns {:ok, []}" do
+    assert {:ok, []} = LocationIndex.list_locations(unique_hash())
+  end
+
+  test "multiple add_location/2 calls accumulate distinct nodes" do
+    hash = unique_hash()
+
+    :ok = LocationIndex.add_location(hash, :"node_a@127.0.0.1")
+    :ok = LocationIndex.add_location(hash, :"node_b@127.0.0.1")
+
+    assert {:ok, nodes} = LocationIndex.list_locations(hash)
+    assert Enum.sort(nodes) == Enum.sort([:"node_a@127.0.0.1", :"node_b@127.0.0.1"])
+  end
+
+  test "remove_location/2 drops exactly that node" do
+    hash = unique_hash()
+    :ok = LocationIndex.add_location(hash, :"node_a@127.0.0.1")
+    :ok = LocationIndex.add_location(hash, :"node_b@127.0.0.1")
+
+    :ok = LocationIndex.remove_location(hash, :"node_a@127.0.0.1")
+
+    assert {:ok, [:"node_b@127.0.0.1"]} = LocationIndex.list_locations(hash)
+  end
+end

--- a/test/riptide/blob_store_capstone_test.exs
+++ b/test/riptide/blob_store_capstone_test.exs
@@ -1,0 +1,97 @@
+defmodule Riptide.BlobStoreCapstoneTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Authz.Policy
+  alias Riptide.BlobStore
+  alias Riptide.Capability
+  alias Riptide.Capability.Definition
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "blob_capstone_#{System.unique_integer([:positive])}")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :blob_data_dir, dir)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    FakeStore.start(%{
+      {"acme", ["capabilities", "greetPerson"]} => [
+        %Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      ]
+    })
+
+    on_exit(fn ->
+      File.rm_rf!(dir)
+
+      if pid = Process.whereis(FakeStore) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  test "exit criterion (issue #72): a Capability's output is stored as a blob, retrievable via a hash-pointer Fact" do
+    definition = %Definition{
+      name: RDF.iri("urn:riptide:capability:greetPerson"),
+      kind: :effect,
+      component: "test/fixtures/riptide_capability/fixture.wasm",
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    assert {:ok, output} = Capability.invoke(definition, "acme", nil, ["World"])
+
+    assert {:ok, hash} = BlobStore.put(output)
+
+    # The hash-pointer Fact: an ordinary RDF triple a real ExecuteInterpreter
+    # caller would write onto whatever resource this Capability's result
+    # attaches to — hand-built here since general Capability-output-to-blob
+    # wiring is explicitly out of scope for this phase (spec §3).
+    fact =
+      {RDF.iri("urn:test:greeting-result"), RDF.iri("urn:test:attachment"),
+       RDF.iri("urn:riptide-blob:sha256:" <> hash)}
+
+    graph = RDF.Graph.new([fact])
+
+    extracted_hash =
+      graph
+      |> RDF.Graph.get(RDF.iri("urn:test:greeting-result"))
+      |> RDF.Description.first(RDF.iri("urn:test:attachment"))
+      |> RDF.IRI.to_string()
+      |> String.trim_leading("urn:riptide-blob:sha256:")
+
+    assert extracted_hash == hash
+    assert {:ok, ^output} = BlobStore.get(extracted_hash)
+  end
+end

--- a/test/riptide/blob_store_cluster_test.exs
+++ b/test/riptide/blob_store_cluster_test.exs
@@ -1,0 +1,269 @@
+defmodule Riptide.BlobStoreClusterTest do
+  use ExUnit.Case, async: false
+
+  import Riptide.MultiNodeTestHelpers, only: [unique_pairs: 1]
+
+  @moduletag timeout: 120_000
+
+  @peers [
+    {:blob_a, "blob-a", ~c"127.0.0.50"},
+    {:blob_b, "blob-b", ~c"127.0.0.51"},
+    {:blob_c, "blob-c", ~c"127.0.0.52"}
+  ]
+
+  # A 4th, spare node — only the healer test needs it. With exactly 3 peers
+  # total (RF), killing one leaves only 2 remaining nodes, both already
+  # holding a copy — there's no unused node anywhere for the healer to
+  # promote as a replacement, so "repair" could never be observed. Mirrors
+  # ra_cluster_replace_member_test.exs's own @peers ++ [@replacement] shape
+  # for the exact same reason.
+  @spare {:blob_d, "blob-d", ~c"127.0.0.53"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"blob_store_cluster_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "put/1 replicates to RF other live nodes; get/1 succeeds from a node that never wrote it" do
+    peers = bootstrap_peers(@peers)
+    [{_pid_a, node_a, _}, {_pid_b, node_b, _}, {_pid_c, node_c, _}] = peers
+
+    bytes = :crypto.strong_rand_bytes(1024)
+
+    assert {:ok, hash} = :erpc.call(node_a, Riptide.BlobStore, :put, [bytes])
+
+    assert eventually(fn ->
+             case :erpc.call(node_a, Riptide.BlobStore.LocationIndex, :list_locations, [hash]) do
+               {:ok, nodes} -> Enum.sort(nodes) == Enum.sort([node_a, node_b, node_c])
+               _ -> false
+             end
+           end)
+
+    # node_c never received the original put/1 directly from a test call —
+    # it only has a copy because put/1's own replication pushed one there.
+    assert {:ok, ^bytes} = :erpc.call(node_c, Riptide.BlobStore, :get, [hash])
+  end
+
+  test "a corrupted local copy is rejected on read, not silently served" do
+    peers = bootstrap_peers(@peers)
+    [{_pid_a, node_a, _}, _peer_b, _peer_c] = peers
+
+    bytes = :crypto.strong_rand_bytes(1024)
+    {:ok, hash} = :erpc.call(node_a, Riptide.BlobStore, :put, [bytes])
+
+    # Corrupt node_a's own local copy directly on disk.
+    path = :erpc.call(node_a, Riptide.BlobStore, :path_for, [hash])
+    :erpc.call(node_a, File, :write, [path, "corrupted"])
+
+    assert {:error, :not_found} = :erpc.call(node_a, Riptide.BlobStore, :get, [hash])
+  end
+
+  test "healer repairs a blob after its holding node dies" do
+    peers = bootstrap_peers(@peers ++ [@spare])
+    [{_pid_a, node_a, _}, {_pid_b, _node_b, _}, {_pid_c, node_c, _}, {_pid_d, _node_d, _}] = peers
+
+    bytes = :crypto.strong_rand_bytes(1024)
+    {:ok, hash} = :erpc.call(node_a, Riptide.BlobStore, :put, [bytes])
+
+    assert eventually(fn ->
+             match?(
+               {:ok, [_, _, _]},
+               :erpc.call(node_a, Riptide.BlobStore.LocationIndex, :list_locations, [hash])
+             )
+           end)
+
+    stop_peer_for(peers, node_c)
+
+    assert eventually(
+             fn ->
+               :erpc.call(node_a, Riptide.BlobStore.Healer, :sweep, [])
+
+               case :erpc.call(node_a, Riptide.BlobStore.LocationIndex, :list_locations, [hash]) do
+                 {:ok, nodes} -> length(nodes) == 3 and node_c not in nodes
+                 _ -> false
+               end
+             end,
+             100
+           )
+
+    # The repaired-in replica set still serves the original bytes correctly.
+    {:ok, [n | _]} = :erpc.call(node_a, Riptide.BlobStore.LocationIndex, :list_locations, [hash])
+    assert {:ok, ^bytes} = :erpc.call(n, Riptide.BlobStore, :get, [hash])
+  end
+
+  # Bare `:peer` nodes never boot the full Riptide.Application (its
+  # RiptideWeb.Endpoint/MetricsEndpoint would conflict on the same ports
+  # across multiple simultaneously-running peers on this one machine) —
+  # mirrors test/riptide/placement_membership_cluster_test.exs's own
+  # established pattern of starting only the specific pieces this test
+  # actually needs, not the whole app.
+  defp bootstrap_peers(specs) do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    peers =
+      for {alive_name, ordinal, host} <- specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, &stop_peer/1)
+
+      Enum.each(specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"blob_store_cluster_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, ordinal} <- peers do
+      bootstrap_node(node, ordinal)
+    end
+
+    # PlacementMembership's own genesis formation normally waits on a short
+    # settle window (Phase 3e) plus the periodic :reconcile tick — too slow
+    # for a test. bootstrap_once/0 is the public, synchronous, idempotent
+    # "join or form genesis right now" entry point tests are meant to call
+    # directly (see its own doc). Called on every peer since any of them
+    # might be the one that actually forms the cluster; the others just
+    # discover it as already-formed.
+    for {_pid, node, _ordinal} <- peers do
+      :ok = :erpc.call(node, Riptide.PlacementMembership, :bootstrap_once, [])
+    end
+
+    # Only the first `target_size/0` (default 3) sorted candidates ever
+    # become placement-cluster members — form_genesis_if_selected/0 caps
+    # genesis at target_size(), and reconcile/0's own ambient try_join only
+    # fires `if length(members) < target_size()`, which is never true again
+    # once exactly 3 have joined. A 4th, spare peer (see @spare) is
+    # therefore NEVER expected to join the placement cluster itself — it
+    # only needs distributed-Erlang connectivity (already established above
+    # via connect_node/1) to run its own BlobStore/Healer and receive
+    # replicated blob bytes. Waiting on ALL of `peers` here would never
+    # converge whenever a spare is present.
+    core_peers = Enum.take(peers, Riptide.PlacementMembership.target_size())
+
+    assert eventually(fn ->
+             Enum.all?(core_peers, fn {_pid, node, _ordinal} ->
+               match?(
+                 {:ok, _},
+                 :erpc.call(node, Riptide.RaCluster.Placement, :local_placement_members, [])
+               )
+             end)
+           end)
+
+    peers
+  end
+
+  defp bootstrap_node(node, ordinal) do
+    :erpc.call(node, System, :put_env, [
+      "RIPTIDE_BLOB_DATA_DIR",
+      Path.join(File.cwd!(), "#{ordinal}/blob_data")
+    ])
+
+    {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+
+    case :erpc.call(node, :ra_system, :start, [
+           :erpc.call(node, Riptide.RaCluster, :system_config, [])
+         ]) do
+      {:ok, _pid} -> :ok
+      {:ok, _pid, _info} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+
+    {:ok, _} =
+      start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+
+    {:ok, _} = start_unlinked(node, Riptide.PlacementMembership, :start_link, [[]])
+    {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+
+    {:ok, _} =
+      start_unlinked(node, Registry, :start_link, [
+        [keys: :unique, name: Riptide.SupervisedProcess.Registry]
+      ])
+
+    {:ok, _} =
+      start_unlinked(node, DynamicSupervisor, :start_link, [
+        [strategy: :one_for_one, name: Riptide.SupervisedProcess.DynamicSupervisor]
+      ])
+
+    {:ok, _} = start_unlinked(node, Riptide.BlobStore, :start_link, [[]])
+    {:ok, _} = start_unlinked(node, Riptide.BlobStore.Healer, :start_link, [[]])
+  end
+
+  # Starts `apply(mod, fun, args)` on `node` without linking whatever it
+  # starts to the transient process `:erpc.call/4` uses to dispatch the
+  # call — mirrors placement_membership_cluster_test.exs's own helper of
+  # the same name/shape exactly.
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+    ref = make_ref()
+
+    :erpc.call(node, Kernel, :spawn, [
+      fn ->
+        result = apply(mod, fun, args)
+        send(parent, {ref, result})
+        Process.sleep(:infinity)
+      end
+    ])
+
+    receive do
+      {^ref, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp stop_peer_for(peers, target_node) do
+    {pid, ^target_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == target_node end)
+
+    stop_peer({pid, target_node, nil})
+  end
+
+  defp stop_peer({pid, _node, _ordinal}) do
+    if Process.alive?(pid) do
+      try do
+        :peer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -34,4 +34,23 @@ defmodule Riptide.BlobStoreTest do
     assert {:ok, hash} = BlobStore.put(bytes)
     assert {:ok, ^bytes} = BlobStore.get(hash)
   end
+
+  test "the blob store is registered and reachable via Riptide.SupervisedProcess" do
+    assert [{pid, Riptide.BlobStore}] =
+             Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store")
+
+    assert Process.alive?(pid)
+  end
+
+  test "a restart is allowed once put/1 has completed and the process is idle" do
+    bytes = :crypto.strong_rand_bytes(1024)
+    assert {:ok, _hash} = BlobStore.put(bytes)
+
+    # Proves session_active?/1 and handle_stop_if_idle/4 are wired correctly
+    # for the idle case; genuinely proving a restart is *refused* mid-write
+    # needs a deliberately slow/blocking write to interleave a concurrent
+    # restart request against, which isn't worth the complexity here — the
+    # wiring itself (this test) is what's load-bearing to verify.
+    assert :ok = Riptide.SupervisedProcess.request_restart("blob_store")
+  end
 end

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -1,0 +1,37 @@
+defmodule Riptide.BlobStoreTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.BlobStore
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "blob_store_test_#{System.unique_integer([:positive])}")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :blob_data_dir, dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    :ok
+  end
+
+  test "put/1 then get/1 round-trips the exact bytes" do
+    bytes = :crypto.strong_rand_bytes(1024)
+
+    assert {:ok, hash} = BlobStore.put(bytes)
+    assert {:ok, ^bytes} = BlobStore.get(hash)
+  end
+
+  test "the returned hash is the SHA-256 hex digest of the content" do
+    bytes = "hello world"
+    expected = Base.encode16(:crypto.hash(:sha256, bytes), case: :lower)
+
+    assert {:ok, ^expected} = BlobStore.put(bytes)
+  end
+
+  test "get/1 for an unknown hash returns :not_found" do
+    assert {:error, :not_found} = BlobStore.get(String.duplicate("0", 64))
+  end
+
+  test "a blob well over 10MB round-trips correctly" do
+    bytes = :crypto.strong_rand_bytes(11 * 1024 * 1024)
+
+    assert {:ok, hash} = BlobStore.put(bytes)
+    assert {:ok, ^bytes} = BlobStore.get(hash)
+  end
+end

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -46,11 +46,45 @@ defmodule Riptide.BlobStoreTest do
     bytes = :crypto.strong_rand_bytes(1024)
     assert {:ok, _hash} = BlobStore.put(bytes)
 
+    [{old_pid, Riptide.BlobStore}] =
+      Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store")
+
     # Proves session_active?/1 and handle_stop_if_idle/4 are wired correctly
     # for the idle case; genuinely proving a restart is *refused* mid-write
     # needs a deliberately slow/blocking write to interleave a concurrent
     # restart request against, which isn't worth the complexity here — the
     # wiring itself (this test) is what's load-bearing to verify.
     assert :ok = Riptide.SupervisedProcess.request_restart("blob_store")
+
+    # Riptide.BlobStore is a single, application-wide singleton (not a
+    # fresh process per test) — request_restart/1 returning :ok only means
+    # the restart was *accepted*, not that the old process has finished
+    # exiting and a new one has finished starting. Without waiting for a
+    # genuinely new pid to appear, a later test's own BlobStore.put/1 call
+    # can race the still-dying old process and hit a spurious
+    # :restart_requested exit — wait here so every subsequent test starts
+    # from a fully-settled state.
+    assert eventually(fn ->
+             case Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store") do
+               [{^old_pid, Riptide.BlobStore}] -> false
+               [{new_pid, Riptide.BlobStore}] -> Process.alive?(new_pid)
+               [] -> false
+             end
+           end)
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(20) && eventually(fun, attempts_left - 1)
+    end
+  end
+
+  test "put/1 on a single connected node records exactly that node in the location index" do
+    bytes = :crypto.strong_rand_bytes(1024)
+    assert {:ok, hash} = BlobStore.put(bytes)
+
+    assert {:ok, [node()]} == Riptide.BlobStore.LocationIndex.list_locations(hash)
   end
 end

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -2,6 +2,7 @@ defmodule Riptide.BlobStoreTest do
   use ExUnit.Case, async: false
 
   alias Riptide.BlobStore
+  alias Riptide.BlobStore.LocationIndex
 
   setup do
     dir = Path.join(System.tmp_dir!(), "blob_store_test_#{System.unique_integer([:positive])}")
@@ -85,12 +86,12 @@ defmodule Riptide.BlobStoreTest do
     bytes = :crypto.strong_rand_bytes(1024)
     assert {:ok, hash} = BlobStore.put(bytes)
 
-    assert {:ok, [node()]} == Riptide.BlobStore.LocationIndex.list_locations(hash)
+    assert {:ok, [node()]} == LocationIndex.list_locations(hash)
   end
 
   test "get/1 falls back to the location index on a local miss, still returns :not_found if no listed node has it either" do
     hash = String.duplicate("a", 64)
-    :ok = Riptide.BlobStore.LocationIndex.add_location(hash, node())
+    :ok = LocationIndex.add_location(hash, node())
 
     # node() itself is listed but has no local file for this hash — the
     # fallback path must terminate cleanly rather than loop or crash when
@@ -107,7 +108,7 @@ defmodule Riptide.BlobStoreTest do
     # force-delete, since LocationIndex's stream is shared across the whole
     # suite and force-deleting it races any other test/process writing to
     # it) so this hash now has no location index entry at all.
-    :ok = Riptide.BlobStore.LocationIndex.remove_location(hash, node())
+    :ok = LocationIndex.remove_location(hash, node())
 
     # If get/1 incorrectly consulted the (now hash-less) location index
     # before checking local disk, this would fail.

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -55,6 +55,7 @@ defmodule Riptide.BlobStoreTest do
     # needs a deliberately slow/blocking write to interleave a concurrent
     # restart request against, which isn't worth the complexity here — the
     # wiring itself (this test) is what's load-bearing to verify.
+    ref = Process.monitor(old_pid)
     assert :ok = Riptide.SupervisedProcess.request_restart("blob_store")
 
     # Riptide.BlobStore is a single, application-wide singleton (not a
@@ -64,10 +65,17 @@ defmodule Riptide.BlobStoreTest do
     # genuinely new pid to appear, a later test's own BlobStore.put/1 call
     # can race the still-dying old process and hit a spurious
     # :restart_requested exit — wait here so every subsequent test starts
-    # from a fully-settled state.
+    # from a fully-settled state. Mirrors
+    # test/riptide/supervised_process_test.exs's own established two-step
+    # pattern (deterministic :DOWN wait for the old process's actual exit,
+    # then poll for re-registration) rather than polling a single window
+    # for both at once — a single combined window measurably under-budgets
+    # a slower CI runner's real restart latency, caught live via CI
+    # (passed consistently locally, failed on CI's own hardware).
+    assert_receive {:DOWN, ^ref, :process, ^old_pid, _reason}, 5_000
+
     assert eventually(fn ->
              case Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store") do
-               [{^old_pid, Riptide.BlobStore}] -> false
                [{new_pid, Riptide.BlobStore}] -> Process.alive?(new_pid)
                [] -> false
              end

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -87,4 +87,30 @@ defmodule Riptide.BlobStoreTest do
 
     assert {:ok, [node()]} == Riptide.BlobStore.LocationIndex.list_locations(hash)
   end
+
+  test "get/1 falls back to the location index on a local miss, still returns :not_found if no listed node has it either" do
+    hash = String.duplicate("a", 64)
+    :ok = Riptide.BlobStore.LocationIndex.add_location(hash, node())
+
+    # node() itself is listed but has no local file for this hash — the
+    # fallback path must terminate cleanly rather than loop or crash when
+    # every listed node comes up empty.
+    assert {:error, :not_found} = BlobStore.get(hash)
+  end
+
+  test "get/1 for a genuinely present local blob never touches the location index" do
+    bytes = :crypto.strong_rand_bytes(1024)
+    {:ok, hash} = BlobStore.put(bytes)
+
+    # put/1 already recorded node() in the location index for this hash —
+    # remove just that one entry (an ordinary write, not a stream-level
+    # force-delete, since LocationIndex's stream is shared across the whole
+    # suite and force-deleting it races any other test/process writing to
+    # it) so this hash now has no location index entry at all.
+    :ok = Riptide.BlobStore.LocationIndex.remove_location(hash, node())
+
+    # If get/1 incorrectly consulted the (now hash-less) location index
+    # before checking local disk, this would fail.
+    assert {:ok, ^bytes} = BlobStore.get(hash)
+  end
 end


### PR DESCRIPTION
## Summary
- Implements Track C's 6j — content-addressed, RF-replicated blob storage as a privileged, built-in instance of 6b-ii's `Riptide.SupervisedProcess` primitive.
- Content-addressed via SHA-256 (whole-blob hashing); bytes replicate to RF (default 3) other live nodes via direct distributed-Erlang calls, never through Ra consensus, since immutable content-addressed bytes need no consensus to replicate safely.
- A dedicated location index (`hash -> [nodes]`) and a repair healer, mirroring `Riptide.Stream.ReplicaHealer`'s own shape, keep a blob's replica count at RF even after a node dies.
- Garbage collection is fully specified (reference-counted manifest state machine, adapted from Riak CS) but explicitly not implemented this phase, per the spec's own scope.
- Motivated by a concrete gap: `Riptide.Capability.invoke/4` requires a literal local filesystem path, so dynamic Capability registration (future work) needs durable, fleet-reachable blob storage underneath it.

Spec: `docs/superpowers/specs/2026-08-30-phase-6j-large-object-blob-storage-design.md` (PR #113).

## Test plan
- [x] `mix test` — full suite green (505 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR