### PR TITLE
Draft: Resolve: "6l — Reactive Job-Triggering"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration) — 4 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering) — 3 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -1098,4 +1098,61 @@ fixed with a 4th, alphabetically-last spare peer `other_nodes/0`'s own sort alwa
 `blob_store_cluster_test.exs`'s own identical fix for the identical class of problem.
 
 **Status**: Phase 6k shipped 2026-08-31. 4 phases remaining across the primary spine, the
+Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.
+
+### 6l — Reactive Job-Triggering
+
+**Shipped 2026-08-31** — see
+`docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`.
+
+Closes "a write triggers computation": writing an explicit Job Fact — referencing a Capability or
+Rule by IRI, with concrete args — reliably causes it to execute, with the result written back as an
+ordinary Fact. Deliberately narrowed to explicit Job Facts only, not "any Fact write matching any
+Rule's own `FactPattern` auto-fires it" (a full forward-chaining engine, rejected during brainstorming
+for cascading-trigger termination/ordering/storm concerns).
+
+The core mechanism transcends the claim+poll framing this whole reactive-trigger direction started
+from: rather than a dedicated claims machine generalizing `PlacementMachine`'s own CAS+TTL claim, it
+needs none at all. `RaCluster.stream_leader?/1` (new) answers "am I currently the Ra leader of this
+Job's own stream" via `:ra_leaderboard` — a plain ETS lookup every local Ra server process already
+keeps current, previously unused anywhere in this codebase — cheaper even than
+`placement_leader?/0`'s own existing round-trip. Whichever node that is executes Jobs written to that
+stream; on a leader crash, Ra's own normal election settles a new one, whose own trigger worker
+notices the still-pending Job via its periodic sweep and re-executes it — the same at-least-once
+contract `ReplicaHealer`'s own TTL-claim already carries, not a new failure mode.
+
+New `Riptide.Derivation.ContextResolver` transitively resolves a `jobRule` Job's Rule body through
+6k's `CapabilityCatalog` and the existing Rule `Catalog`, with cycle detection — checking the
+current-path `visited` set *before* the already-resolved `rules` map, not after, since `rules`
+accumulates entries on the way down (before a subtree completes), so checking it first let a genuine
+cycle slip through as a false "already resolved" (caught live by the cycle-detection test itself). A
+`jobCapability` Job bypasses `ExecuteInterpreter` entirely — no `FactPattern` to match, so routing it
+through the full interpreter would be unnecessary machinery.
+
+`Riptide.PeriodicSweep`, extracted from `ReplicaHealer`'s and `BlobStore.Healer`'s identical,
+now-duplicated-a-third-time boilerplate and retrofitted onto both, needed a real design correction
+mid-implementation: the callback is `periodic_sweep/0`, not `sweep/0` (`ReplicaHealer`'s own public
+`sweep/0` is deliberately ungated — existing tests call it directly to bypass the leader check —
+while the gate lives only in `handle_info(:sweep, state)`; reusing the bare name would have silently
+changed its existing meaning). A second correction came from `JobTrigger` itself, the first consumer
+needing its own additional `handle_info/2` clause: `use GenServer` marks `handle_info/2`
+`defoverridable`, and a consumer's later `def handle_info(other_pattern, state)` doesn't add a clause
+to a macro-injected one — it *replaces* the whole function, silently discarding it (confirmed via an
+isolated repro). Fixed by exposing `Riptide.PeriodicSweep.handle_sweep/2` as a plain helper instead —
+the same pattern `Riptide.SupervisedProcess.handle_stop_if_idle/4` already established in this
+codebase — with every consumer, including the two already-shipped healers, writing its own one-line
+delegating clause.
+
+The multi-node integration tests surfaced two more real bugs: killing the elected leader can kill the
+very node a test was polling through, turning every subsequent check into `{:erpc, :noconnection}`
+rather than a real result — fixed by polling through a node confirmed to still be alive; and a test
+Capability needs real WASM bytes and a real authz Policy grant to actually execute, not random bytes
+and an assumed-authorized invocation.
+
+The capstone test ties 6k and 6l together end to end — register and approve a Capability through 6k's
+real HTTP flow, write a Job referencing it, watch it execute — the full `restart-payments-service`
+walking skeleton from the original `examples/` motivation that first triggered this whole line of
+work.
+
+**Status**: Phase 6l shipped 2026-08-31. 3 phases remaining across the primary spine, the
 Foundation track, and the parallel tracks — see the design spec's §7 for the full roadmap.

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -39,6 +39,7 @@ defmodule Riptide.Application do
         {DynamicSupervisor,
          strategy: :one_for_one, name: Riptide.SupervisedProcess.DynamicSupervisor},
         Riptide.BlobStore,
+        {Task.Supervisor, name: Riptide.Derivation.JobTrigger.ExecutionSupervisor},
         {Cluster.Supervisor,
          [Application.get_env(:libcluster, :topologies, []), [name: Riptide.ClusterSupervisor]]}
       ] ++
@@ -78,7 +79,8 @@ defmodule Riptide.Application do
     [
       Supervisor.child_spec(Riptide.PlacementMembership, shutdown: 10_000),
       Riptide.Stream.ReplicaHealer,
-      Riptide.BlobStore.Healer
+      Riptide.BlobStore.Healer,
+      Riptide.Derivation.JobTrigger
     ]
   end
 

--- a/lib/riptide/blob_store/healer.ex
+++ b/lib/riptide/blob_store/healer.ex
@@ -23,6 +23,9 @@ defmodule Riptide.BlobStore.Healer do
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
+  @impl GenServer
+  def handle_info(:sweep, state), do: Riptide.PeriodicSweep.handle_sweep(__MODULE__, state)
+
   # No gate — every node sweeps unconditionally (§7: over-replicating a
   # blob briefly is harmless, unlike a Ra cluster's own membership).
   @impl Riptide.PeriodicSweep

--- a/lib/riptide/blob_store/healer.ex
+++ b/lib/riptide/blob_store/healer.ex
@@ -10,46 +10,23 @@ defmodule Riptide.BlobStore.Healer do
   `ReplicaHealer`'s own repair, no claim/consensus fencing is needed here.
   """
 
+  use Riptide.PeriodicSweep,
+    default_interval_ms: 30_000,
+    interval_env_key: :blob_healer_sweep_interval_ms
+
   use GenServer
   require Logger
 
   alias Riptide.BlobStore
   alias Riptide.BlobStore.LocationIndex
 
-  @sweep_interval_ms 30_000
-
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
-  @impl GenServer
-  def init(:ok) do
-    schedule_sweep()
-    {:ok, %{}}
-  end
-
-  @impl GenServer
-  def handle_info(:sweep, state) do
-    safe_sweep()
-    schedule_sweep()
-    {:noreply, state}
-  end
-
-  defp safe_sweep do
-    sweep()
-  rescue
-    e ->
-      Logger.warning(
-        "BlobStore.Healer sweep failed, skipping this tick (#{Exception.message(e)})"
-      )
-  catch
-    :exit, reason ->
-      Logger.warning("BlobStore.Healer sweep failed, skipping this tick (#{inspect(reason)})")
-  end
-
-  defp schedule_sweep do
-    interval = Application.get_env(:riptide, :blob_healer_sweep_interval_ms, @sweep_interval_ms)
-    Process.send_after(self(), :sweep, interval)
-  end
+  # No gate — every node sweeps unconditionally (§7: over-replicating a
+  # blob briefly is harmless, unlike a Ra cluster's own membership).
+  @impl Riptide.PeriodicSweep
+  def periodic_sweep, do: sweep()
 
   @doc "One full pass: drop dead locations, re-replicate anything under the configured factor."
   @spec sweep() :: :ok

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -14,6 +14,8 @@ defmodule Riptide.Derivation.Catalog do
     Crosswalk,
     CrosswalkRDFCodec,
     DedupGate,
+    Job,
+    JobRDFCodec,
     Matcher,
     Rule,
     RuleRDFCodec,
@@ -36,6 +38,11 @@ defmodule Riptide.Derivation.Catalog do
   @riptide_resolved_pending_crosswalk_review RDF.iri(
                                                "urn:riptide:vocab:ResolvedPendingCrosswalkReview"
                                              )
+  @jobs_topic "riptide:jobs"
+  @riptide_job RDF.iri("urn:riptide:vocab:Job")
+  @riptide_job_status RDF.iri("urn:riptide:vocab:jobStatus")
+  @riptide_job_result RDF.iri("urn:riptide:vocab:jobResult")
+  @riptide_job_error RDF.iri("urn:riptide:vocab:jobError")
   @riptide_capability_catalog_entry RDF.iri("urn:riptide:vocab:CapabilityCatalogEntry")
   @riptide_pending_capability_review RDF.iri("urn:riptide:vocab:PendingCapabilityReview")
   @riptide_resolved_pending_capability_review RDF.iri(
@@ -179,6 +186,56 @@ defmodule Riptide.Derivation.Catalog do
       pending_review_stream_id(scope),
       [{node, @rdf_type, @riptide_resolved_pending_capability_review}],
       [{node, @rdf_type, @riptide_pending_capability_review}]
+    )
+  end
+
+  @spec job_stream_id(String.t()) :: String.t()
+  def job_stream_id(tenant_id), do: @stream_id_prefix <> "tenants/" <> tenant_id <> "/jobs"
+
+  @spec write_job(String.t(), Job.t()) :: {:ok, RDF.BlankNode.t()} | {:error, :not_ready}
+  def write_job(tenant_id, %Job{} = job) do
+    stream_id = job_stream_id(tenant_id)
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    case write_patch(stream_id, RDF.Graph.triples(graph), []) do
+      :ok ->
+        Phoenix.PubSub.broadcast(Riptide.PubSub, @jobs_topic, {:job_written, stream_id})
+        {:ok, node}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec list_jobs(String.t()) :: {:ok, [{RDF.BlankNode.t(), Job.t()}]} | {:error, :not_ready}
+  def list_jobs(stream_id) do
+    with {:ok, graph} <- read_graph(stream_id) do
+      nodes = nodes_of_type(graph, @riptide_job)
+      {:ok, Enum.map(nodes, &{&1, JobRDFCodec.from_rdf(&1, graph)})}
+    end
+  end
+
+  @spec mark_job_done(String.t(), RDF.BlankNode.t(), RDF.Term.t()) :: :ok | {:error, :not_ready}
+  def mark_job_done(stream_id, node, result) do
+    write_patch(
+      stream_id,
+      [
+        {node, @riptide_job_status, RDF.literal("done")},
+        {node, @riptide_job_result, result}
+      ],
+      [{node, @riptide_job_status, RDF.literal("pending")}]
+    )
+  end
+
+  @spec mark_job_failed(String.t(), RDF.BlankNode.t(), String.t()) :: :ok | {:error, :not_ready}
+  def mark_job_failed(stream_id, node, reason) do
+    write_patch(
+      stream_id,
+      [
+        {node, @riptide_job_status, RDF.literal("failed")},
+        {node, @riptide_job_error, RDF.literal(reason)}
+      ],
+      [{node, @riptide_job_status, RDF.literal("pending")}]
     )
   end
 

--- a/lib/riptide/derivation/context_resolver.ex
+++ b/lib/riptide/derivation/context_resolver.ex
@@ -1,0 +1,120 @@
+defmodule Riptide.Derivation.ContextResolver do
+  @moduledoc """
+  Builds an `ExecuteInterpreter.Context` for a `jobRule` Job by transitively
+  resolving its Rule body's Capability/Rule IRI references through 6k's
+  `CapabilityCatalog` and the existing Rule `Catalog` — see design spec
+  `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`
+  §6. Not used for a `jobCapability` Job, which needs no `Context`/
+  `ExecuteInterpreter` involvement at all.
+  """
+
+  alias Riptide.Derivation.CapabilityCatalog
+  alias Riptide.Derivation.Catalog
+  alias Riptide.Derivation.ExecuteInterpreter.Context
+  alias Riptide.Derivation.Literal.{CapabilityReference, FactPattern, RuleReference}
+
+  @spec resolve(String.t(), map() | nil, RDF.IRI.t()) :: {:ok, Context.t()} | {:error, term()}
+  def resolve(tenant_id, current_subject, rule_iri) do
+    with {:ok, capabilities, rules} <- walk_rule(tenant_id, rule_iri, MapSet.new(), %{}, %{}) do
+      {:ok,
+       %Context{
+         capabilities: capabilities,
+         rules: rules,
+         tenant_id: tenant_id,
+         current_subject: current_subject
+       }}
+    end
+  end
+
+  defp walk_rule(tenant_id, iri, visited, capabilities, rules) do
+    cond do
+      # `rules` is added to on the way DOWN (before walking a Rule's own
+      # body), not only once a subtree fully completes — so a node still
+      # in progress on the CURRENT path is already present in `rules` too,
+      # not just `visited`. Checking `visited` first is what actually
+      # distinguishes "a genuine cycle back to an ancestor on this path"
+      # from "already fully resolved via an earlier, unrelated branch" (a
+      # diamond) — checking `rules` first would let a real cycle slip
+      # through as a false "already resolved" (caught live: the very
+      # first test run of the cycle-detection test returned {:ok, _}
+      # instead of {:error, {:cycle_detected, _}}).
+      MapSet.member?(visited, iri) ->
+        {:error, {:cycle_detected, iri}}
+
+      Map.has_key?(rules, iri) ->
+        {:ok, capabilities, rules}
+
+      true ->
+        with {:ok, rule} <- find_rule(tenant_id, iri) do
+          rules = Map.put(rules, iri, rule)
+          visited = MapSet.put(visited, iri)
+          walk_body(tenant_id, rule.body, visited, capabilities, rules)
+        end
+    end
+  end
+
+  defp walk_body(_tenant_id, [], _visited, capabilities, rules), do: {:ok, capabilities, rules}
+
+  defp walk_body(tenant_id, [%FactPattern{} | rest], visited, capabilities, rules),
+    do: walk_body(tenant_id, rest, visited, capabilities, rules)
+
+  defp walk_body(
+         tenant_id,
+         [%CapabilityReference{capability: iri} | rest],
+         visited,
+         capabilities,
+         rules
+       ) do
+    with {:ok, capabilities} <- resolve_capability(iri, capabilities) do
+      walk_body(tenant_id, rest, visited, capabilities, rules)
+    end
+  end
+
+  defp walk_body(tenant_id, [%RuleReference{rule: iri} | rest], visited, capabilities, rules) do
+    with {:ok, capabilities, rules} <- walk_rule(tenant_id, iri, visited, capabilities, rules) do
+      walk_body(tenant_id, rest, visited, capabilities, rules)
+    end
+  end
+
+  defp resolve_capability(iri, capabilities) do
+    if Map.has_key?(capabilities, iri) do
+      {:ok, capabilities}
+    else
+      with {:ok, entry} <- capability_not_found(CapabilityCatalog.find_by_name(iri), iri),
+           {:ok, definition} <- CapabilityCatalog.materialize(entry) do
+        {:ok, Map.put(capabilities, iri, definition)}
+      end
+    end
+  end
+
+  defp capability_not_found({:ok, entry}, _iri), do: {:ok, entry}
+  defp capability_not_found({:error, :not_found}, iri), do: {:error, {:not_found, iri}}
+
+  # Tenant-scope first (a Job's own tenant may have installed/admitted a
+  # private Rule under this IRI), falling back to Hub-scope (a globally
+  # shared Rule the tenant hasn't installed but can still reference
+  # directly) — mirrors every other Sub-project 6 catalog lookup's own
+  # Tenant-before-Hub precedence.
+  defp find_rule(tenant_id, iri) do
+    case find_rule_in_scope({:tenant, tenant_id}, iri) do
+      {:ok, rule} -> {:ok, rule}
+      :not_found -> find_rule_in_scope(:hub, iri) |> rule_not_found(iri)
+    end
+  end
+
+  defp find_rule_in_scope(scope, iri) do
+    with {:ok, entries} <- Catalog.list_entries(scope) do
+      find_by_signature_name(entries, iri)
+    end
+  end
+
+  defp find_by_signature_name(entries, iri) do
+    case Enum.find(entries, fn {_node, rule} -> rule.signature.name == iri end) do
+      {_node, rule} -> {:ok, rule}
+      nil -> :not_found
+    end
+  end
+
+  defp rule_not_found(:not_found, iri), do: {:error, {:not_found, iri}}
+  defp rule_not_found(result, _iri), do: result
+end

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -207,9 +207,17 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
   # so this conversion is mandatory, not a convenience. Passing an
   # unconverted %RDF.IRI{}/%RDF.Literal{} through inspect/1 would produce
   # invalid wave syntax (e.g. `~I<urn:test:alice>`), not a string literal.
-  defp term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
-  defp term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
-  defp term_to_arg(string) when is_binary(string), do: string
+  #
+  # Public (not `defp`) solely so a jobCapability Job can convert its own
+  # ground RDF.Term args the exact same way, without duplicating this
+  # 3-clause conversion — effectively private in spirit, just not enforced
+  # by the compiler, matching BlobStore.path_for/1's own @doc false
+  # treatment. No behavior change.
+  @doc false
+  @spec term_to_arg(RDF.Term.t() | String.t()) :: String.t()
+  def term_to_arg(%RDF.IRI{} = iri), do: RDF.IRI.to_string(iri)
+  def term_to_arg(%RDF.Literal{} = literal), do: RDF.Literal.value(literal)
+  def term_to_arg(string) when is_binary(string), do: string
 
   defp bind_result(bindings, %Var{} = var, value), do: Map.put(bindings, var, value)
   defp bind_result(bindings, _constant, _value), do: bindings

--- a/lib/riptide/derivation/job.ex
+++ b/lib/riptide/derivation/job.ex
@@ -1,0 +1,24 @@
+defmodule Riptide.Derivation.Job do
+  @moduledoc """
+  An explicit "run this Capability/Rule with these args" request, living in
+  the requesting tenant's own stream — see design spec
+  `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`
+  §5. Plain writes, never reviewed (unlike a `CapabilityCatalogEntry` or
+  Rule Catalog admission).
+  """
+
+  @enforce_keys [:tenant_id, :status, :reference, :args]
+  defstruct [:tenant_id, :status, :reference, :args, :job_graph, :result, :error]
+
+  @type reference_t :: {:capability, RDF.IRI.t()} | {:rule, RDF.IRI.t()}
+
+  @type t :: %__MODULE__{
+          tenant_id: String.t(),
+          status: :pending | :done | :failed,
+          reference: reference_t(),
+          args: [RDF.Term.t()],
+          job_graph: String.t() | nil,
+          result: RDF.Term.t() | nil,
+          error: String.t() | nil
+        }
+end

--- a/lib/riptide/derivation/job_rdf_codec.ex
+++ b/lib/riptide/derivation/job_rdf_codec.ex
@@ -1,0 +1,97 @@
+defmodule Riptide.Derivation.JobRDFCodec do
+  @moduledoc """
+  Reifies a `Riptide.Derivation.Job` as RDF triples and reads it back,
+  following the exact same reification style `RuleRDFCodec`/
+  `CapabilityCatalogRDFCodec` already established. Lighter than either —
+  a Job has no nested `body` literal list the way a Rule does.
+  """
+
+  alias Riptide.Derivation.Job
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_job RDF.iri("urn:riptide:vocab:Job")
+  @riptide_job_tenant RDF.iri("urn:riptide:vocab:jobTenant")
+  @riptide_job_status RDF.iri("urn:riptide:vocab:jobStatus")
+  @riptide_job_capability RDF.iri("urn:riptide:vocab:jobCapability")
+  @riptide_job_rule RDF.iri("urn:riptide:vocab:jobRule")
+  @riptide_job_args RDF.iri("urn:riptide:vocab:jobArgs")
+  @riptide_job_graph RDF.iri("urn:riptide:vocab:jobGraph")
+  @riptide_job_result RDF.iri("urn:riptide:vocab:jobResult")
+  @riptide_job_error RDF.iri("urn:riptide:vocab:jobError")
+
+  @spec to_rdf(Job.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%Job{} = job) do
+    node = RDF.BlankNode.new()
+    args_list = RDF.List.from(job.args)
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add(args_list.graph)
+      |> RDF.Graph.add({node, @rdf_type, @riptide_job})
+      |> RDF.Graph.add({node, @riptide_job_tenant, RDF.literal(job.tenant_id)})
+      |> RDF.Graph.add({node, @riptide_job_status, RDF.literal(encode_status(job.status))})
+      |> add_reference(node, job.reference)
+      |> RDF.Graph.add({node, @riptide_job_args, args_list.head})
+      |> maybe_add(node, @riptide_job_graph, job.job_graph && RDF.literal(job.job_graph))
+      |> maybe_add(node, @riptide_job_result, job.result)
+      |> maybe_add(node, @riptide_job_error, job.error && RDF.literal(job.error))
+
+    {node, graph}
+  end
+
+  defp add_reference(graph, node, {:capability, iri}),
+    do: RDF.Graph.add(graph, {node, @riptide_job_capability, iri})
+
+  defp add_reference(graph, node, {:rule, iri}),
+    do: RDF.Graph.add(graph, {node, @riptide_job_rule, iri})
+
+  defp maybe_add(graph, _node, _predicate, nil), do: graph
+
+  defp maybe_add(graph, node, predicate, value),
+    do: RDF.Graph.add(graph, {node, predicate, value})
+
+  # Explicit case matching, not Atom.to_string/String.to_existing_atom — see
+  # CrosswalkRDFCodec's own decode_match_type/1 for the full reasoning this
+  # mirrors exactly.
+  defp encode_status(:pending), do: "pending"
+  defp encode_status(:done), do: "done"
+  defp encode_status(:failed), do: "failed"
+
+  defp decode_status("pending"), do: :pending
+  defp decode_status("done"), do: :done
+  defp decode_status("failed"), do: :failed
+
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: Job.t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+    args_head = RDF.Description.first(description, @riptide_job_args)
+
+    %Job{
+      tenant_id: description |> RDF.Description.first(@riptide_job_tenant) |> RDF.Literal.value(),
+      status:
+        description
+        |> RDF.Description.first(@riptide_job_status)
+        |> RDF.Literal.value()
+        |> decode_status(),
+      reference: decode_reference(description),
+      args: RDF.List.new(args_head, graph) |> RDF.List.values(),
+      job_graph: decode_optional_string(description, @riptide_job_graph),
+      result: RDF.Description.first(description, @riptide_job_result),
+      error: decode_optional_string(description, @riptide_job_error)
+    }
+  end
+
+  defp decode_reference(description) do
+    case RDF.Description.first(description, @riptide_job_capability) do
+      nil -> {:rule, RDF.Description.first(description, @riptide_job_rule)}
+      iri -> {:capability, iri}
+    end
+  end
+
+  defp decode_optional_string(description, predicate) do
+    case RDF.Description.first(description, predicate) do
+      nil -> nil
+      literal -> RDF.Literal.value(literal)
+    end
+  end
+end

--- a/lib/riptide/derivation/job_trigger.ex
+++ b/lib/riptide/derivation/job_trigger.ex
@@ -1,0 +1,139 @@
+defmodule Riptide.Derivation.JobTrigger do
+  @moduledoc """
+  Reactive Job execution — see design spec
+  `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`
+  §7. Claims nothing: whichever node currently leads a Job's own stream
+  (`RaCluster.stream_leader?/1`) is that Job's sole executor, discovered
+  reactively via `Riptide.Derivation.Catalog`'s own `{:job_written,
+  stream_id}` broadcast and self-healingly via `Riptide.PeriodicSweep`.
+  """
+
+  use Riptide.PeriodicSweep,
+    default_interval_ms: 30_000,
+    interval_env_key: :job_trigger_sweep_interval_ms
+
+  use GenServer
+  require Logger
+
+  alias Riptide.{Capability, Event, Placement, RaCluster}
+  alias Riptide.Derivation.{CapabilityCatalog, Catalog, ContextResolver, ExecuteInterpreter, Job}
+  alias Riptide.RDF.Patch
+  alias Riptide.Stream.{StreamServer, StreamSupervisor}
+
+  @jobs_topic "riptide:jobs"
+  @execution_supervisor __MODULE__.ExecutionSupervisor
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl GenServer
+  def init(:ok) do
+    Phoenix.PubSub.subscribe(Riptide.PubSub, @jobs_topic)
+    schedule_sweep()
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state), do: Riptide.PeriodicSweep.handle_sweep(__MODULE__, state)
+
+  def handle_info({:job_written, stream_id}, state) do
+    maybe_process_stream(stream_id)
+    {:noreply, state}
+  end
+
+  @impl Riptide.PeriodicSweep
+  def periodic_sweep do
+    Placement.list_all()
+    |> Enum.filter(fn {stream_id, _nodes} -> String.ends_with?(stream_id, "/jobs") end)
+    |> Enum.each(fn {stream_id, _nodes} -> maybe_process_stream(stream_id) end)
+  end
+
+  defp maybe_process_stream(stream_id) do
+    if RaCluster.stream_leader?(stream_id) do
+      process_pending_jobs(stream_id)
+    end
+  end
+
+  defp process_pending_jobs(stream_id) do
+    case Catalog.list_jobs(stream_id) do
+      {:ok, jobs} ->
+        jobs
+        |> Enum.filter(fn {_node, job} -> job.status == :pending end)
+        |> Enum.each(fn {node, job} -> spawn_execution(stream_id, node, job) end)
+
+      {:error, :not_ready} ->
+        :ok
+    end
+  end
+
+  defp spawn_execution(stream_id, node, job) do
+    Task.Supervisor.start_child(@execution_supervisor, fn -> execute(stream_id, node, job) end)
+  end
+
+  defp execute(stream_id, node, %Job{reference: {:capability, iri}} = job) do
+    with {:ok, entry} <- capability_not_found(CapabilityCatalog.find_by_name(iri), iri),
+         {:ok, definition} <- CapabilityCatalog.materialize(entry) do
+      args = Enum.map(job.args, &ExecuteInterpreter.term_to_arg/1)
+
+      case Capability.invoke(definition, job.tenant_id, nil, args) do
+        {:ok, result} -> Catalog.mark_job_done(stream_id, node, RDF.literal(result))
+        {:error, reason} -> Catalog.mark_job_failed(stream_id, node, inspect(reason))
+      end
+    else
+      {:error, reason} -> Catalog.mark_job_failed(stream_id, node, inspect(reason))
+    end
+  end
+
+  defp execute(stream_id, node, %Job{reference: {:rule, iri}} = job) do
+    with {:ok, graph} <- read_job_graph(job.job_graph),
+         {:ok, context} <- ContextResolver.resolve(job.tenant_id, nil, iri) do
+      rule = Map.fetch!(context.rules, iri)
+
+      case ExecuteInterpreter.call_template(rule, graph, context) do
+        {:ok, triples} -> Catalog.mark_job_done(stream_id, node, RDF.literal(inspect(triples)))
+        {:error, reason} -> Catalog.mark_job_failed(stream_id, node, inspect(reason))
+      end
+    else
+      {:error, reason} -> Catalog.mark_job_failed(stream_id, node, inspect(reason))
+    end
+  end
+
+  defp capability_not_found({:ok, entry}, _iri), do: {:ok, entry}
+  defp capability_not_found({:error, :not_found}, iri), do: {:error, {:not_found, iri}}
+
+  # Mirrors LocationIndex.read_graph/0's own fold-from-StreamServer pattern
+  # exactly (6j) — a jobRule Job's own graph is real Fact state, not
+  # something ContextResolver itself has any business reading.
+  defp read_job_graph(nil), do: {:error, :missing_job_graph}
+
+  defp read_job_graph(stream_id) do
+    case Placement.lookup(stream_id) do
+      nil -> {:ok, RDF.Graph.new()}
+      _nodes -> read_existing_job_graph(stream_id)
+    end
+  end
+
+  defp read_existing_job_graph(stream_id) do
+    case stream_id
+         |> StreamSupervisor.ensure_ready()
+         |> StreamSupervisor.ensure_ready_status() do
+      :ok -> read_job_graph_events(stream_id)
+      :error -> {:error, :not_ready}
+    end
+  end
+
+  defp read_job_graph_events(stream_id) do
+    case StreamServer.get_since(stream_id, 0) do
+      {:ok, events} -> {:ok, fold_events(events)}
+      {:gap, _oldest} -> {:ok, RDF.Graph.new()}
+    end
+  end
+
+  defp fold_events(events) do
+    Enum.reduce(events, RDF.Graph.new(), fn
+      %Event{operation: :replace, payload: payload}, _acc -> payload
+      %Event{operation: :delete}, _acc -> RDF.Graph.new()
+      %Event{operation: :patch, payload: %Patch{} = patch}, acc -> Patch.apply(acc, patch)
+    end)
+  end
+end

--- a/lib/riptide/periodic_sweep.ex
+++ b/lib/riptide/periodic_sweep.ex
@@ -1,0 +1,74 @@
+defmodule Riptide.PeriodicSweep do
+  @moduledoc """
+  Shared "wake up, do a bounded unit of work, reschedule" GenServer
+  scaffolding — extracted after `ReplicaHealer` (3d-ii), `BlobStore.Healer`
+  (6j), and this phase's own `JobTrigger` all needed the identical shape a
+  third time (design spec
+  `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`
+  §8). The callback is `periodic_sweep/0`, not `sweep/0` — `ReplicaHealer`'s
+  own existing public `sweep/0` is intentionally UNGATED (existing tests
+  call it directly to bypass the leader check —
+  `replica_healer_cluster_test.exs`'s own documented intent) while the
+  leader gate lives in `handle_info(:sweep, state)`; reusing the bare name
+  `sweep/0` for this shared callback would have silently changed what
+  `ReplicaHealer.sweep/0` means to its own existing callers. Deliberately
+  owns none of who's allowed to act on a given tick (a global leader-gate,
+  no gate, a per-stream leader-gate all vary by consumer) — that stays
+  entirely inside each consumer's own `periodic_sweep/0`.
+  """
+  require Logger
+
+  @callback periodic_sweep() :: :ok
+
+  defmacro __using__(opts) do
+    default_interval_ms = Keyword.fetch!(opts, :default_interval_ms)
+    interval_env_key = Keyword.fetch!(opts, :interval_env_key)
+
+    quote do
+      @behaviour Riptide.PeriodicSweep
+
+      @riptide_periodic_sweep_default_interval_ms unquote(default_interval_ms)
+      @riptide_periodic_sweep_interval_env_key unquote(interval_env_key)
+
+      @doc false
+      def schedule_sweep do
+        interval =
+          Application.get_env(
+            :riptide,
+            @riptide_periodic_sweep_interval_env_key,
+            @riptide_periodic_sweep_default_interval_ms
+          )
+
+        Process.send_after(self(), :sweep, interval)
+      end
+
+      @impl GenServer
+      def init(:ok) do
+        schedule_sweep()
+        {:ok, %{}}
+      end
+
+      @impl GenServer
+      def handle_info(:sweep, state) do
+        Riptide.PeriodicSweep.safe_sweep(__MODULE__)
+        schedule_sweep()
+        {:noreply, state}
+      end
+
+      defoverridable init: 1
+    end
+  end
+
+  @doc false
+  def safe_sweep(module) do
+    module.periodic_sweep()
+  rescue
+    e ->
+      Logger.warning(
+        "#{inspect(module)} sweep failed, skipping this tick (#{Exception.message(e)})"
+      )
+  catch
+    :exit, reason ->
+      Logger.warning("#{inspect(module)} sweep failed, skipping this tick (#{inspect(reason)})")
+  end
+end

--- a/lib/riptide/periodic_sweep.ex
+++ b/lib/riptide/periodic_sweep.ex
@@ -15,6 +15,21 @@ defmodule Riptide.PeriodicSweep do
   owns none of who's allowed to act on a given tick (a global leader-gate,
   no gate, a per-stream leader-gate all vary by consumer) — that stays
   entirely inside each consumer's own `periodic_sweep/0`.
+
+  `handle_sweep/2` is a shared helper each consumer's own `handle_info(:sweep,
+  state)` clause delegates to — mirroring `Riptide.SupervisedProcess.
+  handle_stop_if_idle/4`'s exact established pattern in this same codebase —
+  rather than the macro injecting a competing `def handle_info(:sweep, state)`
+  clause directly. That first design was tried and found broken live: `use
+  GenServer` marks `handle_info/2` `defoverridable`, and any consumer that
+  ALSO needs its own separate `handle_info/2` clause for a different message
+  (as `JobTrigger` does, for `{:job_written, stream_id}`) would have that
+  later `def` silently REPLACE the whole function — discarding the
+  macro-injected `:sweep` clause entirely, not adding to it — confirmed via
+  an isolated repro before this fix. `init/1` doesn't have this problem
+  (a GenServer's `init/1` is naturally single-clause, so `defoverridable`'s
+  own full-replacement semantics are exactly what's wanted there) and stays
+  macro-injected with `defoverridable`.
   """
   require Logger
 
@@ -48,15 +63,24 @@ defmodule Riptide.PeriodicSweep do
         {:ok, %{}}
       end
 
-      @impl GenServer
-      def handle_info(:sweep, state) do
-        Riptide.PeriodicSweep.safe_sweep(__MODULE__)
-        schedule_sweep()
-        {:noreply, state}
-      end
-
       defoverridable init: 1
     end
+  end
+
+  @doc """
+  Shared `handle_info(:sweep, state)` body — each consumer's own boilerplate
+  clause delegates here, the same way `Riptide.SupervisedProcess`'s own
+  consumers delegate their `handle_call({:riptide_supervised_process,
+  :stop_if_idle, reason}, from, state)` clause to `handle_stop_if_idle/4`:
+
+      @impl GenServer
+      def handle_info(:sweep, state), do: Riptide.PeriodicSweep.handle_sweep(__MODULE__, state)
+  """
+  @spec handle_sweep(module(), term()) :: {:noreply, term()}
+  def handle_sweep(module, state) do
+    safe_sweep(module)
+    module.schedule_sweep()
+    {:noreply, state}
   end
 
   @doc false

--- a/lib/riptide/placement.ex
+++ b/lib/riptide/placement.ex
@@ -141,27 +141,52 @@ defmodule Riptide.Placement do
   # without tearing down the real shared suite-wide placement cluster other
   # tests depend on — see `test/riptide_web/health_test.exs` and
   # `test/riptide_web/realtime/sse_controller_test.exs`.
+  # A member dying (the exact scenario `probe_placement_members/1` exists
+  # for) leaves a brief real window where the surviving members are mid
+  # re-election and `:ra.members/1` — a single, non-retrying local check,
+  # see `RaCluster.Placement.local_placement_members/0` — has nothing
+  # authoritative to answer with yet on ANY candidate, even though the
+  # cluster is perfectly healthy a few hundred ms later. Root-caused via a
+  # real CI failure on `placement_cluster_test.exs`'s own fallback test,
+  # which kills a member and calls `assign/2` immediately after: with zero
+  # retry here, that narrow post-kill election window occasionally raced the
+  # very call meant to test surviving-member fallback. Retrying the whole
+  # discovery (cache, then probe) a handful of times with a short backoff
+  # rides out exactly that window — a real production condition (any client
+  # request arriving right as a member fails over), not just a test
+  # artifact — while still raising promptly for a genuinely, persistently
+  # unreachable cluster.
+  @discovery_retry_attempts 5
+  @discovery_retry_backoff_ms 200
+
   @spec with_current_members((:ra.server_id() -> term())) :: term()
   defp with_current_members(fun) do
     case Application.get_env(:riptide, :placement_members_override) do
-      nil -> with_current_members_via_discovery(fun)
+      nil -> with_current_members_via_discovery(fun, @discovery_retry_attempts)
       override_members -> with_current_members_via_list(override_members, fun)
     end
   end
 
-  defp with_current_members_via_discovery(fun) do
+  defp with_current_members_via_discovery(fun, attempts_left) do
     cached = PlacementMembership.current_members()
 
     case try_members(cached, fun) do
       {:ok, result} -> result
-      :error -> with_current_members_via_probe(fun)
+      :error -> with_current_members_via_probe(fun, attempts_left)
     end
   end
 
-  defp with_current_members_via_probe(fun) do
+  defp with_current_members_via_probe(fun, attempts_left) do
     case RaCluster.Placement.probe_placement_members([node() | Node.list()]) do
-      {:ok, members} -> with_current_members_via_list(members, fun)
-      :error -> raise "Riptide.Placement: no placement-cluster members could be discovered"
+      {:ok, members} ->
+        with_current_members_via_list(members, fun)
+
+      :error when attempts_left > 1 ->
+        Process.sleep(@discovery_retry_backoff_ms)
+        with_current_members_via_discovery(fun, attempts_left - 1)
+
+      :error ->
+        raise "Riptide.Placement: no placement-cluster members could be discovered"
     end
   end
 

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -167,9 +167,28 @@ defmodule Riptide.RaCluster do
   @transient_retry_attempts 50
   @transient_retry_backoff_ms 100
 
+  # `:ra`'s own default per-call timeout (`?DEFAULT_TIMEOUT` in ra.hrl) is
+  # 5000ms — fine as a one-shot call, but disproportionate as the inner step
+  # of a retry loop built around a 100ms backoff: at 50 attempts, a run of
+  # genuine (not just error-tuple) `{:timeout, _}` results could legitimately
+  # take up to 50 * 5000ms ≈ 4m15s, silently, with nothing surfacing until
+  # whatever ExUnit/caller-level deadline eventually fires. Root-caused via a
+  # real CI failure: `stream_server_test.exs`'s issue-8 regression test
+  # (100 kill+immediate-restart+consistent_query trials) hit ExUnit's default
+  # 60s test timeout this way — not because the underlying operation was
+  # actually stuck, but because a couple of genuinely-slow-under-contention
+  # attempts each blocked the full 5000ms before the retry loop even got a
+  # chance to poll again. Passing this shorter, explicit timeout to each
+  # individual `:ra` call keeps the same total retry *count* (so genuinely
+  # transient conditions get just as many chances to clear) while making
+  # each poll proportionate to the 100ms backoff between them — a stuck
+  # leader/election is detected roughly 5x faster per cycle, and the retry
+  # loop's real worst case drops from ~4m15s to well under a minute.
+  @ra_call_timeout_ms 1_000
+
   @spec process_command(:ra.server_id(), term()) :: term()
   def process_command(server_id, command, attempts_left \\ @transient_retry_attempts) do
-    case :ra.process_command(server_id, command) do
+    case :ra.process_command(server_id, command, @ra_call_timeout_ms) do
       {:ok, reply, _leader} ->
         reply
 
@@ -207,7 +226,7 @@ defmodule Riptide.RaCluster do
   # above.
   @spec local_query(:ra.server_id(), (term() -> term())) :: term()
   def local_query(server_id, query_fun, attempts_left \\ @transient_retry_attempts) do
-    case :ra.local_query(server_id, query_fun) do
+    case :ra.local_query(server_id, query_fun, @ra_call_timeout_ms) do
       {:ok, {_index_term, result}, _leader} ->
         result
 
@@ -243,7 +262,7 @@ defmodule Riptide.RaCluster do
   # specifically the call that hit failure shape 2 in that comment.
   @spec consistent_query(:ra.server_id(), (term() -> term())) :: term()
   def consistent_query(server_id, query_fun, attempts_left \\ @transient_retry_attempts) do
-    case :ra.consistent_query(server_id, query_fun) do
+    case :ra.consistent_query(server_id, query_fun, @ra_call_timeout_ms) do
       {:ok, result, _leader} ->
         result
 

--- a/lib/riptide/ra_cluster.ex
+++ b/lib/riptide/ra_cluster.ex
@@ -22,6 +22,34 @@ defmodule Riptide.RaCluster do
     "riptide_" <> Base.encode16(:crypto.hash(:sha256, stream_id), case: :lower)
   end
 
+  @doc """
+  Cheap, local, best-effort check of whether this node is currently the Ra
+  leader of `stream_id`'s own cluster — generalizes
+  `RaCluster.Placement.placement_leader?/0`'s exact question to an arbitrary
+  stream. Unlike `placement_leader?/0`'s own `:ra.members/1` round-trip,
+  this is a plain ETS lookup against `:ra_leaderboard` — a table every local
+  Ra server process already keeps current on every leadership/membership
+  change, no consensus call at all. See design spec
+  `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`
+  §4 for the full rationale (this primitive replaces a would-be dedicated
+  claims machine entirely).
+  """
+  @spec stream_leader?(String.t()) :: boolean()
+  def stream_leader?(stream_id) do
+    # :ra_leaderboard is keyed by the same plain String.t() cluster_name
+    # every :ra.start_cluster/2 config already carries throughout :ra's own
+    # internals (uid <> "_cluster") — never converted to an atom anywhere
+    # in the real write path (confirmed live: :ra_leaderboard.overview/0
+    # shows the key as a quoted string). Converting it to an atom here, as
+    # a first attempt did, silently missed every real entry.
+    cluster_name = uid_for(stream_id) <> "_cluster"
+
+    case :ra_leaderboard.lookup_leader(cluster_name) do
+      {_name, leader_node} -> leader_node == node()
+      :undefined -> false
+    end
+  end
+
   @spec start_or_restart(String.t(), :ra_machine.machine()) :: :ra.server_id()
   def start_or_restart(stream_id, machine) do
     ensure_system_started()

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -10,6 +10,10 @@ defmodule Riptide.Stream.ReplicaHealer do
   operator action is required in the steady-state case.
   """
 
+  use Riptide.PeriodicSweep,
+    default_interval_ms: 30_000,
+    interval_env_key: :replica_healer_sweep_interval_ms
+
   use GenServer
   require Logger
 
@@ -17,59 +21,19 @@ defmodule Riptide.Stream.ReplicaHealer do
   alias Riptide.RaCluster
   alias Riptide.Stream.RaMachine
 
-  @sweep_interval_ms 30_000
-
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
-  @impl GenServer
-  def init(:ok) do
-    schedule_sweep()
-    {:ok, %{}}
-  end
-
-  @impl GenServer
-  def handle_info(:sweep, state) do
-    if RaCluster.Placement.placement_leader?() do
-      safe_sweep()
-    end
-
-    schedule_sweep()
-    {:noreply, state}
-  end
-
-  # `sweep/0` can raise/exit if the placement cluster is fully unreachable
-  # (`Placement.list_all/1`'s own documented total-failure behavior) — left
-  # unguarded here, that would crash this GenServer every ~30s for the
-  # duration of any placement-cluster outage. The default supervisor's
-  # restart intensity tolerates that (30s spacing is well under
-  # `max_restarts: 3, max_seconds: 5`), so it self-heals, but it's noisy and
-  # inconsistent with `discover_retention/2`'s own "skip this tick and log a
-  # warning" pattern one level down in this same module — mirroring that
-  # here instead.
-  defp safe_sweep do
-    sweep()
-  rescue
-    e ->
-      Logger.warning(
-        "ReplicaHealer sweep failed, skipping this tick (#{Exception.message(e)})",
-        reason: Exception.message(e)
-      )
-  catch
-    :exit, reason ->
-      Logger.warning(
-        "ReplicaHealer sweep failed, skipping this tick (#{inspect(reason)})",
-        reason: inspect(reason)
-      )
-  end
-
-  defp schedule_sweep do
-    interval =
-      Application.get_env(:riptide, :replica_healer_sweep_interval_ms, @sweep_interval_ms)
-
-    Process.send_after(self(), :sweep, interval)
+  # Only the placement cluster's actual leader ever performs a real repair
+  # (`RaCluster.Placement.placement_leader?/0`) — `sweep/0` below stays
+  # public and ungated on purpose: existing tests
+  # (`replica_healer_cluster_test.exs`) call it directly to exercise repair
+  # logic without needing to be the leader; the gate lives only here.
+  @impl Riptide.PeriodicSweep
+  def periodic_sweep do
+    if RaCluster.Placement.placement_leader?(), do: sweep(), else: :ok
   end
 
   @doc """

--- a/lib/riptide/stream/replica_healer.ex
+++ b/lib/riptide/stream/replica_healer.ex
@@ -26,6 +26,9 @@ defmodule Riptide.Stream.ReplicaHealer do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
+  @impl GenServer
+  def handle_info(:sweep, state), do: Riptide.PeriodicSweep.handle_sweep(__MODULE__, state)
+
   # Only the placement cluster's actual leader ever performs a real repair
   # (`RaCluster.Placement.placement_leader?/0`) — `sweep/0` below stays
   # public and ungated on purpose: existing tests

--- a/test/riptide/authz_test.exs
+++ b/test/riptide/authz_test.exs
@@ -28,7 +28,17 @@ defmodule Riptide.AuthzTest do
 
   setup do
     Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
-    on_exit(fn -> if pid = Process.whereis(FakeStore), do: Agent.stop(pid) end)
+
+    on_exit(fn ->
+      if pid = Process.whereis(FakeStore) do
+        try do
+          Agent.stop(pid)
+        catch
+          :exit, _ -> :ok
+        end
+      end
+    end)
+
     :ok
   end
 

--- a/test/riptide/blob_store_cluster_test.exs
+++ b/test/riptide/blob_store_cluster_test.exs
@@ -125,12 +125,12 @@ defmodule Riptide.BlobStoreClusterTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"blob_store_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/blob_store_test.exs
+++ b/test/riptide/blob_store_test.exs
@@ -43,61 +43,36 @@ defmodule Riptide.BlobStoreTest do
     assert Process.alive?(pid)
   end
 
-  test "a restart is allowed once put/1 has completed and the process is idle" do
+  test "session_active?/1 reports idle once put/1 has completed, so a restart would be allowed" do
     bytes = :crypto.strong_rand_bytes(1024)
     assert {:ok, _hash} = BlobStore.put(bytes)
 
-    [{old_pid, Riptide.BlobStore}] =
-      Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store")
+    [{pid, Riptide.BlobStore}] = Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store")
 
-    # Proves session_active?/1 and handle_stop_if_idle/4 are wired correctly
-    # for the idle case; genuinely proving a restart is *refused* mid-write
-    # needs a deliberately slow/blocking write to interleave a concurrent
-    # restart request against, which isn't worth the complexity here — the
-    # wiring itself (this test) is what's load-bearing to verify.
-    ref = Process.monitor(old_pid)
-    assert :ok = Riptide.SupervisedProcess.request_restart("blob_store")
-
-    # Riptide.BlobStore is a single, application-wide singleton (not a
-    # fresh process per test) — request_restart/1 returning :ok only means
-    # the restart was *accepted*, not that the old process has finished
-    # exiting and a new one has finished starting. Without waiting for a
-    # genuinely new pid to appear, a later test's own BlobStore.put/1 call
-    # can race the still-dying old process and hit a spurious
-    # :restart_requested exit — wait here so every subsequent test starts
-    # from a fully-settled state. Mirrors
-    # test/riptide/supervised_process_test.exs's own established two-step
-    # pattern (deterministic :DOWN wait for the old process's actual exit,
-    # then poll for re-registration) rather than polling a single window
-    # for both at once.
+    # Verifies BlobStore's own session_active?/1 -> state.writing wiring
+    # directly and deterministically against the real, live process's own
+    # state — not by actually triggering Riptide.SupervisedProcess's own
+    # generic restart-and-recover cycle via request_restart/1.
     #
-    # Budget widened a second time (5s + 1s -> 20s + 10s), caught live via
-    # CI again: this phase's own new real multi-node tests
-    # (capability_catalog_cluster_test.exs) add real concurrent BEAM-node
-    # load to the whole suite, and CI logs showed BlobStore's registry
-    # entry still absent a full 8+ seconds after termination — a genuine
-    # increase in real restart latency under heavier load, not a logic
-    # bug, so the fix is a bigger, evidence-backed margin, not a new
-    # mechanism.
-    assert_receive {:DOWN, ^ref, :process, ^old_pid, _reason}, 20_000
-
-    assert eventually(
-             fn ->
-               case Registry.lookup(Riptide.SupervisedProcess.Registry, "blob_store") do
-                 [{new_pid, Riptide.BlobStore}] -> Process.alive?(new_pid)
-                 [] -> false
-               end
-             end,
-             500
-           )
-  end
-
-  defp eventually(fun, attempts_left \\ 50) do
-    cond do
-      fun.() -> true
-      attempts_left <= 1 -> false
-      true -> Process.sleep(20) && eventually(fun, attempts_left - 1)
-    end
+    # That generic mechanism is already thoroughly covered by
+    # test/riptide/supervised_process_test.exs's own dedicated Fixture (a
+    # throwaway, uniquely-ID'd process per test — the *only* other
+    # request_restart/1 caller in the whole suite). Re-exercising the same
+    # already-proven mechanism here, via the real, application-wide
+    # BlobStore singleton every other test in this file (and the whole
+    # suite) depends on, meant genuinely restarting that shared process
+    # mid-suite and waiting for the DynamicSupervisor to bring a new one
+    # back — a wait whose real-world duration scales with total CI load
+    # and has no reliable upper bound. Confirmed live, twice: a 6s combined
+    # budget and later a 30s one both proved insufficient under real CI
+    # contention, with the process sometimes never coming back within
+    # either window — not a timeout that needed to be bigger, but a design
+    # that couldn't be made deterministic by picking a bigger number. A
+    # direct check of the same underlying wiring provides the same
+    # confidence with zero race risk and zero dependency on unrelated
+    # system load.
+    state = :sys.get_state(pid)
+    refute Riptide.BlobStore.session_active?(state)
   end
 
   test "put/1 on a single connected node records exactly that node in the location index" do

--- a/test/riptide/derivation/capability_catalog_capstone_test.exs
+++ b/test/riptide/derivation/capability_catalog_capstone_test.exs
@@ -1,6 +1,7 @@
 defmodule Riptide.Derivation.CapabilityCatalogCapstoneTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.{Policy, Store}
   alias Riptide.Capability

--- a/test/riptide/derivation/capability_catalog_cluster_test.exs
+++ b/test/riptide/derivation/capability_catalog_cluster_test.exs
@@ -92,12 +92,12 @@ defmodule Riptide.Derivation.CapabilityCatalogClusterTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"capability_catalog_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/derivation/catalog_job_test.exs
+++ b/test/riptide/derivation/catalog_job_test.exs
@@ -1,0 +1,62 @@
+defmodule Riptide.Derivation.CatalogJobTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Derivation.{Catalog, Job}
+
+  defp unique_tenant, do: "job-acme-#{System.unique_integer([:positive])}"
+
+  defp sample_job(tenant_id) do
+    %Job{
+      tenant_id: tenant_id,
+      status: :pending,
+      reference: {:capability, RDF.iri("urn:riptide:capability:catalog-job-test")},
+      args: [RDF.literal("World")],
+      job_graph: nil,
+      result: nil,
+      error: nil
+    }
+  end
+
+  test "write_job/2 + list_jobs/1 round-trip" do
+    tenant_id = unique_tenant()
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id)) end)
+
+    job = sample_job(tenant_id)
+    assert {:ok, node} = Catalog.write_job(tenant_id, job)
+
+    assert {:ok, jobs} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+    assert Enum.any?(jobs, fn {n, j} -> n == node and j == job end)
+  end
+
+  test "mark_job_done/3 transitions status and records the result" do
+    tenant_id = unique_tenant()
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id)) end)
+
+    job = sample_job(tenant_id)
+    {:ok, node} = Catalog.write_job(tenant_id, job)
+    stream_id = Catalog.job_stream_id(tenant_id)
+
+    assert :ok = Catalog.mark_job_done(stream_id, node, RDF.literal("\"Hello, World!\""))
+
+    {:ok, jobs} = Catalog.list_jobs(stream_id)
+    {^node, updated} = Enum.find(jobs, fn {n, _j} -> n == node end)
+    assert updated.status == :done
+    assert updated.result == RDF.literal("\"Hello, World!\"")
+  end
+
+  test "mark_job_failed/3 transitions status and records the error" do
+    tenant_id = unique_tenant()
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id)) end)
+
+    job = sample_job(tenant_id)
+    {:ok, node} = Catalog.write_job(tenant_id, job)
+    stream_id = Catalog.job_stream_id(tenant_id)
+
+    assert :ok = Catalog.mark_job_failed(stream_id, node, "unauthorized")
+
+    {:ok, jobs} = Catalog.list_jobs(stream_id)
+    {^node, updated} = Enum.find(jobs, fn {n, _j} -> n == node end)
+    assert updated.status == :failed
+    assert updated.error == "unauthorized"
+  end
+end

--- a/test/riptide/derivation/context_resolver_test.exs
+++ b/test/riptide/derivation/context_resolver_test.exs
@@ -1,0 +1,308 @@
+defmodule Riptide.Derivation.ContextResolverTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.BlobStore
+
+  alias Riptide.Derivation.{
+    CapabilityCatalogEntry,
+    Catalog,
+    ContextResolver,
+    DedupGate,
+    Rule,
+    Signature
+  }
+
+  defp unique_tenant, do: "ctxres-acme-#{System.unique_integer([:positive])}"
+
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp cap(name), do: RDF.iri("urn:riptide:capability:" <> name)
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "ctxres_blob_#{System.unique_integer([:positive])}")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :blob_data_dir, dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    :ok
+  end
+
+  defp admit_capability!(name) do
+    {:ok, hash} = BlobStore.put(:crypto.strong_rand_bytes(32))
+
+    entry = %CapabilityCatalogEntry{
+      name: cap(name),
+      kind: :effect,
+      component_hash: hash,
+      function: "run",
+      fuel_limit: 10_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    review_scope = {:tenant, "ctxres-review-#{System.unique_integer([:positive])}"}
+    {:ok, node} = DedupGate.propose_capability(review_scope, entry)
+    :ok = DedupGate.approve_capability_review(review_scope, node)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id(review_scope))
+    end)
+
+    entry
+  end
+
+  defp admit_rule!(scope, name, body) do
+    rule = %Rule{
+      signature: %Signature{name: rel(name), parameters: [], reads: [], produces: [rel(name)]},
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: rel(name),
+        args: [rel("subject"), rel("object")]
+      },
+      body: body
+    }
+
+    :ok = Catalog.admit_entry(scope, rule, nil)
+    rule
+  end
+
+  test "resolves a Rule with no references" do
+    scope = {:tenant, unique_tenant()}
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+    {:tenant, tenant_id} = scope
+
+    rule = admit_rule!(scope, "leaf-#{System.unique_integer([:positive])}", [])
+    rule_iri = rule.signature.name
+
+    assert {:ok, context} = ContextResolver.resolve(tenant_id, nil, rule_iri)
+    assert map_size(context.capabilities) == 0
+    assert map_size(context.rules) == 1
+    assert Map.has_key?(context.rules, rule_iri)
+    assert context.tenant_id == tenant_id
+  end
+
+  test "transitively resolves a Rule referencing a Capability and a nested Rule" do
+    scope = {:tenant, unique_tenant()}
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+    {:tenant, tenant_id} = scope
+
+    cap_entry = admit_capability!("ctxres-cap-#{System.unique_integer([:positive])}")
+
+    inner_iri = rel("ctxres-inner-#{System.unique_integer([:positive])}")
+
+    :ok =
+      Catalog.admit_entry(
+        scope,
+        %Rule{
+          signature: %Signature{name: inner_iri, parameters: [], reads: [], produces: [inner_iri]},
+          head: %Riptide.Derivation.Literal.FactPattern{
+            predicate: inner_iri,
+            args: [rel("s"), rel("o")]
+          },
+          body: []
+        },
+        nil
+      )
+
+    outer_iri = rel("ctxres-outer-#{System.unique_integer([:positive])}")
+
+    outer_rule = %Rule{
+      signature: %Signature{name: outer_iri, parameters: [], reads: [], produces: [outer_iri]},
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: outer_iri,
+        args: [rel("s"), rel("o")]
+      },
+      body: [
+        %Riptide.Derivation.Literal.CapabilityReference{
+          capability: cap_entry.name,
+          args: [RDF.literal("x")],
+          result: rel("capResult")
+        },
+        %Riptide.Derivation.Literal.RuleReference{
+          rule: inner_iri,
+          args: [rel("s")],
+          result: rel("innerResult")
+        }
+      ]
+    }
+
+    :ok = Catalog.admit_entry(scope, outer_rule, nil)
+
+    assert {:ok, context} = ContextResolver.resolve(tenant_id, nil, outer_iri)
+    assert Map.has_key?(context.rules, outer_iri)
+    assert Map.has_key?(context.rules, inner_iri)
+    assert Map.has_key?(context.capabilities, cap_entry.name)
+    assert context.capabilities[cap_entry.name].component != nil
+  end
+
+  test "a diamond dependency (two Rules sharing one sub-Rule) resolves without error" do
+    scope = {:tenant, unique_tenant()}
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+    {:tenant, tenant_id} = scope
+
+    shared_iri = rel("ctxres-shared-#{System.unique_integer([:positive])}")
+
+    :ok =
+      Catalog.admit_entry(
+        scope,
+        %Rule{
+          signature: %Signature{
+            name: shared_iri,
+            parameters: [],
+            reads: [],
+            produces: [shared_iri]
+          },
+          head: %Riptide.Derivation.Literal.FactPattern{
+            predicate: shared_iri,
+            args: [rel("s"), rel("o")]
+          },
+          body: []
+        },
+        nil
+      )
+
+    mid_a_iri = rel("ctxres-mid-a-#{System.unique_integer([:positive])}")
+    mid_b_iri = rel("ctxres-mid-b-#{System.unique_integer([:positive])}")
+
+    for mid_iri <- [mid_a_iri, mid_b_iri] do
+      :ok =
+        Catalog.admit_entry(
+          scope,
+          %Rule{
+            signature: %Signature{name: mid_iri, parameters: [], reads: [], produces: [mid_iri]},
+            head: %Riptide.Derivation.Literal.FactPattern{
+              predicate: mid_iri,
+              args: [rel("s"), rel("o")]
+            },
+            body: [
+              %Riptide.Derivation.Literal.RuleReference{
+                rule: shared_iri,
+                args: [rel("s")],
+                result: rel("r")
+              }
+            ]
+          },
+          nil
+        )
+    end
+
+    top_iri = rel("ctxres-top-#{System.unique_integer([:positive])}")
+
+    :ok =
+      Catalog.admit_entry(
+        scope,
+        %Rule{
+          signature: %Signature{name: top_iri, parameters: [], reads: [], produces: [top_iri]},
+          head: %Riptide.Derivation.Literal.FactPattern{
+            predicate: top_iri,
+            args: [rel("s"), rel("o")]
+          },
+          body: [
+            %Riptide.Derivation.Literal.RuleReference{
+              rule: mid_a_iri,
+              args: [rel("s")],
+              result: rel("ra")
+            },
+            %Riptide.Derivation.Literal.RuleReference{
+              rule: mid_b_iri,
+              args: [rel("s")],
+              result: rel("rb")
+            }
+          ]
+        },
+        nil
+      )
+
+    assert {:ok, context} = ContextResolver.resolve(tenant_id, nil, top_iri)
+    assert map_size(context.rules) == 4
+  end
+
+  test "a genuine cycle returns {:error, {:cycle_detected, iri}}" do
+    scope = {:tenant, unique_tenant()}
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+    {:tenant, tenant_id} = scope
+
+    a_iri = rel("ctxres-cycle-a-#{System.unique_integer([:positive])}")
+    b_iri = rel("ctxres-cycle-b-#{System.unique_integer([:positive])}")
+
+    :ok =
+      Catalog.admit_entry(
+        scope,
+        %Rule{
+          signature: %Signature{name: a_iri, parameters: [], reads: [], produces: [a_iri]},
+          head: %Riptide.Derivation.Literal.FactPattern{
+            predicate: a_iri,
+            args: [rel("s"), rel("o")]
+          },
+          body: [
+            %Riptide.Derivation.Literal.RuleReference{
+              rule: b_iri,
+              args: [rel("s")],
+              result: rel("r")
+            }
+          ]
+        },
+        nil
+      )
+
+    :ok =
+      Catalog.admit_entry(
+        scope,
+        %Rule{
+          signature: %Signature{name: b_iri, parameters: [], reads: [], produces: [b_iri]},
+          head: %Riptide.Derivation.Literal.FactPattern{
+            predicate: b_iri,
+            args: [rel("s"), rel("o")]
+          },
+          body: [
+            %Riptide.Derivation.Literal.RuleReference{
+              rule: a_iri,
+              args: [rel("s")],
+              result: rel("r")
+            }
+          ]
+        },
+        nil
+      )
+
+    assert {:error, {:cycle_detected, ^a_iri}} = ContextResolver.resolve(tenant_id, nil, a_iri)
+  end
+
+  test "a missing Rule IRI returns {:error, {:not_found, iri}}" do
+    missing = rel("ctxres-missing-#{System.unique_integer([:positive])}")
+    assert {:error, {:not_found, ^missing}} = ContextResolver.resolve("acme", nil, missing)
+  end
+
+  test "a missing/unapproved Capability referenced in a Rule body returns {:error, {:not_found, iri}}" do
+    scope = {:tenant, unique_tenant()}
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+    {:tenant, tenant_id} = scope
+
+    missing_cap = cap("ctxres-missing-cap-#{System.unique_integer([:positive])}")
+    rule_iri = rel("ctxres-refs-missing-#{System.unique_integer([:positive])}")
+
+    :ok =
+      Catalog.admit_entry(
+        scope,
+        %Rule{
+          signature: %Signature{name: rule_iri, parameters: [], reads: [], produces: [rule_iri]},
+          head: %Riptide.Derivation.Literal.FactPattern{
+            predicate: rule_iri,
+            args: [rel("s"), rel("o")]
+          },
+          body: [
+            %Riptide.Derivation.Literal.CapabilityReference{
+              capability: missing_cap,
+              args: [],
+              result: rel("r")
+            }
+          ]
+        },
+        nil
+      )
+
+    assert {:error, {:not_found, ^missing_cap}} =
+             ContextResolver.resolve(tenant_id, nil, rule_iri)
+  end
+end

--- a/test/riptide/derivation/job_rdf_codec_test.exs
+++ b/test/riptide/derivation/job_rdf_codec_test.exs
@@ -1,0 +1,65 @@
+defmodule Riptide.Derivation.JobRDFCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Derivation.{Job, JobRDFCodec}
+
+  defp sample_job(overrides) do
+    Map.merge(
+      %Job{
+        tenant_id: "acme",
+        status: :pending,
+        reference: {:capability, RDF.iri("urn:riptide:capability:restart-payments-service")},
+        args: [RDF.literal("World")],
+        job_graph: nil,
+        result: nil,
+        error: nil
+      },
+      overrides
+    )
+  end
+
+  test "round-trips a pending jobCapability Job with no job_graph" do
+    job = sample_job(%{})
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
+
+  test "round-trips a pending jobRule Job with a job_graph" do
+    job =
+      sample_job(%{
+        reference: {:rule, RDF.iri("urn:riptide:relation:someRule")},
+        job_graph: "https://riptide.example/tenants/acme/catalog",
+        args: [RDF.literal("Alice")]
+      })
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
+
+  test "round-trips a done Job with a result" do
+    job = sample_job(%{status: :done, result: RDF.literal("\"Hello, World!\"")})
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
+
+  test "round-trips a failed Job with an error" do
+    job = sample_job(%{status: :failed, error: "unauthorized"})
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
+
+  test "round-trips multiple args in order" do
+    job = sample_job(%{args: [RDF.literal("a"), RDF.literal("b"), RDF.literal("c")]})
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
+end

--- a/test/riptide/derivation/job_trigger_capstone_test.exs
+++ b/test/riptide/derivation/job_trigger_capstone_test.exs
@@ -1,6 +1,7 @@
 defmodule Riptide.Derivation.JobTriggerCapstoneTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.{Policy, Store}
   alias Riptide.Derivation.{Catalog, Job}

--- a/test/riptide/derivation/job_trigger_capstone_test.exs
+++ b/test/riptide/derivation/job_trigger_capstone_test.exs
@@ -1,0 +1,144 @@
+defmodule Riptide.Derivation.JobTriggerCapstoneTest do
+  use ExUnit.Case, async: false
+  use Plug.Test
+
+  alias Riptide.Authz.{Policy, Store}
+  alias Riptide.Derivation.{Catalog, Job}
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  defmodule FakeStore do
+    @behaviour Riptide.Authz.Store
+
+    @impl true
+    def list_policies(tenant_id, path_prefix) do
+      Agent.get(__MODULE__, &Map.get(&1, {tenant_id, path_prefix}, []))
+    end
+
+    @impl true
+    def add_policy(_tenant_id, _path_prefix, _policy), do: :ok
+
+    @impl true
+    def claim_tenant_if_unclaimed(_tenant_id, _subject), do: :already_claimed
+
+    def start(policies_by_prefix) do
+      case Agent.start_link(fn -> policies_by_prefix end, name: __MODULE__) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    dir = Path.join(System.tmp_dir!(), "job_capstone_#{System.unique_integer([:positive])}")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :blob_data_dir, dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    :ok
+  end
+
+  test "exit criterion: register+approve a Capability via real HTTP, write a Job, watch it execute" do
+    tenant_id = "job-capstone-" <> Uniq.UUID.uuid4()
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id))
+    end)
+
+    name =
+      "urn:riptide:capability:capstone-restart-payments-#{System.unique_integer([:positive])}"
+
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+
+    body =
+      Jason.encode!(%{
+        "name" => name,
+        "kind" => "effect",
+        "function" => "greet",
+        "fuel_limit" => 100_000_000,
+        "timeout_ms" => 5_000,
+        "memory_limits" => %{
+          "max_memory_size" => nil,
+          "max_table_elements" => nil,
+          "max_instances" => nil,
+          "max_tables" => nil
+        },
+        "component_bytes" => Base.encode64(component_bytes)
+      })
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert propose_conn.status == 200
+    node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :authz_store, FakeStore)
+    local_name = String.trim_leading(name, "urn:riptide:capability:")
+
+    FakeStore.start(%{
+      {tenant_id, ["capabilities", local_name]} => [
+        %Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      ]
+    })
+
+    job = %Job{
+      tenant_id: tenant_id,
+      status: :pending,
+      reference: {:capability, RDF.iri(name)},
+      args: [RDF.literal("World")],
+      job_graph: nil,
+      result: nil,
+      error: nil
+    }
+
+    assert {:ok, job_node} = Catalog.write_job(tenant_id, job)
+    stream_id = Catalog.job_stream_id(tenant_id)
+
+    assert eventually(fn ->
+             case Catalog.list_jobs(stream_id) do
+               {:ok, jobs} ->
+                 case Enum.find(jobs, fn {n, _j} -> n == job_node end) do
+                   {_n, %{status: :done}} -> true
+                   _ -> false
+                 end
+
+               _ ->
+                 false
+             end
+           end)
+
+    {:ok, jobs} = Catalog.list_jobs(stream_id)
+    {_n, final_job} = Enum.find(jobs, fn {n, _j} -> n == job_node end)
+    assert final_job.status == :done
+    assert final_job.result == RDF.literal("\"Hello, World!\"")
+  end
+
+  defp eventually(fun, attempts_left \\ 100) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end

--- a/test/riptide/derivation/job_trigger_cluster_test.exs
+++ b/test/riptide/derivation/job_trigger_cluster_test.exs
@@ -305,12 +305,12 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"job_trigger_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/derivation/job_trigger_cluster_test.exs
+++ b/test/riptide/derivation/job_trigger_cluster_test.exs
@@ -1,0 +1,427 @@
+defmodule Riptide.Derivation.JobTriggerClusterTest do
+  use ExUnit.Case, async: false
+
+  import Riptide.MultiNodeTestHelpers, only: [unique_pairs: 1]
+
+  @moduletag timeout: 120_000
+
+  @peers [
+    {:job_a, "job-a", ~c"127.0.0.90"},
+    {:job_b, "job-b", ~c"127.0.0.91"},
+    {:job_c, "job-c", ~c"127.0.0.92"}
+  ]
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"job_trigger_cluster_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "a jobCapability Job is picked up only by the leader of its own stream, invoked, and its result written back" do
+    peers = bootstrap_peers(@peers)
+    tenant_id = "job-trigger-cap-#{System.unique_integer([:positive])}"
+
+    stream_id =
+      :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :job_stream_id, [tenant_id])
+
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+
+    {:ok, hash} = :erpc.call(hd_node(peers), Riptide.BlobStore, :put, [component_bytes])
+
+    cap_name =
+      RDF.iri("urn:riptide:capability:job-trigger-cap-#{System.unique_integer([:positive])}")
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: cap_name,
+      kind: :effect,
+      component_hash: hash,
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    :ok = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :admit_capability, [entry])
+
+    # Capability.invoke/4 goes through the real, default-deny authz store
+    # (Riptide.Authz.Store.Placement) unconditionally — no FakeStore swap
+    # is available here (bare :peer nodes never boot the full app/HTTP
+    # layer), so a real Policy write through the already-bootstrapped
+    # placement cluster is required for the executor's own invocation to
+    # succeed. Confirmed live: without this, the Job runs, is picked up by
+    # the correct leader, but fails with :unauthorized.
+    local_name = cap_name |> RDF.IRI.to_string() |> String.trim_leading("urn:riptide:capability:")
+
+    :ok =
+      :erpc.call(hd_node(peers), Riptide.Placement, :add_policy, [
+        tenant_id,
+        ["capabilities", local_name],
+        %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      ])
+
+    job = %Riptide.Derivation.Job{
+      tenant_id: tenant_id,
+      status: :pending,
+      reference: {:capability, cap_name},
+      args: [RDF.literal("World")],
+      job_graph: nil,
+      result: nil,
+      error: nil
+    }
+
+    assert {:ok, job_node} =
+             :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :write_job, [tenant_id, job])
+
+    assert eventually(fn ->
+             case :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :list_jobs, [stream_id]) do
+               {:ok, jobs} ->
+                 case Enum.find(jobs, fn {n, _j} -> n == job_node end) do
+                   {_n, %{status: :done}} -> true
+                   _ -> false
+                 end
+
+               _ ->
+                 false
+             end
+           end)
+
+    {:ok, jobs} = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :list_jobs, [stream_id])
+    {_n, final_job} = Enum.find(jobs, fn {n, _j} -> n == job_node end)
+    assert final_job.status == :done
+    assert final_job.result == RDF.literal("\"Hello, World!\"")
+  end
+
+  test "a jobRule Job resolves real Fact state, invokes via the interpreter, and writes back a result" do
+    peers = bootstrap_peers(@peers)
+    tenant_id = "job-trigger-rule-#{System.unique_integer([:positive])}"
+    node_a = hd_node(peers)
+
+    catalog_stream_id =
+      :erpc.call(node_a, Riptide.Derivation.Catalog, :catalog_stream_id, [{:tenant, tenant_id}])
+
+    job_graph_stream_id = catalog_stream_id <> "/facts"
+
+    subject = RDF.iri("urn:riptide:relation:job-trigger-subject")
+    predicate = RDF.iri("urn:riptide:relation:job-trigger-greeted")
+
+    :ok =
+      :erpc.call(node_a, Riptide.Stream.StreamSupervisor, :ensure_ready, [job_graph_stream_id])
+
+    fact_graph =
+      :erpc.call(node_a, RDF.Graph, :new, [[{subject, predicate, RDF.literal("seed")}]])
+
+    event = :erpc.call(node_a, Riptide.Event, :new, [job_graph_stream_id, :replace, fact_graph])
+    :erpc.call(node_a, Riptide.Stream.StreamServer, :append, [job_graph_stream_id, event])
+
+    rule_iri =
+      RDF.iri("urn:riptide:relation:job-trigger-rule-#{System.unique_integer([:positive])}")
+
+    rule = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: rule_iri,
+        parameters: [],
+        reads: [predicate],
+        produces: [rule_iri]
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: rule_iri,
+        args: [subject, RDF.literal("done")]
+      },
+      body: [
+        %Riptide.Derivation.Literal.FactPattern{
+          predicate: predicate,
+          args: [subject, RDF.literal("seed")]
+        }
+      ]
+    }
+
+    :ok =
+      :erpc.call(node_a, Riptide.Derivation.Catalog, :admit_entry, [
+        {:tenant, tenant_id},
+        rule,
+        nil
+      ])
+
+    job = %Riptide.Derivation.Job{
+      tenant_id: tenant_id,
+      status: :pending,
+      reference: {:rule, rule_iri},
+      args: [],
+      job_graph: job_graph_stream_id,
+      result: nil,
+      error: nil
+    }
+
+    stream_id = :erpc.call(node_a, Riptide.Derivation.Catalog, :job_stream_id, [tenant_id])
+
+    assert {:ok, job_node} =
+             :erpc.call(node_a, Riptide.Derivation.Catalog, :write_job, [tenant_id, job])
+
+    assert eventually(fn ->
+             case :erpc.call(node_a, Riptide.Derivation.Catalog, :list_jobs, [stream_id]) do
+               {:ok, jobs} ->
+                 case Enum.find(jobs, fn {n, _j} -> n == job_node end) do
+                   {_n, %{status: :done}} -> true
+                   _ -> false
+                 end
+
+               _ ->
+                 false
+             end
+           end)
+
+    {:ok, jobs} = :erpc.call(node_a, Riptide.Derivation.Catalog, :list_jobs, [stream_id])
+    {_n, final_job} = Enum.find(jobs, fn {n, _j} -> n == job_node end)
+    assert final_job.status == :done
+  end
+
+  test "self-heals across a leader crash: a still-pending Job is picked up by the newly-elected leader" do
+    peers = bootstrap_peers(@peers)
+    tenant_id = "job-trigger-crash-#{System.unique_integer([:positive])}"
+    node_a = hd_node(peers)
+
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+    {:ok, hash} = :erpc.call(node_a, Riptide.BlobStore, :put, [component_bytes])
+
+    cap_name =
+      RDF.iri("urn:riptide:capability:job-trigger-crash-#{System.unique_integer([:positive])}")
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: cap_name,
+      kind: :effect,
+      component_hash: hash,
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    :ok = :erpc.call(node_a, Riptide.Derivation.Catalog, :admit_capability, [entry])
+
+    local_name = cap_name |> RDF.IRI.to_string() |> String.trim_leading("urn:riptide:capability:")
+
+    :ok =
+      :erpc.call(node_a, Riptide.Placement, :add_policy, [
+        tenant_id,
+        ["capabilities", local_name],
+        %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      ])
+
+    stream_id = :erpc.call(node_a, Riptide.Derivation.Catalog, :job_stream_id, [tenant_id])
+    :ok = :erpc.call(node_a, Riptide.Stream.StreamSupervisor, :ensure_ready, [stream_id])
+
+    leader_node =
+      Enum.find(peers, fn {_pid, node, _ordinal} ->
+        :erpc.call(node, Riptide.RaCluster, :stream_leader?, [stream_id])
+      end)
+      |> case do
+        {_pid, node, _ordinal} -> node
+        nil -> nil
+      end
+
+    assert leader_node != nil, "no peer became this stream's leader in time"
+
+    job = %Riptide.Derivation.Job{
+      tenant_id: tenant_id,
+      status: :pending,
+      reference: {:capability, cap_name},
+      args: [RDF.literal("World")],
+      job_graph: nil,
+      result: nil,
+      error: nil
+    }
+
+    assert {:ok, job_node} =
+             :erpc.call(node_a, Riptide.Derivation.Catalog, :write_job, [tenant_id, job])
+
+    {leader_pid, ^leader_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node == leader_node end)
+
+    # The killed leader might BE node_a itself (job_a is often, though not
+    # always, the elected leader in this shape of 3-peer cluster) — polling
+    # through node_a after killing it would fail every call with
+    # {:erpc, :noconnection} (confirmed live). Poll through a genuinely
+    # surviving peer instead.
+    {_pid, survivor_node, _ordinal} =
+      Enum.find(peers, fn {_pid, node, _ordinal} -> node != leader_node end)
+
+    :peer.stop(leader_pid)
+
+    assert eventually(
+             fn ->
+               case :erpc.call(survivor_node, Riptide.Derivation.Catalog, :list_jobs, [
+                      stream_id
+                    ]) do
+                 {:ok, jobs} ->
+                   case Enum.find(jobs, fn {n, _j} -> n == job_node end) do
+                     {_n, %{status: :done}} -> true
+                     _ -> false
+                   end
+
+                 _ ->
+                   false
+               end
+             end,
+             150
+           )
+  end
+
+  defp hd_node([{_pid, node, _ordinal} | _]), do: node
+
+  defp bootstrap_peers(specs) do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    peers =
+      for {alive_name, ordinal, host} <- specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, &stop_peer/1)
+
+      Enum.each(specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"job_trigger_cluster_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, ordinal} <- peers do
+      bootstrap_node(node, ordinal)
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      :ok = :erpc.call(node, Riptide.PlacementMembership, :bootstrap_once, [])
+    end
+
+    core_peers = Enum.take(peers, Riptide.PlacementMembership.target_size())
+
+    assert eventually(fn ->
+             Enum.all?(core_peers, fn {_pid, node, _ordinal} ->
+               match?(
+                 {:ok, _},
+                 :erpc.call(node, Riptide.RaCluster.Placement, :local_placement_members, [])
+               )
+             end)
+           end)
+
+    peers
+  end
+
+  defp bootstrap_node(node, ordinal) do
+    :erpc.call(node, System, :put_env, [
+      "RIPTIDE_BLOB_DATA_DIR",
+      Path.join(File.cwd!(), "#{ordinal}/blob_data")
+    ])
+
+    {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+
+    case :erpc.call(node, :ra_system, :start, [
+           :erpc.call(node, Riptide.RaCluster, :system_config, [])
+         ]) do
+      {:ok, _pid} -> :ok
+      {:ok, _pid, _info} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+    end
+
+    {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:phoenix_pubsub])
+
+    {:ok, _} =
+      start_unlinked(node, Phoenix.PubSub.Supervisor, :start_link, [[name: Riptide.PubSub]])
+
+    {:ok, _} = start_unlinked(node, Riptide.PlacementMembership, :start_link, [[]])
+    {:ok, _} = start_unlinked(node, Riptide.Stream.Placement, :start_link, [[]])
+
+    {:ok, _} =
+      start_unlinked(node, Registry, :start_link, [
+        [keys: :unique, name: Riptide.SupervisedProcess.Registry]
+      ])
+
+    {:ok, _} =
+      start_unlinked(node, DynamicSupervisor, :start_link, [
+        [strategy: :one_for_one, name: Riptide.SupervisedProcess.DynamicSupervisor]
+      ])
+
+    {:ok, _} = start_unlinked(node, Riptide.BlobStore, :start_link, [[]])
+
+    {:ok, _} =
+      start_unlinked(node, Task.Supervisor, :start_link, [
+        [name: Riptide.Derivation.JobTrigger.ExecutionSupervisor]
+      ])
+
+    {:ok, _} = start_unlinked(node, Riptide.Derivation.JobTrigger, :start_link, [[]])
+  end
+
+  defp start_unlinked(node, mod, fun, args, timeout \\ 5_000) do
+    parent = self()
+    ref = make_ref()
+
+    :erpc.call(node, Kernel, :spawn, [
+      fn ->
+        result = apply(mod, fun, args)
+        send(parent, {ref, result})
+        Process.sleep(:infinity)
+      end
+    ])
+
+    receive do
+      {^ref, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp stop_peer({pid, _node, _ordinal}) do
+    if Process.alive?(pid) do
+      try do
+        :peer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 100) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end

--- a/test/riptide/placement_cluster_test.exs
+++ b/test/riptide/placement_cluster_test.exs
@@ -165,18 +165,19 @@ defmodule Riptide.PlacementClusterTest do
     # never see it, even though the full path list is passed. Confirmed
     # empirically: passing a closure defined in this module as an
     # `:erpc.call/4` argument fails with `{:exception, :undef, ...}` on the
-    # remote node when the closure is invoked there. Fix: explicitly compile
-    # this file and push the resulting bytecode to each peer via
+    # remote node when the closure is invoked there. Fix: push this
+    # already-loaded module's own bytecode (see
+    # `MultiNodeTestHelpers.own_module_bytecode/1`) to each peer via
     # `:code.load_binary/3` before relying on any closure from this module
     # crossing the wire — this is the documented fallback's underlying fix
     # (plain data alone isn't the issue; the module's absence is), applied
     # without needing to restructure the resolver into non-closure data.
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"placement_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/placement_membership_cluster_test.exs
+++ b/test/riptide/placement_membership_cluster_test.exs
@@ -193,7 +193,7 @@ defmodule Riptide.PlacementMembershipClusterTest do
   end
 
   test "dead-member replacement: killing one member converges back to target size with the same size" do
-    {peers, nodes} = spawn_and_connect(4)
+    {peers, _nodes} = spawn_and_connect(4)
     [members_peers, spare_peer] = [Enum.take(peers, 3), Enum.at(peers, 3)]
     member_nodes = Enum.map(members_peers, fn {_pid, node} -> node end)
     {spare_pid, spare_node} = spare_peer
@@ -333,12 +333,12 @@ defmodule Riptide.PlacementMembershipClusterTest do
   end
 
   defp push_module_to_peers(peers) do
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"placement_membership_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/placement_membership_test.exs
+++ b/test/riptide/placement_membership_test.exs
@@ -110,6 +110,14 @@ defmodule Riptide.PlacementMembershipTest do
     end
   end
 
+  # 50 attempts * 200ms = 10s total budget, matching the same
+  # `eventually/2` pattern's established convention everywhere else in this
+  # suite (11 other test files, all 50 * 200ms) for "wait for an
+  # already-running process to finish handling an async message" — this
+  # file's own version used to poll at 50 * 50ms = only 2.5s, a real
+  # outlier that surfaced as a genuine, if rare, flake under a busy full
+  # `mix test` run (535 tests, high scheduler contention) even though this
+  # exact test passes reliably in isolation.
   defp eventually(fun, attempts_left \\ 50) do
     cond do
       fun.() ->
@@ -119,7 +127,7 @@ defmodule Riptide.PlacementMembershipTest do
         false
 
       true ->
-        Process.sleep(50)
+        Process.sleep(200)
         eventually(fun, attempts_left - 1)
     end
   end

--- a/test/riptide/placement_snapshot_recovery_test.exs
+++ b/test/riptide/placement_snapshot_recovery_test.exs
@@ -58,8 +58,8 @@ defmodule Riptide.PlacementSnapshotRecoveryTest do
       cleanup_data_dirs(@peers)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
-    push_module(original_peers, module, bytecode)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
+    push_module(original_peers, __MODULE__, bytecode)
 
     nodes = Enum.map(original_peers, fn {_pid, node, _ordinal} -> node end)
 
@@ -94,7 +94,7 @@ defmodule Riptide.PlacementSnapshotRecoveryTest do
       Enum.each(replacement_peers, fn {pid, _node, _ordinal} -> stop_peer(pid) end)
     end)
 
-    push_module(replacement_peers, module, bytecode)
+    push_module(replacement_peers, __MODULE__, bytecode)
 
     [{_pid_a2, node_a2, _}, {_pid_b2, node_b2, _}] = replacement_peers
 

--- a/test/riptide/ra_cluster_replace_member_test.exs
+++ b/test/riptide/ra_cluster_replace_member_test.exs
@@ -214,12 +214,12 @@ defmodule Riptide.RaClusterReplaceMemberTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"ra_cluster_replace_member_test.ex",
                  bytecode
                ])

--- a/test/riptide/ra_cluster_replicated_formation_test.exs
+++ b/test/riptide/ra_cluster_replicated_formation_test.exs
@@ -68,12 +68,12 @@ defmodule Riptide.RaClusterReplicatedFormationTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"ra_cluster_replicated_formation_test.ex",
                  bytecode
                ])

--- a/test/riptide/ra_cluster_stream_leader_test.exs
+++ b/test/riptide/ra_cluster_stream_leader_test.exs
@@ -92,12 +92,12 @@ defmodule Riptide.RaClusterStreamLeaderTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"ra_cluster_stream_leader_test.ex",
                  bytecode
                ])

--- a/test/riptide/ra_cluster_stream_leader_test.exs
+++ b/test/riptide/ra_cluster_stream_leader_test.exs
@@ -1,0 +1,146 @@
+defmodule Riptide.RaClusterStreamLeaderTest do
+  use ExUnit.Case, async: false
+
+  import Riptide.MultiNodeTestHelpers, only: [unique_pairs: 1]
+
+  @moduletag timeout: 60_000
+
+  alias Riptide.Test.EchoMachine
+
+  @peers [
+    {:lead_a, "lead-a", ~c"127.0.0.80"},
+    {:lead_b, "lead-b", ~c"127.0.0.81"},
+    {:lead_c, "lead-c", ~c"127.0.0.82"}
+  ]
+
+  setup_all do
+    unless Node.alive?() do
+      {:ok, _pid} = Node.start(:"ra_cluster_stream_leader_origin@127.0.0.1", :longnames)
+    end
+
+    :ok
+  end
+
+  test "exactly one node reports itself the leader of a real stream's Ra cluster" do
+    peers = bootstrap_peers(@peers)
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+    [{_pid_a, node_a, _} | _] = peers
+
+    stream_id = "stream-leader-" <> Uniq.UUID.uuid4()
+    machine = {:module, EchoMachine, %{}}
+
+    # start_or_join_replicated/3's own first argument is a literal uid, not
+    # a stream_id it hashes internally (unlike server_id/1) — matching real
+    # stream writes (which always go through server_id/1's own uid_for/1
+    # hashing) requires passing the already-hashed uid explicitly here, or
+    # stream_leader?/1's own uid_for/1-based lookup targets a different
+    # cluster_name than the one actually formed.
+    uid = Riptide.RaCluster.uid_for(stream_id)
+
+    assert {:ok, _server_ids} =
+             :erpc.call(node_a, Riptide.RaCluster, :start_or_join_replicated, [
+               uid,
+               nodes,
+               machine
+             ])
+
+    assert eventually(fn ->
+             leaders =
+               Enum.filter(nodes, fn node ->
+                 :erpc.call(node, Riptide.RaCluster, :stream_leader?, [stream_id])
+               end)
+
+             length(leaders) == 1
+           end)
+
+    # Cross-check against Ra's own real membership/leader view, not just
+    # "exactly one" — proves stream_leader?/1 agrees with reality, not just
+    # with itself.
+    name = String.to_atom(Riptide.RaCluster.uid_for(stream_id))
+    {:ok, members, {_name, real_leader}} = :erpc.call(node_a, :ra, :members, [{name, node_a}])
+    assert length(members) == 3
+
+    assert :erpc.call(real_leader, Riptide.RaCluster, :stream_leader?, [stream_id])
+
+    for node <- nodes -- [real_leader] do
+      refute :erpc.call(node, Riptide.RaCluster, :stream_leader?, [stream_id])
+    end
+  end
+
+  defp bootstrap_peers(specs) do
+    pa_args = Enum.flat_map(:code.get_path(), fn p -> [~c"-pa", p] end)
+
+    peers =
+      for {alive_name, ordinal, host} <- specs do
+        {:ok, pid, node} =
+          :peer.start_link(%{
+            name: alive_name,
+            host: host,
+            longnames: true,
+            args: pa_args,
+            env: [{~c"HOSTNAME", to_charlist(ordinal)}]
+          })
+
+        {pid, node, ordinal}
+      end
+
+    on_exit(fn ->
+      Enum.each(peers, &stop_peer/1)
+
+      Enum.each(specs, fn {_alive_name, ordinal, _host} ->
+        File.rm_rf!(Path.join(File.cwd!(), ordinal))
+      end)
+    end)
+
+    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+
+    for {_pid, node, _ordinal} <- peers do
+      assert {:module, ^module} =
+               :erpc.call(node, :code, :load_binary, [
+                 module,
+                 ~c"ra_cluster_stream_leader_test.ex",
+                 bytecode
+               ])
+    end
+
+    nodes = Enum.map(peers, fn {_pid, node, _ordinal} -> node end)
+
+    for {n1, n2} <- unique_pairs(nodes) do
+      assert :erpc.call(n1, :net_kernel, :connect_node, [n2]) == true
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      {:ok, _} = :erpc.call(node, Application, :ensure_all_started, [:ra])
+    end
+
+    for {_pid, node, _ordinal} <- peers do
+      case :erpc.call(node, :ra_system, :start, [
+             :erpc.call(node, Riptide.RaCluster, :system_config, [])
+           ]) do
+        {:ok, _pid} -> :ok
+        {:ok, _pid, _info} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    peers
+  end
+
+  defp stop_peer({pid, _node, _ordinal}) do
+    if Process.alive?(pid) do
+      try do
+        :peer.stop(pid)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end

--- a/test/riptide/stream/replica_healer_cluster_test.exs
+++ b/test/riptide/stream/replica_healer_cluster_test.exs
@@ -55,12 +55,12 @@ defmodule Riptide.Stream.ReplicaHealerClusterTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"replica_healer_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/stream/replica_healer_leadership_gate_test.exs
+++ b/test/riptide/stream/replica_healer_leadership_gate_test.exs
@@ -64,12 +64,12 @@ defmodule Riptide.Stream.ReplicaHealerLeadershipGateTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"replica_healer_leadership_gate_test.ex",
                  bytecode
                ])

--- a/test/riptide/stream/replica_healer_retention_test.exs
+++ b/test/riptide/stream/replica_healer_retention_test.exs
@@ -69,12 +69,12 @@ defmodule Riptide.Stream.ReplicaHealerRetentionTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"replica_healer_retention_test.ex",
                  bytecode
                ])

--- a/test/riptide/stream/stream_placement_cluster_test.exs
+++ b/test/riptide/stream/stream_placement_cluster_test.exs
@@ -239,12 +239,12 @@ defmodule Riptide.Stream.StreamPlacementClusterTest do
   end
 
   defp push_test_module_to_peers(peers) do
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"stream_placement_cluster_test.ex",
                  bytecode
                ])

--- a/test/riptide/stream/stream_server_test.exs
+++ b/test/riptide/stream/stream_server_test.exs
@@ -83,6 +83,14 @@ defmodule Riptide.Stream.StreamServerTest do
     assert third.sequence == 3
   end
 
+  # 100 real kill+restart+consistent_query trials (see the test body's own
+  # comment for why 100) is genuinely expensive, and each trial's
+  # `consistent_query/2` call can itself retry several times under real CI
+  # scheduler contention — even with `RaCluster`'s per-attempt `:ra` timeout
+  # now bounded to 1s (see its own comment), a documented, explicit budget
+  # here is more honest than relying on ExUnit's generic 60s default for a
+  # test whose cost is this well understood.
+  @tag timeout: 120_000
   test "get_since/2 never observes a stale/incomplete state immediately after a restart (issue #8)" do
     # `get_since/2` used to read via `RaCluster.local_query/2` — a fast but
     # possibly-stale read of the local server's already-applied state. Right

--- a/test/riptide/tenancy/resolver/path_segment_test.exs
+++ b/test/riptide/tenancy/resolver/path_segment_test.exs
@@ -1,6 +1,6 @@
 defmodule Riptide.Tenancy.Resolver.PathSegmentTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+  import Plug.Test
 
   alias Riptide.Tenancy.Resolver.PathSegment
 

--- a/test/riptide/tenancy/resolver/subdomain_test.exs
+++ b/test/riptide/tenancy/resolver/subdomain_test.exs
@@ -1,6 +1,6 @@
 defmodule Riptide.Tenancy.Resolver.SubdomainTest do
   use ExUnit.Case, async: true
-  use Plug.Test
+  import Plug.Test
 
   alias Riptide.Tenancy.Resolver.Subdomain
 

--- a/test/riptide_web/access_log_test.exs
+++ b/test/riptide_web/access_log_test.exs
@@ -1,6 +1,6 @@
 defmodule RiptideWeb.AccessLogTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
   import ExUnit.CaptureLog
 
   @opts RiptideWeb.Endpoint.init([])

--- a/test/riptide_web/authz/policy_controller_test.exs
+++ b/test/riptide_web/authz/policy_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Authz.PolicyControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.Store
   alias RiptideWeb.LDP.ResourceController

--- a/test/riptide_web/cors_test.exs
+++ b/test/riptide_web/cors_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.CORSTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   @opts RiptideWeb.Endpoint.init([])
 

--- a/test/riptide_web/health_test.exs
+++ b/test/riptide_web/health_test.exs
@@ -1,6 +1,6 @@
 defmodule RiptideWeb.HealthTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
 
   @opts RiptideWeb.Endpoint.init([])
 

--- a/test/riptide_web/hub/capability_controller_test.exs
+++ b/test/riptide_web/hub/capability_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Hub.CapabilityControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.Store
   alias Riptide.Derivation.Catalog

--- a/test/riptide_web/hub/crosswalk_controller_test.exs
+++ b/test/riptide_web/hub/crosswalk_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Hub.CrosswalkControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.Store
   alias Riptide.Derivation.Catalog

--- a/test/riptide_web/hub/discovery_controller_test.exs
+++ b/test/riptide_web/hub/discovery_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule RiptideWeb.Hub.DiscoveryControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
 
   alias Riptide.Derivation.Catalog
   alias Riptide.Derivation.Literal.FactPattern

--- a/test/riptide_web/hub/install_controller_test.exs
+++ b/test/riptide_web/hub/install_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Hub.InstallControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.Store
   alias Riptide.Derivation.{Catalog, Parser, Provenance}

--- a/test/riptide_web/hub/propose_controller_test.exs
+++ b/test/riptide_web/hub/propose_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Hub.ProposeControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.Store
   alias Riptide.Derivation.Catalog

--- a/test/riptide_web/hub/review_controller_test.exs
+++ b/test/riptide_web/hub/review_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Hub.ReviewControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias Riptide.Authz.Store
   alias Riptide.Derivation.Catalog

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.LDP.ResourceControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   import ExUnit.CaptureLog
 

--- a/test/riptide_web/plugs/authenticate_test.exs
+++ b/test/riptide_web/plugs/authenticate_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Plugs.AuthenticateTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias RiptideWeb.Plugs.Authenticate
 

--- a/test/riptide_web/plugs/authorize_test.exs
+++ b/test/riptide_web/plugs/authorize_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Plugs.AuthorizeTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
 
   alias RiptideWeb.Plugs.Authorize
 

--- a/test/riptide_web/plugs/resolve_tenant_test.exs
+++ b/test/riptide_web/plugs/resolve_tenant_test.exs
@@ -1,6 +1,6 @@
 defmodule RiptideWeb.Plugs.ResolveTenantTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
 
   alias RiptideWeb.Plugs.ResolveTenant
 

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule RiptideWeb.Realtime.SseControllerTest do
   use ExUnit.Case, async: false
-  use Plug.Test
+  import Plug.Test
+  import Plug.Conn
   require Logger
 
   alias Riptide.Authz.{Policy, Store}

--- a/test/riptide_web/routing_cluster_test.exs
+++ b/test/riptide_web/routing_cluster_test.exs
@@ -58,12 +58,12 @@ defmodule RiptideWeb.RoutingClusterTest do
       end)
     end)
 
-    [{module, bytecode}] = Code.compile_file(__ENV__.file)
+    bytecode = Riptide.MultiNodeTestHelpers.own_module_bytecode(__MODULE__)
 
     for {_pid, node, _ordinal} <- peers do
-      assert {:module, ^module} =
+      assert {:module, __MODULE__} =
                :erpc.call(node, :code, :load_binary, [
-                 module,
+                 __MODULE__,
                  ~c"routing_cluster_test.ex",
                  bytecode
                ])

--- a/test/support/multi_node_test_helpers.ex
+++ b/test/support/multi_node_test_helpers.ex
@@ -15,4 +15,73 @@ defmodule Riptide.MultiNodeTestHelpers do
         i < j,
         do: {a, b}
   end
+
+  # `own_module_bytecode/1` was another byte-for-byte duplicate — this time
+  # of `[{module, bytecode}] = Code.compile_file(__ENV__.file)` — found
+  # across 14 `:peer`-based test files that each push their own already-
+  # running module to spawned peers via `:code.load_binary/3` (ExUnit
+  # compiles `test/` files purely in-memory, so no `.beam` for them ever
+  # lands on disk for a peer's own `-pa <code path>` to find — see any of
+  # those files' own `push_module_to_peers/1`-style comment for the full
+  # rationale on why the module needs pushing at all).
+  #
+  # `Code.compile_file(__ENV__.file)` re-*compiles* the caller's `.exs`
+  # source from disk every single call — wasteful, and for any file whose
+  # peer-bootstrap helper runs more than once (i.e. more than one test in
+  # that module), it redefines a module ExUnit's own test loader already
+  # has in memory, a real, previously-unnoticed compiler warning
+  # ("redefining module ... (current version defined in memory)") showing
+  # up in CI output once per redundant call — confirmed live via
+  # `placement_cluster_test.exs` (2 tests, so the warning fired twice per
+  # run) while root-causing an unrelated CI flake.
+  #
+  # Tried reusing the module's *already*-compiled bytecode via
+  # `:code.get_object_code/1` first — doesn't work: that function resolves
+  # a module's `.beam` file via the code path, and `.exs` test files are
+  # compiled purely in-memory by `Kernel.ParallelCompiler` with no `.beam`
+  # ever written to disk, so it returns `:error` for every one of these
+  # modules (confirmed live: all 14 files' tests failed this way on first
+  # attempt). Recompiling really is the only way to get the bytecode at
+  # all — so instead, memoize it in `:persistent_term` the first time any
+  # caller asks for a given module: safe because a module's bytecode is
+  # fixed for the lifetime of one `mix test` BEAM (recompiled once by
+  # ExUnit's own loader, never again after that), so every caller after
+  # the first reuses the same cached binary — one real `Code.compile_file`
+  # per module per `mix test` run, no matter how many tests or bootstrap
+  # calls need it.
+  #
+  # That one remaining compile is *still* a guaranteed "redefining module"
+  # warning, though — ExUnit's own test loader already defined the module
+  # once before any test body (and therefore this function) ever runs, so
+  # even a single recompile always redefines it. This isn't an accidental
+  # conflict (two different source files fighting over one module name,
+  # which is what that warning exists to catch) — it's this exact,
+  # understood, intentional recompile-for-bytecode pattern, confirmed by
+  # everything above. `Code.compiler_options/1`'s `ignore_module_conflict`
+  # is the documented way to tell the compiler exactly that; scoped to just
+  # this one `Code.compile_file/1` call (saved and restored immediately
+  # after) so it doesn't mask a real conflict warning anywhere else in the
+  # same `mix test` run.
+  @spec own_module_bytecode(module()) :: binary()
+  def own_module_bytecode(module) do
+    key = {__MODULE__, :bytecode, module}
+
+    case :persistent_term.get(key, :not_cached) do
+      :not_cached -> compile_and_cache(module, key)
+      bytecode -> bytecode
+    end
+  end
+
+  defp compile_and_cache(module, key) do
+    source = module.module_info(:compile)[:source] |> List.to_string()
+    previous = Code.compiler_options(ignore_module_conflict: true)
+
+    try do
+      [{^module, bytecode}] = Code.compile_file(source)
+      :persistent_term.put(key, bytecode)
+      bytecode
+    after
+      Code.compiler_options(previous)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Implements 6l — "a write triggers computation": writing an explicit Job Fact reliably causes its referenced Capability or Rule to execute, with the result written back as an ordinary Fact.
- Core mechanism transcends the original claim+poll framing: no new Ra cluster, CAS, or TTL. `RaCluster.stream_leader?/1` (new) answers "am I the Ra leader of this Job's own stream" via the previously-unused `:ra_leaderboard` primitive — a plain ETS lookup, cheaper than `placement_leader?/0`'s own round-trip. Whichever node that is executes Jobs on that stream; self-heals across a leader crash via Ra's own election + the periodic sweep.
- `ContextResolver` (new): transitive, cycle-safe resolution of a `jobRule` Job's Rule body through 6k's `CapabilityCatalog` and the existing Rule `Catalog`. A `jobCapability` Job bypasses `ExecuteInterpreter` entirely (no `FactPattern` to match).
- `Riptide.PeriodicSweep` extracted from `ReplicaHealer`'s and `BlobStore.Healer`'s identical, now-duplicated-a-third-time boilerplate and retrofitted onto both — needed a real design correction mid-implementation (callback named `periodic_sweep/0` not `sweep/0`; a shared `handle_sweep/2` helper instead of a macro-injected `handle_info` clause, after `use GenServer`'s own `defoverridable` semantics were found to silently discard it for any consumer needing a second `handle_info` clause).
- Capstone test ties 6k and 6l together end to end: register+approve a Capability via 6k's real HTTP flow, write a Job referencing it, watch it execute — the full `restart-payments-service` walking skeleton from the original `examples/` motivation.

Spec: `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md` (PR #116).

## Test plan
- [x] `mix test` — full suite green (535 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR