### PR TITLE
Draft: Resolve: "6d-ii — Concurrent-effects design spike"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1209,3 +1209,52 @@ surfaced as a rare flake under full-suite scheduler contention; and `authz_test.
 Verified with 8 consecutive full `mix test` / `mix test --warnings-as-errors` runs (0 failures, 0
 warnings each time), `mix format --check-formatted`, and `mix credo --strict`, before merging #116 and
 #118 (2026-08-31).
+
+### 6d-ii — Concurrent-Effects Coordination
+
+**Shipped 2026-09-01** — see
+`docs/superpowers/specs/2026-09-01-phase-6d-ii-concurrent-effects-design.md` and the research log's
+Part 4 (a real research pass — 24 sources, 25 claims adversarially verified — replacing the parent
+spec's own informal "checked: neither sagas nor CRDTs establish this" note).
+
+Gives `JobTrigger` a hard, load-bearing guarantee that two Jobs for the same Tenant declaring the same
+`resource_key` never execute concurrently — newly urgent once 6l shipped, since two different Job
+streams owned by two different leader nodes could otherwise invoke overlapping EffectCapabilities with
+zero coordination.
+
+The core insight: no new coordination primitive was needed at all. 6l already guarantees exactly one
+node — whichever currently leads a Tenant's Job stream — executes that Tenant's Jobs
+(`RaCluster.stream_leader?/1`). Since every Job for a Tenant, regardless of which resource it targets,
+is already funneled through that same single process, resource-key exclusion reduces to purely local,
+in-memory bookkeeping on `JobTrigger` itself: two `:ets` tables (the currently-in-flight resource-key
+set, and a monitor-ref-to-resource reverse map for crash-safe release), both created in `init/1` and
+therefore dying with the process — a crashed or handed-off leader's reservations simply cease to exist,
+the same at-least-once contract Job execution already has, not a new failure mode. No CAS, no TTL, no
+lease, no fencing token (the research log explains why fencing tokens don't apply here: there's no
+"lock holder pauses and later wakes up to act" window to defend against, since the code that invokes a
+Capability only ever runs as a direct consequence of currently being the leader).
+
+`Job` gained an optional `resource_key` field (nil by default — opt-in, not a tax on every Job). Two
+real subtleties found during implementation, both by a failing test catching a wrong assumption rather
+than by reasoning it out in advance: (1) `Process.monitor/1` inside the exclusion helper monitors from
+whichever process *calls* it — correct for the production dispatch path (already running inside
+`JobTrigger`'s own process via `handle_info`/`periodic_sweep`), but a test calling it directly would
+make the *test* process own the monitor, silently breaking crash-safe cleanup; fixed with a
+`test_run_exclusively/2` entry point that routes through a real (non-self) `GenServer.call`, letting
+`handle_call/3` execute the reservation from within `JobTrigger` itself the same way the production
+path already does — the production path can't use `GenServer.call` itself, since it already runs
+inside that same process and would deadlock calling itself. (2) A unit test asserting a locked
+resource stays locked flaked because the first task's trivial function completed and was
+monitor-cleaned-up before the test's own follow-up assertion ran — the reservation's presence *at
+return time* was correctly guaranteed, but nothing kept it present afterward for an near-instant
+function; fixed by having the first task block until the test explicitly lets it finish.
+
+Explicitly **not** covered by this phase, stated plainly rather than silently dropped: routing
+`GeneralizationFidelity`'s Capability replay (6e-ii) through this same mechanism. That call site isn't
+dispatched by `JobTrigger` at all today and may run on a different node than the Tenant's Job-stream
+leader, so closing that gap needs cross-node leader-routing — meaningfully different machinery than
+local `:ets` state — left as a tracked follow-up rather than bolted onto this plan.
+
+**Status**: Phase 6d-ii shipped 2026-09-01. 4 phases remaining — see issue #58's own restated summary
+for the current list (6g-ii deferred with no exit criterion yet; 6c-iii-a/6c-iii-b, Track B, ready to
+start; Capability grant flow/OAuth, Track A, ready to start).

--- a/lib/riptide/derivation/job.ex
+++ b/lib/riptide/derivation/job.ex
@@ -5,10 +5,16 @@ defmodule Riptide.Derivation.Job do
   `docs/superpowers/specs/2026-08-31-phase-6l-reactive-job-triggering-design.md`
   §5. Plain writes, never reviewed (unlike a `CapabilityCatalogEntry` or
   Rule Catalog admission).
+
+  A Job may declare `resource_key` (see design spec
+  `docs/superpowers/specs/2026-09-01-phase-6d-ii-concurrent-effects-design.md`
+  §4.3) to mark that it must never execute concurrently with another Job
+  for the same Tenant declaring the same key. `nil` (the default) means
+  this Job isn't subject to that coordination at all.
   """
 
   @enforce_keys [:tenant_id, :status, :reference, :args]
-  defstruct [:tenant_id, :status, :reference, :args, :job_graph, :result, :error]
+  defstruct [:tenant_id, :status, :reference, :args, :job_graph, :result, :error, :resource_key]
 
   @type reference_t :: {:capability, RDF.IRI.t()} | {:rule, RDF.IRI.t()}
 
@@ -19,6 +25,7 @@ defmodule Riptide.Derivation.Job do
           args: [RDF.Term.t()],
           job_graph: String.t() | nil,
           result: RDF.Term.t() | nil,
-          error: String.t() | nil
+          error: String.t() | nil,
+          resource_key: String.t() | nil
         }
 end

--- a/lib/riptide/derivation/job_rdf_codec.ex
+++ b/lib/riptide/derivation/job_rdf_codec.ex
@@ -18,6 +18,7 @@ defmodule Riptide.Derivation.JobRDFCodec do
   @riptide_job_graph RDF.iri("urn:riptide:vocab:jobGraph")
   @riptide_job_result RDF.iri("urn:riptide:vocab:jobResult")
   @riptide_job_error RDF.iri("urn:riptide:vocab:jobError")
+  @riptide_job_resource_key RDF.iri("urn:riptide:vocab:jobResourceKey")
 
   @spec to_rdf(Job.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
   def to_rdf(%Job{} = job) do
@@ -35,6 +36,11 @@ defmodule Riptide.Derivation.JobRDFCodec do
       |> maybe_add(node, @riptide_job_graph, job.job_graph && RDF.literal(job.job_graph))
       |> maybe_add(node, @riptide_job_result, job.result)
       |> maybe_add(node, @riptide_job_error, job.error && RDF.literal(job.error))
+      |> maybe_add(
+        node,
+        @riptide_job_resource_key,
+        job.resource_key && RDF.literal(job.resource_key)
+      )
 
     {node, graph}
   end
@@ -77,7 +83,8 @@ defmodule Riptide.Derivation.JobRDFCodec do
       args: RDF.List.new(args_head, graph) |> RDF.List.values(),
       job_graph: decode_optional_string(description, @riptide_job_graph),
       result: RDF.Description.first(description, @riptide_job_result),
-      error: decode_optional_string(description, @riptide_job_error)
+      error: decode_optional_string(description, @riptide_job_error),
+      resource_key: decode_optional_string(description, @riptide_job_resource_key)
     }
   end
 

--- a/lib/riptide/derivation/job_trigger.ex
+++ b/lib/riptide/derivation/job_trigger.ex
@@ -6,6 +6,22 @@ defmodule Riptide.Derivation.JobTrigger do
   (`RaCluster.stream_leader?/1`) is that Job's sole executor, discovered
   reactively via `Riptide.Derivation.Catalog`'s own `{:job_written,
   stream_id}` broadcast and self-healingly via `Riptide.PeriodicSweep`.
+
+  A Job may declare `resource_key` — see design spec
+  `docs/superpowers/specs/2026-09-01-phase-6d-ii-concurrent-effects-design.md`
+  §4 — to mark that it must never execute concurrently with another Job for
+  the same Tenant declaring the same key. Because every Job for a Tenant is
+  already guaranteed to be evaluated by this same, uniquely Ra-elected
+  process (the property `RaCluster.stream_leader?/1` already gives, §4.1),
+  enforcing that is purely local, in-memory bookkeeping — two `:ets` tables
+  owned by this process (`@resource_locks_table` for the currently-in-flight
+  set, `@resource_monitors_table` to map a monitored Task's `reference()`
+  back to the resource it holds, for crash-safe release) — not a new
+  distributed primitive. Both tables die with this process, by design: on
+  crash or planned leadership handover, whatever they held stops mattering
+  (§4.4), and the newly-started/newly-leading process begins with an empty
+  set — the same at-least-once contract Job execution already has,
+  `resource_key` or not.
   """
 
   use Riptide.PeriodicSweep,
@@ -23,11 +39,24 @@ defmodule Riptide.Derivation.JobTrigger do
   @jobs_topic "riptide:jobs"
   @execution_supervisor __MODULE__.ExecutionSupervisor
 
+  # :public, not :protected — deliberately readable AND writable from
+  # outside this process. Every real write still only ever happens from
+  # within this process (run_exclusively/2 and the :DOWN handler below both
+  # execute here — see test_run_exclusively/2's own comment for how tests
+  # preserve that), so this doesn't weaken the actual guarantee; it only
+  # lets tests assert against table contents directly
+  # (`:ets.lookup(@resource_locks_table, ...)`) without a bespoke
+  # inspection API.
+  @resource_locks_table :job_trigger_resource_locks
+  @resource_monitors_table :job_trigger_resource_monitors
+
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
   @impl GenServer
   def init(:ok) do
+    :ets.new(@resource_locks_table, [:set, :public, :named_table])
+    :ets.new(@resource_monitors_table, [:set, :public, :named_table])
     Phoenix.PubSub.subscribe(Riptide.PubSub, @jobs_topic)
     schedule_sweep()
     {:ok, %{}}
@@ -41,11 +70,75 @@ defmodule Riptide.Derivation.JobTrigger do
     {:noreply, state}
   end
 
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    case :ets.lookup(@resource_monitors_table, ref) do
+      [{^ref, resource}] ->
+        :ets.delete(@resource_monitors_table, ref)
+        :ets.delete(@resource_locks_table, resource)
+
+      [] ->
+        :ok
+    end
+
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_call({:run_exclusively, resource, fun}, _from, state) do
+    {:reply, run_exclusively(resource, fun), state}
+  end
+
   @impl Riptide.PeriodicSweep
   def periodic_sweep do
     Placement.list_all()
     |> Enum.filter(fn {stream_id, _nodes} -> String.ends_with?(stream_id, "/jobs") end)
     |> Enum.each(fn {stream_id, _nodes} -> maybe_process_stream(stream_id) end)
+  end
+
+  # Test-only entry point. `run_exclusively/2` below calls `Process.monitor/1`
+  # against whatever process calls IT — correct in production, since
+  # try_spawn_execution/3 always calls it from within this GenServer's own
+  # process (handle_info and periodic_sweep both execute here already,
+  # unchanged from before this module gained resource-key exclusion). A
+  # test calling run_exclusively/2 directly would instead make the TEST
+  # process own the monitor, so the crash-safe cleanup in
+  # handle_info({:DOWN, ...}) above — which only ever runs inside THIS
+  # process — would never fire for it. Routing through a real (non-self)
+  # GenServer.call makes handle_call/3 above execute run_exclusively/2 from
+  # within this process instead, exactly like the production path. Can't
+  # make the production path itself go through GenServer.call: it's always
+  # invoked from within this same process already (see above), and a
+  # process calling GenServer.call on itself deadlocks.
+  @doc false
+  @spec test_run_exclusively({String.t(), String.t()} | nil, (-> term())) :: :ok | :skipped
+  def test_run_exclusively(resource, fun) do
+    GenServer.call(__MODULE__, {:run_exclusively, resource, fun})
+  end
+
+  # Runs `fun` under `@execution_supervisor`, exclusively for `resource` (a
+  # `{tenant_id, resource_key}` pair) if given — `nil` skips exclusion
+  # entirely (most Jobs don't declare a resource_key, design spec §4.3).
+  # `:ets.insert_new/2` is the whole reservation: an atomic "claim this key
+  # only if nobody already holds it," so there's no separate
+  # check-then-claim race. Returns `:skipped` (not an error) when the
+  # resource is already held — the caller is expected to just retry on its
+  # own next sweep, the same as any other transient condition already is.
+  @doc false
+  @spec run_exclusively({String.t(), String.t()} | nil, (-> term())) :: :ok | :skipped
+  def run_exclusively(nil, fun) do
+    Task.Supervisor.start_child(@execution_supervisor, fun)
+    :ok
+  end
+
+  def run_exclusively(resource, fun) do
+    if :ets.insert_new(@resource_locks_table, {resource}) do
+      {:ok, pid} = Task.Supervisor.start_child(@execution_supervisor, fun)
+      ref = Process.monitor(pid)
+      :ets.insert(@resource_monitors_table, {ref, resource})
+      :ok
+    else
+      :skipped
+    end
   end
 
   defp maybe_process_stream(stream_id) do
@@ -59,15 +152,19 @@ defmodule Riptide.Derivation.JobTrigger do
       {:ok, jobs} ->
         jobs
         |> Enum.filter(fn {_node, job} -> job.status == :pending end)
-        |> Enum.each(fn {node, job} -> spawn_execution(stream_id, node, job) end)
+        |> Enum.each(fn {node, job} -> try_spawn_execution(stream_id, node, job) end)
 
       {:error, :not_ready} ->
         :ok
     end
   end
 
-  defp spawn_execution(stream_id, node, job) do
-    Task.Supervisor.start_child(@execution_supervisor, fn -> execute(stream_id, node, job) end)
+  defp try_spawn_execution(stream_id, node, %Job{resource_key: nil} = job) do
+    run_exclusively(nil, fn -> execute(stream_id, node, job) end)
+  end
+
+  defp try_spawn_execution(stream_id, node, %Job{tenant_id: tenant_id, resource_key: key} = job) do
+    run_exclusively({tenant_id, key}, fn -> execute(stream_id, node, job) end)
   end
 
   defp execute(stream_id, node, %Job{reference: {:capability, iri}} = job) do

--- a/test/riptide/derivation/job_rdf_codec_test.exs
+++ b/test/riptide/derivation/job_rdf_codec_test.exs
@@ -62,4 +62,12 @@ defmodule Riptide.Derivation.JobRDFCodecTest do
 
     assert JobRDFCodec.from_rdf(node, graph) == job
   end
+
+  test "round-trips a Job with a resource_key set" do
+    job = sample_job(%{resource_key: "restart-payments-service"})
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
 end

--- a/test/riptide/derivation/job_trigger_cluster_test.exs
+++ b/test/riptide/derivation/job_trigger_cluster_test.exs
@@ -278,6 +278,110 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
            )
   end
 
+  # Proves the mechanism doesn't lose or deadlock a Job in a real
+  # multi-node run — deliberately does NOT also try to prove strict
+  # non-overlap end-to-end here (job_trigger_test.exs's own unit tests
+  # already prove that deterministically). Two real WASM invocations
+  # against the trivial fixture.wasm complete too fast to reliably observe
+  # an overlap window one way or the other in a cluster test, so trying to
+  # assert it here would be flaky, not more rigorous.
+  test "two Jobs for the same Tenant sharing a resource_key both eventually complete" do
+    peers = bootstrap_peers(@peers)
+    tenant_id = "job-trigger-resource-#{System.unique_integer([:positive])}"
+
+    stream_id =
+      :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :job_stream_id, [tenant_id])
+
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+    {:ok, hash} = :erpc.call(hd_node(peers), Riptide.BlobStore, :put, [component_bytes])
+
+    cap_name =
+      RDF.iri("urn:riptide:capability:job-trigger-resource-#{System.unique_integer([:positive])}")
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: cap_name,
+      kind: :effect,
+      component_hash: hash,
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    :ok = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :admit_capability, [entry])
+
+    local_name = cap_name |> RDF.IRI.to_string() |> String.trim_leading("urn:riptide:capability:")
+
+    :ok =
+      :erpc.call(hd_node(peers), Riptide.Placement, :add_policy, [
+        tenant_id,
+        ["capabilities", local_name],
+        %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      ])
+
+    resource_key = "shared-resource-#{System.unique_integer([:positive])}"
+
+    job = fn name ->
+      %Riptide.Derivation.Job{
+        tenant_id: tenant_id,
+        status: :pending,
+        reference: {:capability, cap_name},
+        args: [RDF.literal(name)],
+        job_graph: nil,
+        result: nil,
+        error: nil,
+        resource_key: resource_key
+      }
+    end
+
+    assert {:ok, node1} =
+             :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :write_job, [
+               tenant_id,
+               job.("Alice")
+             ])
+
+    assert {:ok, node2} =
+             :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :write_job, [
+               tenant_id,
+               job.("Bob")
+             ])
+
+    # Whichever of the two Jobs loses the resource_key race on its own
+    # {:job_written, stream_id} broadcast gets skipped that round and only
+    # retried on the next periodic_sweep — 30s in this test env too, since
+    # :job_trigger_sweep_interval_ms has no test-config override. 250 * 200ms
+    # = 50s gives that a real margin, not just this test's default 20s.
+    assert eventually(
+             fn ->
+               case :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :list_jobs, [
+                      stream_id
+                    ]) do
+                 {:ok, jobs} ->
+                   Enum.all?([node1, node2], fn n ->
+                     match?({_n, %{status: :done}}, Enum.find(jobs, fn {jn, _} -> jn == n end))
+                   end)
+
+                 _ ->
+                   false
+               end
+             end,
+             250
+           )
+
+    {:ok, jobs} = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :list_jobs, [stream_id])
+    {_n1, final1} = Enum.find(jobs, fn {n, _} -> n == node1 end)
+    {_n2, final2} = Enum.find(jobs, fn {n, _} -> n == node2 end)
+    assert final1.status == :done
+    assert final2.status == :done
+    assert final1.result == RDF.literal("\"Hello, Alice!\"")
+    assert final2.result == RDF.literal("\"Hello, Bob!\"")
+  end
+
   defp hd_node([{_pid, node, _ordinal} | _]), do: node
 
   defp bootstrap_peers(specs) do

--- a/test/riptide/derivation/job_trigger_test.exs
+++ b/test/riptide/derivation/job_trigger_test.exs
@@ -1,0 +1,90 @@
+defmodule Riptide.Derivation.JobTriggerTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Derivation.JobTrigger
+
+  @resource_locks_table :job_trigger_resource_locks
+  @resource_monitors_table :job_trigger_resource_monitors
+
+  setup do
+    on_exit(fn ->
+      :ets.delete_all_objects(@resource_locks_table)
+      :ets.delete_all_objects(@resource_monitors_table)
+    end)
+
+    :ok
+  end
+
+  describe "run_exclusively/2 (via test_run_exclusively/2, see its own moduledoc)" do
+    test "with resource_key nil, always runs the function, no reservation made" do
+      test_pid = self()
+
+      assert :ok = JobTrigger.test_run_exclusively(nil, fn -> send(test_pid, :ran) end)
+      assert_receive :ran, 1_000
+    end
+
+    test "reserves the resource before returning, so a concurrent second call with the same key is skipped" do
+      resource = {"acme", "run-exclusively-test-#{System.unique_integer([:positive])}"}
+      test_pid = self()
+
+      # The first task must stay in flight long enough for this test's own
+      # follow-up checks to run — run_exclusively/2's reservation is
+      # guaranteed present by the time the call returns (it's made
+      # synchronously inside handle_call, before the Task is even spawned),
+      # but nothing keeps it present afterward if the task's own function
+      # completes (and gets monitored-cleaned-up) near-instantly, which a
+      # bare `send/2` would. 300ms is a generous margin against the
+      # microsecond-scale local ETS operations this test performs while
+      # waiting, not a tight race.
+      assert :ok =
+               JobTrigger.test_run_exclusively(resource, fn ->
+                 send(test_pid, :first_started)
+                 Process.sleep(300)
+                 send(test_pid, :first_done)
+               end)
+
+      assert_receive :first_started, 1_000
+      assert :ets.lookup(@resource_locks_table, resource) != []
+
+      assert :skipped =
+               JobTrigger.test_run_exclusively(resource, fn -> send(test_pid, :second_ran) end)
+
+      refute_receive :second_ran, 500
+      assert_receive :first_done, 1_000
+    end
+
+    test "releases the resource once the function completes normally, allowing a later call to run" do
+      resource = {"acme", "run-exclusively-release-#{System.unique_integer([:positive])}"}
+      test_pid = self()
+
+      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> send(test_pid, :done) end)
+      assert_receive :done, 1_000
+
+      assert eventually(fn -> :ets.lookup(@resource_locks_table, resource) == [] end)
+
+      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> send(test_pid, :ran_again) end)
+      assert_receive :ran_again, 1_000
+    end
+
+    test "releases the resource even if the function crashes abnormally, not just on a normal return" do
+      resource = {"acme", "run-exclusively-crash-#{System.unique_integer([:positive])}"}
+
+      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> raise "boom" end)
+      assert :ets.lookup(@resource_locks_table, resource) != []
+
+      assert eventually(fn -> :ets.lookup(@resource_locks_table, resource) == [] end)
+
+      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> :ok end)
+    end
+  end
+
+  # 50 * 200ms = 10s, matching this suite's own established eventually/2
+  # convention (see e.g. blob_store_cluster_test.exs).
+  defp eventually(fun, attempts_left \\ 50) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements 6d-ii — a hard guarantee that two Jobs for the same Tenant declaring the same `resource_key` never execute concurrently.
- No new Ra cluster, lock, lease, or fencing token: 6l already guarantees exactly one node executes a Tenant's Jobs at a time (its own Job-stream Ra leader); resource-key exclusion is purely local `:ets` state on that same `JobTrigger` process, released via `Process.monitor/1` on the dispatched Task's exit — normal or crashed.
- `Job.resource_key` is optional (`nil` by default) and Tenant-scoped (`{tenant_id, resource_key}`), matching the design spec's caller-supplied-identity conclusion from its own research pass (research log Part 4).
- `GeneralizationFidelity`'s replay path is explicitly NOT covered by this PR (design spec §5, this plan's Global Constraints) — it needs cross-node leader-routing, meaningfully different machinery, left as a tracked follow-up rather than bolted on here.

Spec: `docs/superpowers/specs/2026-09-01-phase-6d-ii-concurrent-effects-design.md` (PR #120).

## Test plan
- [x] `mix test` — full suite green (541 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR