### PR TITLE
Draft: Resolve: "6k — Dynamic Capability Registration"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ priv/ra_data_test/
 # RIPTIDE_BLOB_DATA_DIR/:blob_data_dir isn't overridden — see Phase 6j).
 priv/blob_data/
 
+# Riptide.Derivation.CapabilityCatalog's private local materialization
+# cache (default path when RIPTIDE_CAPABILITY_CACHE_DIR/:capability_cache_dir
+# isn't overridden — see Phase 6k).
+priv/capability_cache/
+
 # Ra's on-disk data directories for the real-:peer-spawned nodes in
 # multi_node_connectivity_test.exs: those bare peer nodes don't load
 # config/test.exs (no Mix config in a plain `:peer`-started node), so

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage) — 5 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration) — 4 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -1046,4 +1046,56 @@ replication doesn't need it to: RF-replication and the healer both work over pla
 connectivity (`Node.list()`), entirely independent of placement-cluster membership.
 
 **Status**: Phase 6j shipped 2026-08-31. 5 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6k — Dynamic Capability Registration
+
+**Shipped 2026-08-31** — see
+`docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md`.
+
+Closes the concrete gap 6j's own spec named but left out of scope: `Riptide.Capability.invoke/4`
+shells out to `wasmtime` against a literal local filesystem path, and
+`Riptide.Derivation.ExecuteInterpreter.Context` has no catalog of its own — every caller must
+hand-build its `capabilities`/`rules` maps. This phase gives Capabilities a real, reviewed, Hub-scope
+catalog addressable by IRI. Wiring that catalog into `Context` resolution and reactively triggering
+invocation from a Fact write is 6l, a separate, dependent phase not yet started.
+
+New `Riptide.Derivation.CapabilityCatalogEntry` mirrors `Capability.Definition`'s own field set
+exactly, except `component` (a literal local path, meaningless outside the node that received it) is
+replaced by `component_hash` — a `BlobStore` content hash. Storage/review mirror 6i's `Crosswalk`/
+`PendingCrosswalkReview` precedent exactly: a sibling stream off the Hub catalog, a
+`PendingCapabilityReview` with no anti-unification or fidelity-replay (a Capability isn't a
+generalization of anything, so there's nothing to replay-test), reviewed through the same
+`DedupGate` authority as any other Hub content.
+
+New `Riptide.Derivation.CapabilityCatalog.materialize/1` resolves a catalog entry into a real,
+invokable `Definition` — reusing a local `BlobStore` replica if this node already holds one (checked
+via `BlobStore.path_for/1`, zero extra copy), otherwise fetching via `BlobStore.get/1` and caching the
+bytes in a *private* local directory, deliberately not registered with `BlobStore`'s own
+`LocationIndex` (a materialize-only optimization cache, not an official replica other nodes should be
+routed to). Zero changes to `Riptide.Capability`/`Definition`/`invoke/4` themselves — this phase is
+purely additive.
+
+`POST /tenants/:tenant_id/hub/capabilities` accepts both the Definition metadata and the WASM bytes
+(base64-encoded, in the same JSON body every other Hub controller already uses) in one request,
+calling `BlobStore.put/1` internally — without giving `BlobStore` itself a general-purpose upload
+endpoint, respecting 6j's own stated scope boundary.
+
+Catalog admission ("this Capability is vetted") and invoke authorization ("this tenant may invoke
+it") stay the cleanly separate concerns they already are: approving a Capability into the Hub catalog
+does not itself authorize anyone to invoke it — a tenant still needs its own `Policy` granting
+`:invoke`, exactly as today for any caller-supplied Capability.
+
+Two real bugs found and fixed during implementation, both caught by the tests that were supposed to
+catch them: (1) `CapabilityCatalogRDFCodec`'s memory-limits sub-node crashed decoding a
+fully-`nil` `memory_limits` — `encode_memory_limits/1` adds zero triples when every field is nil, so
+`RDF.Graph.get/2` returns `nil` rather than an empty `%RDF.Description{}`, and
+`RDF.Description.first/2` doesn't accept `nil`; fixed with an explicit case on the graph lookup
+result. (2) The real multi-node `materialize/1` test initially used only 3 peers, but with the
+default replication factor also 3, `BlobStore.put/1`'s own replication always reaches every connected
+node deterministically in a 3-node cluster — leaving no node to prove a genuine remote fetch from;
+fixed with a 4th, alphabetically-last spare peer `other_nodes/0`'s own sort always excludes, mirroring
+`blob_store_cluster_test.exs`'s own identical fix for the identical class of problem.
+
+**Status**: Phase 6k shipped 2026-08-31. 4 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/derivation/capability_catalog.ex
+++ b/lib/riptide/derivation/capability_catalog.ex
@@ -1,0 +1,81 @@
+defmodule Riptide.Derivation.CapabilityCatalog do
+  @moduledoc """
+  Resolves a Hub-scope `CapabilityCatalogEntry` into a real, invokable
+  `Riptide.Capability.Definition` — see design spec
+  `docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md`
+  §5. Storage/review live in `Riptide.Derivation.Catalog`/`DedupGate`; this
+  module only handles turning a `component_hash` into a literal local path
+  `Capability.invoke/4` can actually shell out to.
+  """
+
+  alias Riptide.BlobStore
+  alias Riptide.Capability.Definition
+  alias Riptide.Derivation.{CapabilityCatalogEntry, Catalog}
+
+  @doc """
+  Finds a Hub-scope Capability by its own `name` IRI. A thin wrapper over
+  `Catalog.list_capabilities/0` — shared here (not duplicated at each call
+  site) since both this module's own capstone usage and 6l's
+  `ContextResolver` need the exact same "resolve by name" lookup.
+  """
+  @spec find_by_name(RDF.IRI.t()) :: {:ok, CapabilityCatalogEntry.t()} | {:error, :not_found}
+  def find_by_name(name) do
+    with {:ok, entries} <- Catalog.list_capabilities() do
+      find_entry(entries, name)
+    end
+  end
+
+  defp find_entry(entries, name) do
+    case Enum.find(entries, fn {_node, entry} -> entry.name == name end) do
+      {_node, entry} -> {:ok, entry}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  @spec materialize(CapabilityCatalogEntry.t()) :: {:ok, Definition.t()} | {:error, term()}
+  def materialize(%CapabilityCatalogEntry{} = entry) do
+    with {:ok, path} <- ensure_local(entry.component_hash) do
+      {:ok,
+       %Definition{
+         name: entry.name,
+         kind: entry.kind,
+         component: path,
+         function: entry.function,
+         fuel_limit: entry.fuel_limit,
+         timeout_ms: entry.timeout_ms,
+         memory_limits: entry.memory_limits
+       }}
+    end
+  end
+
+  defp ensure_local(hash) do
+    local_path = BlobStore.path_for(hash)
+
+    if File.exists?(local_path) do
+      {:ok, local_path}
+    else
+      fetch_and_cache(hash)
+    end
+  end
+
+  defp fetch_and_cache(hash) do
+    with {:ok, bytes} <- BlobStore.get(hash) do
+      path = cache_path_for(hash)
+
+      with :ok <- File.mkdir_p(Path.dirname(path)),
+           :ok <- File.write(path, bytes) do
+        {:ok, path}
+      end
+    end
+  end
+
+  defp cache_path_for(hash) do
+    <<prefix::binary-size(2), rest::binary>> = hash
+    Path.join([cache_dir(), prefix, rest])
+  end
+
+  defp cache_dir do
+    Application.get_env(:riptide, :capability_cache_dir) ||
+      System.get_env("RIPTIDE_CAPABILITY_CACHE_DIR") || "priv/capability_cache"
+  end
+end

--- a/lib/riptide/derivation/capability_catalog_entry.ex
+++ b/lib/riptide/derivation/capability_catalog_entry.ex
@@ -1,0 +1,33 @@
+defmodule Riptide.Derivation.CapabilityCatalogEntry do
+  @moduledoc """
+  A Hub-scope, reviewed Capability, addressable by IRI. Identical field set to
+  `Riptide.Capability.Definition` except `component` (a literal local path,
+  meaningless outside the node that happened to receive it) is replaced by
+  `component_hash` (a content hash, resolvable to real bytes on any node via
+  `Riptide.BlobStore` — see `Riptide.Derivation.CapabilityCatalog.materialize/1`).
+  See design spec
+  `docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md`
+  §4.
+  """
+
+  @enforce_keys [
+    :name,
+    :kind,
+    :component_hash,
+    :function,
+    :fuel_limit,
+    :timeout_ms,
+    :memory_limits
+  ]
+  defstruct [:name, :kind, :component_hash, :function, :fuel_limit, :timeout_ms, :memory_limits]
+
+  @type t :: %__MODULE__{
+          name: RDF.IRI.t(),
+          kind: :effect | :observe,
+          component_hash: String.t(),
+          function: String.t(),
+          fuel_limit: pos_integer(),
+          timeout_ms: pos_integer(),
+          memory_limits: Riptide.Capability.Definition.memory_limits()
+        }
+end

--- a/lib/riptide/derivation/capability_catalog_rdf_codec.ex
+++ b/lib/riptide/derivation/capability_catalog_rdf_codec.ex
@@ -1,0 +1,120 @@
+defmodule Riptide.Derivation.CapabilityCatalogRDFCodec do
+  @moduledoc """
+  Reifies a `Riptide.Derivation.CapabilityCatalogEntry` as RDF triples and
+  reads it back, following the exact same reification style
+  `Riptide.Derivation.CrosswalkRDFCodec` already established.
+  """
+
+  alias Riptide.Derivation.CapabilityCatalogEntry
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_capability_catalog_entry RDF.iri("urn:riptide:vocab:CapabilityCatalogEntry")
+  @riptide_name RDF.iri("urn:riptide:vocab:name")
+  @riptide_capability_kind RDF.iri("urn:riptide:vocab:capabilityKind")
+  @riptide_component_hash RDF.iri("urn:riptide:vocab:componentHash")
+  @riptide_capability_function RDF.iri("urn:riptide:vocab:capabilityFunction")
+  @riptide_fuel_limit RDF.iri("urn:riptide:vocab:fuelLimit")
+  @riptide_timeout_ms RDF.iri("urn:riptide:vocab:timeoutMs")
+  @riptide_memory_limits RDF.iri("urn:riptide:vocab:memoryLimits")
+  @riptide_max_memory_size RDF.iri("urn:riptide:vocab:maxMemorySize")
+  @riptide_max_table_elements RDF.iri("urn:riptide:vocab:maxTableElements")
+  @riptide_max_instances RDF.iri("urn:riptide:vocab:maxInstances")
+  @riptide_max_tables RDF.iri("urn:riptide:vocab:maxTables")
+
+  @spec to_rdf(CapabilityCatalogEntry.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%CapabilityCatalogEntry{} = entry) do
+    node = RDF.BlankNode.new()
+    {limits_node, limits_graph} = encode_memory_limits(entry.memory_limits)
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add(limits_graph)
+      |> RDF.Graph.add({node, @rdf_type, @riptide_capability_catalog_entry})
+      |> RDF.Graph.add({node, @riptide_name, entry.name})
+      |> RDF.Graph.add({node, @riptide_capability_kind, RDF.literal(encode_kind(entry.kind))})
+      |> RDF.Graph.add({node, @riptide_component_hash, RDF.literal(entry.component_hash)})
+      |> RDF.Graph.add({node, @riptide_capability_function, RDF.literal(entry.function)})
+      |> RDF.Graph.add({node, @riptide_fuel_limit, RDF.literal(entry.fuel_limit)})
+      |> RDF.Graph.add({node, @riptide_timeout_ms, RDF.literal(entry.timeout_ms)})
+      |> RDF.Graph.add({node, @riptide_memory_limits, limits_node})
+
+    {node, graph}
+  end
+
+  # Explicit case matching, not Atom.to_string/String.to_existing_atom: see
+  # CrosswalkRDFCodec's own decode_match_type/1 for the full reasoning this
+  # mirrors exactly.
+  defp encode_kind(:effect), do: "effect"
+  defp encode_kind(:observe), do: "observe"
+
+  defp decode_kind("effect"), do: :effect
+  defp decode_kind("observe"), do: :observe
+
+  defp encode_memory_limits(limits) do
+    node = RDF.BlankNode.new()
+
+    graph =
+      RDF.Graph.new()
+      |> maybe_add(node, @riptide_max_memory_size, limits.max_memory_size)
+      |> maybe_add(node, @riptide_max_table_elements, limits.max_table_elements)
+      |> maybe_add(node, @riptide_max_instances, limits.max_instances)
+      |> maybe_add(node, @riptide_max_tables, limits.max_tables)
+
+    {node, graph}
+  end
+
+  defp maybe_add(graph, _node, _predicate, nil), do: graph
+
+  defp maybe_add(graph, node, predicate, value),
+    do: RDF.Graph.add(graph, {node, predicate, RDF.literal(value)})
+
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: CapabilityCatalogEntry.t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+    limits_node = RDF.Description.first(description, @riptide_memory_limits)
+
+    %CapabilityCatalogEntry{
+      name: RDF.Description.first(description, @riptide_name),
+      kind:
+        description
+        |> RDF.Description.first(@riptide_capability_kind)
+        |> RDF.Literal.value()
+        |> decode_kind(),
+      component_hash:
+        description |> RDF.Description.first(@riptide_component_hash) |> RDF.Literal.value(),
+      function:
+        description |> RDF.Description.first(@riptide_capability_function) |> RDF.Literal.value(),
+      fuel_limit:
+        description |> RDF.Description.first(@riptide_fuel_limit) |> RDF.Literal.value(),
+      timeout_ms:
+        description |> RDF.Description.first(@riptide_timeout_ms) |> RDF.Literal.value(),
+      memory_limits: decode_memory_limits(limits_node, graph)
+    }
+  end
+
+  # A fully-nil memory_limits (no field set) means encode_memory_limits/1
+  # added zero triples for its own sub-node — RDF.Graph.get/2 then returns
+  # nil rather than an empty %RDF.Description{}, so that case is handled
+  # explicitly here rather than crashing in RDF.Description.first/2.
+  defp decode_memory_limits(node, graph) do
+    case RDF.Graph.get(graph, node) do
+      nil ->
+        %{max_memory_size: nil, max_table_elements: nil, max_instances: nil, max_tables: nil}
+
+      description ->
+        %{
+          max_memory_size: decode_optional_int(description, @riptide_max_memory_size),
+          max_table_elements: decode_optional_int(description, @riptide_max_table_elements),
+          max_instances: decode_optional_int(description, @riptide_max_instances),
+          max_tables: decode_optional_int(description, @riptide_max_tables)
+        }
+    end
+  end
+
+  defp decode_optional_int(description, predicate) do
+    case RDF.Description.first(description, predicate) do
+      nil -> nil
+      literal -> RDF.Literal.value(literal)
+    end
+  end
+end

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -9,6 +9,8 @@ defmodule Riptide.Derivation.Catalog do
   """
 
   alias Riptide.Derivation.{
+    CapabilityCatalogEntry,
+    CapabilityCatalogRDFCodec,
     Crosswalk,
     CrosswalkRDFCodec,
     DedupGate,
@@ -34,6 +36,11 @@ defmodule Riptide.Derivation.Catalog do
   @riptide_resolved_pending_crosswalk_review RDF.iri(
                                                "urn:riptide:vocab:ResolvedPendingCrosswalkReview"
                                              )
+  @riptide_capability_catalog_entry RDF.iri("urn:riptide:vocab:CapabilityCatalogEntry")
+  @riptide_pending_capability_review RDF.iri("urn:riptide:vocab:PendingCapabilityReview")
+  @riptide_resolved_pending_capability_review RDF.iri(
+                                                "urn:riptide:vocab:ResolvedPendingCapabilityReview"
+                                              )
 
   @type scope :: {:tenant, String.t()} | :hub
 
@@ -124,6 +131,54 @@ defmodule Riptide.Derivation.Catalog do
       pending_review_stream_id(scope),
       [{node, @rdf_type, @riptide_resolved_pending_crosswalk_review}],
       [{node, @rdf_type, @riptide_pending_crosswalk_review}]
+    )
+  end
+
+  @spec capability_stream_id() :: String.t()
+  def capability_stream_id, do: catalog_stream_id(:hub) <> "/capabilities"
+
+  @spec admit_capability(CapabilityCatalogEntry.t()) :: :ok | {:error, :not_ready}
+  def admit_capability(%CapabilityCatalogEntry{} = entry) do
+    {_node, entry_graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
+    write_patch(capability_stream_id(), RDF.Graph.triples(entry_graph), [])
+  end
+
+  @spec list_capabilities() ::
+          {:ok, [{RDF.BlankNode.t(), CapabilityCatalogEntry.t()}]} | {:error, :not_ready}
+  def list_capabilities do
+    with {:ok, graph} <- read_graph(capability_stream_id()) do
+      nodes = nodes_of_type(graph, @riptide_capability_catalog_entry)
+      {:ok, Enum.map(nodes, &{&1, CapabilityCatalogRDFCodec.from_rdf(&1, graph)})}
+    end
+  end
+
+  @spec queue_capability_review(scope(), DedupGate.PendingCapabilityReview.t()) ::
+          {:ok, RDF.BlankNode.t()} | {:error, :not_ready}
+  def queue_capability_review(scope, %DedupGate.PendingCapabilityReview{} = pending) do
+    {node, graph} = DedupGate.PendingCapabilityReview.to_rdf(pending)
+
+    case write_patch(pending_review_stream_id(scope), RDF.Graph.triples(graph), []) do
+      :ok -> {:ok, node}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec list_capability_pending_reviews(scope()) ::
+          {:ok, [{RDF.BlankNode.t(), DedupGate.PendingCapabilityReview.t()}]}
+          | {:error, :not_ready}
+  def list_capability_pending_reviews(scope) do
+    with {:ok, graph} <- read_graph(pending_review_stream_id(scope)) do
+      nodes = nodes_of_type(graph, @riptide_pending_capability_review)
+      {:ok, Enum.map(nodes, &{&1, DedupGate.PendingCapabilityReview.from_rdf(&1, graph)})}
+    end
+  end
+
+  @spec resolve_capability_review(scope(), RDF.BlankNode.t()) :: :ok | {:error, :not_ready}
+  def resolve_capability_review(scope, node) do
+    write_patch(
+      pending_review_stream_id(scope),
+      [{node, @rdf_type, @riptide_resolved_pending_capability_review}],
+      [{node, @rdf_type, @riptide_pending_capability_review}]
     )
   end
 

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -193,6 +193,48 @@ defmodule Riptide.Derivation.DedupGate.PendingCrosswalkReview do
   end
 end
 
+defmodule Riptide.Derivation.DedupGate.PendingCapabilityReview do
+  @moduledoc """
+  A proposed Capability awaiting the proposing Tenant's own review (design
+  spec
+  `docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md`
+  §6). Deliberately as simple as `PendingCrosswalkReview` — a
+  `CapabilityCatalogEntry` isn't a generalization of anything, so there's
+  nothing to anti-unify or replay-test.
+  """
+
+  alias Riptide.Derivation.{CapabilityCatalogEntry, CapabilityCatalogRDFCodec}
+
+  @enforce_keys [:candidate]
+  defstruct [:candidate]
+
+  @type t :: %__MODULE__{candidate: CapabilityCatalogEntry.t()}
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_pending_capability_review RDF.iri("urn:riptide:vocab:PendingCapabilityReview")
+  @riptide_candidate RDF.iri("urn:riptide:vocab:candidate")
+
+  @spec to_rdf(t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%__MODULE__{candidate: candidate}) do
+    node = RDF.BlankNode.new()
+    {candidate_node, candidate_graph} = CapabilityCatalogRDFCodec.to_rdf(candidate)
+
+    graph =
+      candidate_graph
+      |> RDF.Graph.add({node, @rdf_type, @riptide_pending_capability_review})
+      |> RDF.Graph.add({node, @riptide_candidate, candidate_node})
+
+    {node, graph}
+  end
+
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+    candidate_node = RDF.Description.first(description, @riptide_candidate)
+    %__MODULE__{candidate: CapabilityCatalogRDFCodec.from_rdf(candidate_node, graph)}
+  end
+end
+
 defmodule Riptide.Derivation.DedupGate do
   @moduledoc """
   Catalog lookup, the `Reject`/`Merge`/`Admit` decision, and the human
@@ -200,8 +242,22 @@ defmodule Riptide.Derivation.DedupGate do
   `docs/superpowers/specs/2026-08-29-phase-6e-iii-dedupgate-orchestration-design.md`.
   """
 
-  alias Riptide.Derivation.{AntiUnifier, Catalog, Crosswalk, GeneralizationFidelity, Rule, Var}
-  alias Riptide.Derivation.DedupGate.{PendingCrosswalkReview, PendingReview}
+  alias Riptide.Derivation.{
+    AntiUnifier,
+    CapabilityCatalogEntry,
+    Catalog,
+    Crosswalk,
+    GeneralizationFidelity,
+    Rule,
+    Var
+  }
+
+  alias Riptide.Derivation.DedupGate.{
+    PendingCapabilityReview,
+    PendingCrosswalkReview,
+    PendingReview
+  }
+
   alias Riptide.Derivation.ExecuteInterpreter.Context
 
   @type candidates :: [{Rule.t(), AntiUnifier.substitution(), AntiUnifier.substitution()}]
@@ -310,6 +366,28 @@ defmodule Riptide.Derivation.DedupGate do
   @spec decline_crosswalk_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
   def decline_crosswalk_review(review_scope, node),
     do: Catalog.resolve_crosswalk_review(review_scope, node)
+
+  @spec propose_capability(Catalog.scope(), CapabilityCatalogEntry.t()) ::
+          {:ok, RDF.BlankNode.t()} | {:error, term()}
+  def propose_capability(review_scope, %CapabilityCatalogEntry{} = entry) do
+    Catalog.queue_capability_review(review_scope, %PendingCapabilityReview{candidate: entry})
+  end
+
+  @spec approve_capability_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
+  def approve_capability_review(review_scope, node) do
+    with {:ok, pending_reviews} <- Catalog.list_capability_pending_reviews(review_scope),
+         {_node, pending} <- List.keyfind(pending_reviews, node, 0, :not_found) do
+      :ok = Catalog.admit_capability(pending.candidate)
+      Catalog.resolve_capability_review(review_scope, node)
+    else
+      :not_found -> {:error, :not_found}
+      error -> error
+    end
+  end
+
+  @spec decline_capability_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
+  def decline_capability_review(review_scope, node),
+    do: Catalog.resolve_capability_review(review_scope, node)
 
   defp classify(candidate, entries) do
     matching =

--- a/lib/riptide_web/hub/capability_controller.ex
+++ b/lib/riptide_web/hub/capability_controller.ex
@@ -1,0 +1,99 @@
+defmodule RiptideWeb.Hub.CapabilityController do
+  @moduledoc """
+  Propose a Capability (metadata + base64 bytes in one request) and
+  approve/decline it, mirroring `RiptideWeb.Hub.CrosswalkController`'s exact
+  shape (design spec
+  `docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md`
+  §7).
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.BlobStore
+  alias Riptide.Derivation.{CapabilityCatalogEntry, DedupGate}
+
+  def propose(conn, params) do
+    tenant_id = conn.assigns.tenant_id
+
+    case Riptide.HubRateLimit.check_propose(tenant_id) do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_propose(conn, tenant_id, params)
+    end
+  end
+
+  defp handle_propose(
+         conn,
+         tenant_id,
+         %{
+           "name" => name,
+           "kind" => kind_string,
+           "function" => function,
+           "fuel_limit" => fuel_limit,
+           "timeout_ms" => timeout_ms,
+           "memory_limits" => memory_limits_params,
+           "component_bytes" => component_bytes_b64
+         }
+       ) do
+    with {:ok, kind} <- parse_kind(kind_string),
+         {:ok, bytes} <- Base.decode64(component_bytes_b64),
+         {:ok, hash} <- BlobStore.put(bytes) do
+      entry = %CapabilityCatalogEntry{
+        name: RDF.iri(name),
+        kind: kind,
+        component_hash: hash,
+        function: function,
+        fuel_limit: fuel_limit,
+        timeout_ms: timeout_ms,
+        memory_limits: parse_memory_limits(memory_limits_params)
+      }
+
+      case DedupGate.propose_capability({:tenant, tenant_id}, entry) do
+        {:ok, node} ->
+          body = Jason.encode!(%{"outcome" => "queued", "node_id" => RDF.BlankNode.value(node)})
+          conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+        {:error, _reason} ->
+          send_resp(conn, 503, "")
+      end
+    else
+      _error -> send_resp(conn, 400, "")
+    end
+  end
+
+  defp handle_propose(conn, _tenant_id, _params), do: send_resp(conn, 400, "")
+
+  # Explicit case matching, not String.to_existing_atom/1 — mirrors
+  # CrosswalkController's own parse_match_type/1 reasoning exactly.
+  defp parse_kind("effect"), do: {:ok, :effect}
+  defp parse_kind("observe"), do: {:ok, :observe}
+  defp parse_kind(_other), do: {:error, :invalid_kind}
+
+  defp parse_memory_limits(params) do
+    %{
+      max_memory_size: Map.get(params, "max_memory_size"),
+      max_table_elements: Map.get(params, "max_table_elements"),
+      max_instances: Map.get(params, "max_instances"),
+      max_tables: Map.get(params, "max_tables")
+    }
+  end
+
+  def approve(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.approve_capability_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+
+  def decline(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.decline_capability_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+end

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -66,5 +66,9 @@ defmodule RiptideWeb.Router do
     post "/hub/crosswalks", RiptideWeb.Hub.CrosswalkController, :propose
     post "/hub/crosswalk-reviews/:node_id/approve", RiptideWeb.Hub.CrosswalkController, :approve
     post "/hub/crosswalk-reviews/:node_id/decline", RiptideWeb.Hub.CrosswalkController, :decline
+
+    post "/hub/capabilities", RiptideWeb.Hub.CapabilityController, :propose
+    post "/hub/capability-reviews/:node_id/approve", RiptideWeb.Hub.CapabilityController, :approve
+    post "/hub/capability-reviews/:node_id/decline", RiptideWeb.Hub.CapabilityController, :decline
   end
 end

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -69,17 +69,27 @@ defmodule Riptide.BlobStoreTest do
     # test/riptide/supervised_process_test.exs's own established two-step
     # pattern (deterministic :DOWN wait for the old process's actual exit,
     # then poll for re-registration) rather than polling a single window
-    # for both at once — a single combined window measurably under-budgets
-    # a slower CI runner's real restart latency, caught live via CI
-    # (passed consistently locally, failed on CI's own hardware).
-    assert_receive {:DOWN, ^ref, :process, ^old_pid, _reason}, 5_000
+    # for both at once.
+    #
+    # Budget widened a second time (5s + 1s -> 20s + 10s), caught live via
+    # CI again: this phase's own new real multi-node tests
+    # (capability_catalog_cluster_test.exs) add real concurrent BEAM-node
+    # load to the whole suite, and CI logs showed BlobStore's registry
+    # entry still absent a full 8+ seconds after termination — a genuine
+    # increase in real restart latency under heavier load, not a logic
+    # bug, so the fix is a bigger, evidence-backed margin, not a new
+    # mechanism.
+    assert_receive {:DOWN, ^ref, :process, ^old_pid, _reason}, 20_000
 
-    assert eventually(fn ->
-             case Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store") do
-               [{new_pid, Riptide.BlobStore}] -> Process.alive?(new_pid)
-               [] -> false
-             end
-           end)
+    assert eventually(
+             fn ->
+               case Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store") do
+                 [{new_pid, Riptide.BlobStore}] -> Process.alive?(new_pid)
+                 [] -> false
+               end
+             end,
+             500
+           )
   end
 
   defp eventually(fun, attempts_left \\ 50) do

--- a/test/riptide/derivation/capability_catalog_capstone_test.exs
+++ b/test/riptide/derivation/capability_catalog_capstone_test.exs
@@ -1,0 +1,111 @@
+defmodule Riptide.Derivation.CapabilityCatalogCapstoneTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.{Policy, Store}
+  alias Riptide.Capability
+  alias Riptide.Derivation.{CapabilityCatalog, Catalog}
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    dir = Path.join(System.tmp_dir!(), "cap_capstone_#{System.unique_integer([:positive])}")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :blob_data_dir, dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    :ok
+  end
+
+  test "exit criterion: register via real HTTP, approve, resolve and invoke by IRI alone" do
+    tenant_id = "capstone-" <> Uniq.UUID.uuid4()
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    name = "urn:riptide:capability:capstone-greet-#{System.unique_integer([:positive])}"
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+
+    body =
+      Jason.encode!(%{
+        "name" => name,
+        "kind" => "effect",
+        "function" => "greet",
+        "fuel_limit" => 100_000_000,
+        "timeout_ms" => 5_000,
+        "memory_limits" => %{
+          "max_memory_size" => nil,
+          "max_table_elements" => nil,
+          "max_instances" => nil,
+          "max_tables" => nil
+        },
+        "component_bytes" => Base.encode64(component_bytes)
+      })
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert propose_conn.status == 200
+    node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    # Resolution and invocation — never a hand-built %Definition{} anywhere
+    # below this line.
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+
+    local_name = String.trim_leading(name, "urn:riptide:capability:")
+
+    FakeStore.start(%{
+      {"acme", ["capabilities", local_name]} => [
+        %Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      ]
+    })
+
+    assert {:ok, entry} = CapabilityCatalog.find_by_name(RDF.iri(name))
+    assert {:ok, definition} = CapabilityCatalog.materialize(entry)
+    assert {:ok, result} = Capability.invoke(definition, "acme", nil, ["World"])
+    assert result == "\"Hello, World!\""
+  end
+end

--- a/test/riptide/derivation/capability_catalog_cluster_test.exs
+++ b/test/riptide/derivation/capability_catalog_cluster_test.exs
@@ -1,0 +1,212 @@
+defmodule Riptide.Derivation.CapabilityCatalogClusterTest do
+  use ExUnit.Case, async: false
+
+  import Riptide.MultiNodeTestHelpers, only: [unique_pairs: 1]
+
+  @moduletag timeout: 120_000
+
+  @peers [
+    {:cap_a, "cap-a", ~c"127.0.0.60"},
+    {:cap_b, "cap-b", ~c"127.0.0.61"},
+    {:cap_c, "cap-c", ~c"127.0.0.62"}
+  ]
+
+  # A 4th, spare node. With exactly 3 peers total and the default
+  # replication factor also 3, BlobStore.put/1's own other_nodes/0
+  # (Node.list() sorted, first RF-1) always replicates to *every* other
+  # connected node deterministically — there's no node left over to prove a
+  # genuine remote fetch. Naming this one alphabetically last means
+  # other_nodes/0's own sort-and-take-first-2 always excludes it, mirroring
+  # blob_store_cluster_test.exs's own @spare fix for the identical class of
+  # problem (found live by running this test, not anticipated up front).
+  @spare {:cap_d, "cap-d", ~c"127.0.0.63"}
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"capability_catalog_cluster_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "materialize/1 fetches from a remote replica and caches it locally, without registering with LocationIndex" do
+    peers = bootstrap_peers(@peers ++ [@spare])
+    [{_pid_a, node_a, _}, _peer_b, _peer_c, {_pid_d, node_d, _}] = peers
+
+    bytes = :crypto.strong_rand_bytes(1024)
+    {:ok, hash} = :erpc.call(node_a, Riptide.BlobStore, :put, [bytes])
+
+    # node_d never received a local replica from put/1's own replication —
+    # excluded deterministically by other_nodes/0's own sort (see @spare).
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: RDF.iri("urn:riptide:capability:cluster-#{System.unique_integer([:positive])}"),
+      kind: :effect,
+      component_hash: hash,
+      function: "run",
+      fuel_limit: 10_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    assert {:ok, definition} =
+             :erpc.call(node_d, Riptide.Derivation.CapabilityCatalog, :materialize, [entry])
+
+    assert {:ok, bytes_on_d} = :erpc.call(node_d, File, :read, [definition.component])
+    assert bytes_on_d == bytes
+
+    # Never registered as an official BlobStore replica — only a private
+    # materialize cache.
+    assert {:ok, locations} =
+             :erpc.call(node_a, Riptide.BlobStore.LocationIndex, :list_locations, [hash])
+
+    refute node_d in locations
+  end
+
+  defp bootstrap_peers(specs) do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    peers =
+      for {alive_name, ordinal, host} <- specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, &stop_peer/1)
+
+      Enum.each(specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"capability_catalog_cluster_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, ordinal} <- peers do
+      bootstrap_node(node, ordinal)
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      :ok = :erpc.call(node, Riptide.PlacementMembership, :bootstrap_once, [])
+    end
+
+    core_peers = Enum.take(peers, Riptide.PlacementMembership.target_size())
+
+    assert eventually(fn ->
+             Enum.all?(core_peers, fn {_pid, node, _ordinal} ->
+               match?(
+                 {:ok, _},
+                 :erpc.call(node, Riptide.RaCluster.Placement, :local_placement_members, [])
+               )
+             end)
+           end)
+
+    peers
+  end
+
+  defp bootstrap_node(node, ordinal) do
+    :erpc.call(node, System, :put_env, [
+      "RIPTIDE_BLOB_DATA_DIR",
+      Path.join(File.cwd!(), "#{ordinal}/blob_data")
+    ])
+
+    :erpc.call(node, System, :put_env, [
+      "RIPTIDE_CAPABILITY_CACHE_DIR",
+      Path.join(File.cwd!(), "#{ordinal}/capability_cache")
+    ])
+
+    {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+
+    case :erpc.call(node, :ra_system, :start, [
+           :erpc.call(node, Riptide.RaCluster, :system_config, [])
+         ]) do
+      {:ok, _pid} -> :ok
+      {:ok, _pid, _info} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+
+    {:ok, _} =
+      start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+
+    {:ok, _} = start_unlinked(node, Riptide.PlacementMembership, :start_link, [[]])
+    {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+
+    {:ok, _} =
+      start_unlinked(node, Registry, :start_link, [
+        [keys: :unique, name: Riptide.SupervisedProcess.Registry]
+      ])
+
+    {:ok, _} =
+      start_unlinked(node, DynamicSupervisor, :start_link, [
+        [strategy: :one_for_one, name: Riptide.SupervisedProcess.DynamicSupervisor]
+      ])
+
+    {:ok, _} = start_unlinked(node, Riptide.BlobStore, :start_link, [[]])
+  end
+
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+    ref = make_ref()
+
+    :erpc.call(node, Kernel, :spawn, [
+      fn ->
+        result = apply(mod, fun, args)
+        send(parent, {ref, result})
+        Process.sleep(:infinity)
+      end
+    ])
+
+    receive do
+      {^ref, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp stop_peer({pid, _node, _ordinal}) do
+    if Process.alive?(pid) do
+      try do
+        :peer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end

--- a/test/riptide/derivation/capability_catalog_rdf_codec_test.exs
+++ b/test/riptide/derivation/capability_catalog_rdf_codec_test.exs
@@ -1,0 +1,49 @@
+defmodule Riptide.Derivation.CapabilityCatalogRDFCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.{CapabilityCatalogEntry, CapabilityCatalogRDFCodec}
+
+  defp sample_entry(overrides) do
+    Map.merge(
+      %CapabilityCatalogEntry{
+        name: RDF.iri("urn:riptide:capability:restartPaymentsService"),
+        kind: :effect,
+        component_hash: String.duplicate("a", 64),
+        function: "restart",
+        fuel_limit: 10_000_000,
+        timeout_ms: 5_000,
+        memory_limits: %{
+          max_memory_size: nil,
+          max_table_elements: nil,
+          max_instances: nil,
+          max_tables: nil
+        }
+      },
+      overrides
+    )
+  end
+
+  test "to_rdf/1 + from_rdf/2 round-trips every field, including a fully-populated memory_limits" do
+    entry =
+      sample_entry(%{
+        memory_limits: %{
+          max_memory_size: 67_108_864,
+          max_table_elements: 1_000,
+          max_instances: 4,
+          max_tables: 2
+        }
+      })
+
+    {node, graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
+
+    assert CapabilityCatalogRDFCodec.from_rdf(node, graph) == entry
+  end
+
+  test "round-trips :observe kind and a fully-nil memory_limits" do
+    entry = sample_entry(%{kind: :observe})
+
+    {node, graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
+
+    assert CapabilityCatalogRDFCodec.from_rdf(node, graph) == entry
+  end
+end

--- a/test/riptide/derivation/capability_catalog_test.exs
+++ b/test/riptide/derivation/capability_catalog_test.exs
@@ -1,0 +1,66 @@
+defmodule Riptide.Derivation.CapabilityCatalogTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.BlobStore
+  alias Riptide.Capability.Definition
+  alias Riptide.Derivation.{CapabilityCatalog, CapabilityCatalogEntry}
+
+  setup do
+    blob_dir =
+      Path.join(System.tmp_dir!(), "cap_catalog_blob_#{System.unique_integer([:positive])}")
+
+    cache_dir =
+      Path.join(System.tmp_dir!(), "cap_catalog_cache_#{System.unique_integer([:positive])}")
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :blob_data_dir, blob_dir)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :capability_cache_dir, cache_dir)
+
+    on_exit(fn ->
+      File.rm_rf!(blob_dir)
+      File.rm_rf!(cache_dir)
+    end)
+
+    :ok
+  end
+
+  defp sample_entry(hash) do
+    %CapabilityCatalogEntry{
+      name: RDF.iri("urn:riptide:capability:materialize-#{System.unique_integer([:positive])}"),
+      kind: :effect,
+      component_hash: hash,
+      function: "run",
+      fuel_limit: 10_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+  end
+
+  test "materialize/1 reuses an already-local BlobStore replica without a network fetch" do
+    bytes = :crypto.strong_rand_bytes(1024)
+    {:ok, hash} = BlobStore.put(bytes)
+    entry = sample_entry(hash)
+
+    assert {:ok, %Definition{} = definition} = CapabilityCatalog.materialize(entry)
+
+    assert definition.name == entry.name
+    assert definition.kind == entry.kind
+    assert definition.function == entry.function
+    assert definition.fuel_limit == entry.fuel_limit
+    assert definition.timeout_ms == entry.timeout_ms
+    assert definition.memory_limits == entry.memory_limits
+    # Reused BlobStore's own on-disk path directly — no separate cache copy.
+    assert definition.component == BlobStore.path_for(hash)
+    assert File.read!(definition.component) == bytes
+  end
+
+  test "materialize/1 for a hash that exists nowhere returns an error" do
+    entry = sample_entry(String.duplicate("0", 64))
+
+    assert {:error, _reason} = CapabilityCatalog.materialize(entry)
+  end
+end

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -5,6 +5,7 @@ defmodule Riptide.Derivation.DedupGateTest do
 
   alias Riptide.Derivation.{
     AntiUnifier,
+    CapabilityCatalogEntry,
     Catalog,
     Crosswalk,
     DedupGate,
@@ -14,7 +15,12 @@ defmodule Riptide.Derivation.DedupGateTest do
     Signature
   }
 
-  alias Riptide.Derivation.DedupGate.{PendingCrosswalkReview, PendingReview}
+  alias Riptide.Derivation.DedupGate.{
+    PendingCapabilityReview,
+    PendingCrosswalkReview,
+    PendingReview
+  }
+
   alias Riptide.Derivation.ExecuteInterpreter.Context
   alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern}
 
@@ -22,6 +28,26 @@ defmodule Riptide.Derivation.DedupGateTest do
   defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
 
   defp unique_tenant, do: {:tenant, "acme-#{System.unique_integer([:positive])}"}
+
+  defp sample_capability(overrides) do
+    Map.merge(
+      %CapabilityCatalogEntry{
+        name: RDF.iri("urn:riptide:capability:ddg-#{System.unique_integer([:positive])}"),
+        kind: :effect,
+        component_hash: String.duplicate("b", 64),
+        function: "run",
+        fuel_limit: 10_000_000,
+        timeout_ms: 5_000,
+        memory_limits: %{
+          max_memory_size: nil,
+          max_table_elements: nil,
+          max_instances: nil,
+          max_tables: nil
+        }
+      },
+      overrides
+    )
+  end
 
   # A ground CapabilityReference's `result` is a raw Elixir string by this
   # codebase's own established convention (matches `Capability.invoke/4`'s
@@ -723,6 +749,58 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       assert {:ok, entries} = Catalog.list_crosswalks()
       refute Enum.any?(entries, fn {_n, c} -> c == crosswalk end)
+    end
+  end
+
+  describe "PendingCapabilityReview round-trip" do
+    test "round-trips through Catalog.queue_capability_review/2 + list_capability_pending_reviews/1" do
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      pending = %PendingCapabilityReview{candidate: sample_capability(%{})}
+
+      {:ok, node} = Catalog.queue_capability_review(review_scope, pending)
+      assert {:ok, entries} = Catalog.list_capability_pending_reviews(review_scope)
+      assert Enum.any?(entries, fn {n, p} -> n == node and p == pending end)
+    end
+  end
+
+  describe "propose_capability/2 + approve_capability_review/2 + decline_capability_review/2" do
+    test "a proposed Capability is queued, then approval admits it to the Hub capability catalog" do
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      entry = sample_capability(%{})
+
+      assert {:ok, node} = DedupGate.propose_capability(review_scope, entry)
+      assert :ok == DedupGate.approve_capability_review(review_scope, node)
+
+      assert {:ok, entries} = Catalog.list_capabilities()
+      assert Enum.any?(entries, fn {_n, e} -> e == entry end)
+
+      assert {:ok, []} = Catalog.list_capability_pending_reviews(review_scope)
+    end
+
+    test "declining a proposed Capability resolves the review and admits nothing" do
+      review_scope = unique_tenant()
+
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+      end)
+
+      entry = sample_capability(%{})
+
+      {:ok, node} = DedupGate.propose_capability(review_scope, entry)
+      assert :ok == DedupGate.decline_capability_review(review_scope, node)
+
+      assert {:ok, entries} = Catalog.list_capabilities()
+      refute Enum.any?(entries, fn {_n, e} -> e == entry end)
     end
   end
 end

--- a/test/riptide_web/hub/capability_controller_test.exs
+++ b/test/riptide_web/hub/capability_controller_test.exs
@@ -1,0 +1,123 @@
+defmodule RiptideWeb.Hub.CapabilityControllerTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  test "propose a Capability with embedded bytes, then approve it — it becomes live in the Hub capability catalog" do
+    tenant_id = "capability-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    bytes = :crypto.strong_rand_bytes(512)
+    name = "urn:riptide:capability:httpcap-#{System.unique_integer([:positive])}"
+
+    body =
+      Jason.encode!(%{
+        "name" => name,
+        "kind" => "effect",
+        "function" => "run",
+        "fuel_limit" => 10_000_000,
+        "timeout_ms" => 5_000,
+        "memory_limits" => %{
+          "max_memory_size" => nil,
+          "max_table_elements" => nil,
+          "max_instances" => nil,
+          "max_tables" => nil
+        },
+        "component_bytes" => Base.encode64(bytes)
+      })
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert propose_conn.status == 200
+    node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+    assert is_binary(node_id)
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    assert {:ok, entries} = Catalog.list_capabilities()
+    assert Enum.any?(entries, fn {_n, e} -> e.name == RDF.iri(name) end)
+  end
+
+  test "declining a proposed Capability admits nothing" do
+    tenant_id = "capability-decline-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    name = "urn:riptide:capability:httpcapdecline-#{System.unique_integer([:positive])}"
+
+    body =
+      Jason.encode!(%{
+        "name" => name,
+        "kind" => "effect",
+        "function" => "run",
+        "fuel_limit" => 10_000_000,
+        "timeout_ms" => 5_000,
+        "memory_limits" => %{
+          "max_memory_size" => nil,
+          "max_table_elements" => nil,
+          "max_instances" => nil,
+          "max_tables" => nil
+        },
+        "component_bytes" => Base.encode64(:crypto.strong_rand_bytes(64))
+      })
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    decline_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{node_id}/decline")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert decline_conn.status == 200
+
+    assert {:ok, entries} = Catalog.list_capabilities()
+    refute Enum.any?(entries, fn {_n, e} -> e.name == RDF.iri(name) end)
+  end
+end


### PR DESCRIPTION
## Summary
- Implements 6k — a Hub-scope, reviewed catalog of Capabilities addressable by IRI, with WASM bytes durably stored via 6j's `BlobStore` and materialized to a literal local path only when a specific node actually invokes one.
- `CapabilityCatalogEntry`/`PendingCapabilityReview` mirror 6i's `Crosswalk`/`PendingCrosswalkReview` precedent exactly — no anti-unification/fidelity-replay, since a Capability isn't a generalization of anything.
- `CapabilityCatalog.materialize/1` reuses a local `BlobStore` replica if one exists, otherwise fetches and caches privately — with zero changes to `Riptide.Capability`/`Definition`/`invoke/4`.
- `POST /tenants/:tenant_id/hub/capabilities` accepts metadata + base64 bytes in one request, calling `BlobStore.put/1` internally — `BlobStore` itself still has no general-purpose upload endpoint.
- Capstone test proves the literal exit criterion: register via real HTTP, approve, resolve and invoke by IRI alone.

Spec: `docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md` (PR #115).

## Test plan
- [x] `mix test` — full suite green (516 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR