### PR TITLE
Draft: Resolve: "6m — Tenant-Scoped Execution Surface"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1258,3 +1258,89 @@ local `:ets` state — left as a tracked follow-up rather than bolted onto this 
 **Status**: Phase 6d-ii shipped 2026-09-01. 4 phases remaining — see issue #58's own restated summary
 for the current list (6g-ii deferred with no exit criterion yet; 6c-iii-a/6c-iii-b, Track B, ready to
 start; Capability grant flow/OAuth, Track A, ready to start).
+
+### 6m — Tenant-Scoped Execution Surface
+
+**Shipped 2026-09-01** — see
+`docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md`. Direct origin:
+resuming the "tutorial of a computer game" demo idea from earlier brainstorming surfaced a third,
+previously-untracked prerequisite — every piece needed to *run* that demo already existed (Discovery,
+LLMFallback, DedupGate propose/review, Job execution) but only as a Hub-scoped or programmatic API,
+with no Tenant-scoped HTTP surface tying them into one coherent "submit a Task in plain English" flow.
+6m builds that surface; the demo itself is deferred to 6n.
+
+**Core architectural finding**: Riptide has exactly ONE stream storage mechanism — every
+`Riptide.Derivation.Catalog` write and `RiptideWeb.LDP.ResourceController`'s own writes call identical
+primitives (`Riptide.Event.new/3` + `Riptide.Stream.StreamServer.append/2`). "Job stream" and "Catalog
+stream" were never structurally different from an LDP resource — just addressed outside
+`/resources/*path`, which is why they had no read/watch story of their own. Moving
+`Catalog.job_stream_id/1` and `Catalog.catalog_stream_id({:tenant, _})` (Hub's own `/hub/*` addressing
+left untouched) under `/resources/*path` makes `GET /tenants/:id/resources/jobs` and SSE subscription
+work for free through the already-existing generic machinery — eliminating what would otherwise have
+been 2-3 new bespoke read/watch mechanisms. The one cost: a small write-guard on `ResourceController`
+(`replace/2`/`patch/2`/`delete/2`/`create_child/2`) rejecting generic writes to the now-reserved
+`jobs`/`catalog` path prefixes with `409`, since those paths' shape is owned by `Catalog`, not
+arbitrary LDP callers.
+
+`Job` gained three more optional fields (nil by default, same opt-in precedent as 6d-ii's
+`resource_key`): `resolved_via` (`:discovery | :llm_fallback`), `original_description` (the Task's own
+plain-English text), and `trace` (the full ground Rule an LLMFallback resolution produced — reified via
+the same `RuleRDFCodec` reification 6c-i-a already established, not a plain literal, since Tenant
+propose (below) needs to read a real `Rule.t()` back out).
+
+New surface, all under `/tenants/:tenant_id`:
+- `POST /tasks` — Discovery-first, LLMFallback-fallback. A Discovery match writes a `{:rule, iri}` Job
+  with `args: []` and a per-submission `job_graph` stream seeded from the Task's own submitted facts,
+  reusing 6l's already-proven jobRule execution path verbatim. An LLMFallback resolution writes a
+  `{:capability, iri}` Job instead, using the resolved trace's own already-ground `CapabilityReference`
+  args directly — these are two genuinely different reference/args shapes, not one shared helper, since
+  a Discovery-matched CatalogEntry may carry free generalization variables while an LLMFallback trace is
+  always fully ground before it's ever returned.
+- `POST /propose` — takes two Job node references and reads each Job's own recorded `trace` back (not
+  raw Turtle text), then anti-unifies and runs the same `DedupGate.propose/5` orchestration Hub's own
+  propose endpoint uses, `target_scope`/`review_scope` both `{:tenant, tenant_id}`.
+- `POST /pending-reviews/:node_id/{approve,decline}`, `GET /discovery/search` — direct Tenant-scoped
+  analogues of the existing Hub controllers.
+
+Capstone test proves the full exit criterion end-to-end over real HTTP: two Tasks with no matching
+CatalogEntry resolve via LLMFallback; their Jobs' own recorded Traces get proposed against each other
+and queued for review; approving admits the generalization into the Tenant's own Catalog; a third,
+similar Task now resolves via Discovery with zero further LLMFallback calls.
+
+**Three real, previously-latent bugs found and fixed during implementation** (each caught by a test
+actually exercising a code path for the first time, not by inspection):
+1. `DedupGate.PendingReview.decode_evidence/2` crashed on an empty (non-`:not_applicable`)
+   `fidelity_evidence` list — `RDF.List.from([])` encodes to `rdf:nil`, which (unlike every other
+   evidence-head shape this function handles) has no triples of its own describing it, so
+   `RDF.Graph.get/2` returned `nil` and the unconditional `RDF.Description.first(nil, ...)` crashed.
+   Never exercised before the Tenant review test — every prior `PendingReview` fixture in the test
+   suite used a non-empty evidence list.
+2. `GeneralizationFidelity.check_body/3`'s `CapabilityReference` fidelity re-verification compared a
+   fresh `Capability.invoke/4` call's raw Elixir string return directly against a trace's recorded
+   `result` — which is only a raw string *before* the trace ever touches RDF storage. Once a Job's
+   trace round-trips through `RuleRDFCodec` (as every Tenant-propose call does, by design), RDF triples
+   can't hold a bare Elixir binary as an object, so the graph coerces it into a proper `RDF.Literal` —
+   permanently breaking the direct comparison for any trace read back from storage. Fixed by
+   normalizing both sides through the module's own existing `term_to_arg/1` unwrapping helper before
+   comparing, rather than changing `ExecuteInterpreter`'s core binding representation (much wider blast
+   radius across 6b-i/6c-i-b/6f, all already-shipped).
+3. `ExecuteInterpreter` could crash a supervised `JobTrigger` Task with an uncaught `KeyError`: a Var
+   referenced only inside a `CapabilityReference`/`RuleReference`'s own args, with no preceding
+   `FactPattern` binding it, can never receive a value — `Matcher.bindings/3` only ever binds Vars that
+   appear in a `FactPattern`'s own args — yet nothing validated this before executing. Confirmed live:
+   a `DedupGate`-generalized Rule whose only free variable lives inside a `CapabilityReference`'s args
+   (rather than a `FactPattern`) crashed exactly this way when `JobTrigger` picked it up. Fixed with a
+   `check_vars_bound/2` pre-execution pass mirroring `check_resolvable/2`'s existing
+   halt-on-first-problem convention, turning the crash into a clean `{:error, {:unbound_variable, _}}`
+   that `JobTrigger`'s own existing `mark_job_failed` catch-all already handles gracefully.
+
+**Explicitly not covered by this phase**, stated plainly: bug 3 above only stops the crash — it does
+not give a Discovery-matched entry whose free variables live solely inside a `CapabilityReference` any
+way to actually *execute* (such a Job now fails cleanly with `{:unbound_variable, _}` instead of
+crashing a process, but still fails). Making that shape executable needs a real design decision about
+how a Task's own submitted facts should map onto a generalized entry's free Capability-argument
+positions — genuinely new scope, not a mechanical fix, and left as a tracked gap rather than
+freelanced here. Also out of scope per the design spec §8: the demo itself (6n), Hub's own equivalent
+surface, and background (non-Task-triggered) anti-unification discovery.
+
+**Status**: Phase 6m shipped 2026-09-01.

--- a/lib/riptide/derivation/capability_catalog.ex
+++ b/lib/riptide/derivation/capability_catalog.ex
@@ -59,7 +59,7 @@ defmodule Riptide.Derivation.CapabilityCatalog do
   end
 
   defp fetch_and_cache(hash) do
-    with {:ok, bytes} <- BlobStore.get(hash) do
+    with {:ok, bytes} <- safe_get(hash) do
       path = cache_path_for(hash)
 
       with :ok <- File.mkdir_p(Path.dirname(path)),
@@ -67,6 +67,25 @@ defmodule Riptide.Derivation.CapabilityCatalog do
         {:ok, path}
       end
     end
+  end
+
+  # `BlobStore.get/1`'s `GenServer.call` uses the default 5000ms timeout,
+  # but the single `BlobStore` process it calls into can itself block far
+  # longer internally (up to 30s per remote node it tries, sequentially,
+  # once a blob isn't found locally — see `BlobStore.fetch_remote/1`) —
+  # e.g. when a `LocationIndex` entry still points at a node that's since
+  # torn down (a `:peer`-based test cluster that already stopped). A
+  # caller-side timeout there raises/exits the CALLING process, not
+  # `BlobStore`'s own — but `materialize/1`'s own contract promises
+  # `{:error, term()}` for every failure, never a raise. Confirmed live: a
+  # stale `LocationIndex` entry from an earlier test made
+  # `ContextResolver.resolve_all/2` (which materializes every Hub
+  # capability, not just one) time out and 500 an entirely unrelated
+  # Tenant's request.
+  defp safe_get(hash) do
+    BlobStore.get(hash)
+  catch
+    :exit, _ -> {:error, :blob_unavailable}
   end
 
   defp cache_path_for(hash) do

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -53,8 +53,11 @@ defmodule Riptide.Derivation.Catalog do
 
   @spec catalog_stream_id(scope()) :: String.t()
   def catalog_stream_id({:tenant, tenant_id}),
-    do: @stream_id_prefix <> "tenants/" <> tenant_id <> "/catalog"
+    do: @stream_id_prefix <> "tenants/" <> tenant_id <> "/resources/catalog"
 
+  # Unchanged — Hub already has its own working, separate /hub/* HTTP surface
+  # and addressing model (design spec §3); this phase touches only the
+  # Tenant-scoped side.
   def catalog_stream_id(:hub), do: @stream_id_prefix <> "hub/catalog"
 
   @spec pending_review_stream_id(scope()) :: String.t()
@@ -190,7 +193,8 @@ defmodule Riptide.Derivation.Catalog do
   end
 
   @spec job_stream_id(String.t()) :: String.t()
-  def job_stream_id(tenant_id), do: @stream_id_prefix <> "tenants/" <> tenant_id <> "/jobs"
+  def job_stream_id(tenant_id),
+    do: @stream_id_prefix <> "tenants/" <> tenant_id <> "/resources/jobs"
 
   @spec write_job(String.t(), Job.t()) :: {:ok, RDF.BlankNode.t()} | {:error, :not_ready}
   def write_job(tenant_id, %Job{} = job) do

--- a/lib/riptide/derivation/context_resolver.ex
+++ b/lib/riptide/derivation/context_resolver.ex
@@ -26,6 +26,57 @@ defmodule Riptide.Derivation.ContextResolver do
     end
   end
 
+  @doc """
+  Builds a Context populated with EVERY Hub Capability and every Rule visible to `tenant_id`
+  (Tenant-scope entries, then Hub-scope, matching `resolve/3`'s own Tenant-before-Hub precedent) —
+  unlike `resolve/3`, which transitively walks from one known starting Rule, this enumerates
+  everything available up front, for a caller (Task submission, 6m) that doesn't yet know what it
+  needs resolved. A Capability that fails to materialize (e.g. its blob is unreachable) is skipped,
+  not fatal — LLMFallback simply won't be told about it, the same degraded-but-available behavior
+  as if it had never been registered, rather than failing every Task submission because one
+  unrelated Capability is temporarily broken.
+  """
+  @spec resolve_all(String.t(), map() | nil) :: {:ok, Context.t()}
+  def resolve_all(tenant_id, current_subject) do
+    {:ok,
+     %Context{
+       capabilities: all_capabilities(),
+       rules: all_rules(tenant_id),
+       tenant_id: tenant_id,
+       current_subject: current_subject
+     }}
+  end
+
+  defp all_capabilities do
+    case Catalog.list_capabilities() do
+      {:ok, entries} -> Enum.reduce(entries, %{}, &materialize_into/2)
+      {:error, :not_ready} -> %{}
+    end
+  end
+
+  defp materialize_into({_node, entry}, acc) do
+    case CapabilityCatalog.materialize(entry) do
+      {:ok, definition} -> Map.put(acc, entry.name, definition)
+      {:error, _reason} -> acc
+    end
+  end
+
+  defp all_rules(tenant_id) do
+    tenant_rules = rules_by_signature_name({:tenant, tenant_id})
+    hub_rules = rules_by_signature_name(:hub)
+    Map.merge(hub_rules, tenant_rules)
+  end
+
+  defp rules_by_signature_name(scope) do
+    case Catalog.list_entries(scope) do
+      {:ok, entries} ->
+        Map.new(entries, fn {_node, rule} -> {rule.signature.name, rule} end)
+
+      {:error, :not_ready} ->
+        %{}
+    end
+  end
+
   defp walk_rule(tenant_id, iri, visited, capabilities, rules) do
     cond do
       # `rules` is added to on the way DOWN (before walking a Rule's own

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -119,17 +119,26 @@ defmodule Riptide.Derivation.DedupGate.PendingReview do
     }
   end
 
+  # An empty (non-:not_applicable) fidelity_evidence list encodes via
+  # RDF.List.from([]) to rdf:nil, the well-known empty-list sentinel — it
+  # has no triples of its own describing it (RDF.Graph.get/2 returns nil),
+  # unlike every other evidence_head this function handles. Must be checked
+  # before RDF.Description.first/2, which crashes on a nil description.
   defp decode_evidence(node, graph) do
-    description = RDF.Graph.get(graph, node)
+    case RDF.Graph.get(graph, node) do
+      nil ->
+        []
 
-    case RDF.Description.first(description, @rdf_type) do
-      @riptide_fidelity_not_applicable ->
-        :not_applicable
+      description ->
+        case RDF.Description.first(description, @rdf_type) do
+          @riptide_fidelity_not_applicable ->
+            :not_applicable
 
-      _other ->
-        RDF.List.new(node, graph)
-        |> RDF.List.values()
-        |> Enum.map(&decode_one_evidence(&1, graph))
+          _other ->
+            RDF.List.new(node, graph)
+            |> RDF.List.values()
+            |> Enum.map(&decode_one_evidence(&1, graph))
+        end
     end
   end
 

--- a/lib/riptide/derivation/execute_interpreter.ex
+++ b/lib/riptide/derivation/execute_interpreter.ex
@@ -47,7 +47,10 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
   """
   @spec call_template(Rule.t(), RDF.Graph.t(), Context.t()) ::
           {:ok, [RDF.Triple.t()]}
-          | {:error, {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+          | {:error,
+             {:unresolvable, RDF.IRI.t()}
+             | {:unsupported_arity, RDF.IRI.t()}
+             | {:unbound_variable, Var.t()}}
   def call_template(%Rule{} = rule, %RDF.Graph{} = graph, %Context{} = context) do
     call_template(rule, %{}, graph, context)
   end
@@ -63,9 +66,13 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
   """
   @spec call_template(Rule.t(), %{Var.t() => RDF.Term.t()}, RDF.Graph.t(), Context.t()) ::
           {:ok, [RDF.Triple.t()]}
-          | {:error, {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+          | {:error,
+             {:unresolvable, RDF.IRI.t()}
+             | {:unsupported_arity, RDF.IRI.t()}
+             | {:unbound_variable, Var.t()}}
   def call_template(%Rule{} = rule, seed, %RDF.Graph{} = graph, %Context{} = context) do
-    with :ok <- check_resolvable(rule.body, context) do
+    with :ok <- check_resolvable(rule.body, context),
+         :ok <- check_vars_bound(rule.body, seed |> Map.keys() |> MapSet.new()) do
       bindings_list = execute_body(rule.body, seed, graph, context)
       {:ok, Enum.map(bindings_list, &conclude(rule.head, &1))}
     end
@@ -83,9 +90,13 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
   """
   @spec resolve_bindings(Rule.t(), RDF.Graph.t(), Context.t()) ::
           {:ok, [%{Var.t() => RDF.Term.t()}]}
-          | {:error, {:unresolvable, RDF.IRI.t()} | {:unsupported_arity, RDF.IRI.t()}}
+          | {:error,
+             {:unresolvable, RDF.IRI.t()}
+             | {:unsupported_arity, RDF.IRI.t()}
+             | {:unbound_variable, Var.t()}}
   def resolve_bindings(%Rule{} = rule, %RDF.Graph{} = graph, %Context{} = context) do
-    with :ok <- check_resolvable(rule.body, context) do
+    with :ok <- check_resolvable(rule.body, context),
+         :ok <- check_vars_bound(rule.body, MapSet.new()) do
       {:ok, execute_body(rule.body, %{}, graph, context)}
     end
   end
@@ -96,6 +107,60 @@ defmodule Riptide.Derivation.ExecuteInterpreter do
         :ok -> {:cont, :ok}
         error -> {:halt, error}
       end
+    end)
+  end
+
+  # `execute_body/4` matches FactPattern runs positionally against the
+  # graph, binding every Var among their own args along the way — a Var
+  # referenced only inside a CapabilityReference/RuleReference's own args,
+  # with no preceding FactPattern binding it, can never receive a value:
+  # `Matcher.bindings/3` only ever binds Vars that appear in a FactPattern's
+  # own args, so nothing in this body would ever populate it. Left
+  # unchecked, this crashes deep inside `substitute/2`'s `Map.fetch!/2`
+  # (confirmed live: JobTrigger picking up a DedupGate-generalized Rule
+  # whose only free variable lives inside a CapabilityReference's own args
+  # crashed a supervised Task with an uncaught KeyError). Checking up front
+  # turns that into a clean `{:error, _}` instead, matching how
+  # `check_resolvable/2` already handles the sibling
+  # unresolvable-IRI/unsupported-arity cases.
+  @spec check_vars_bound(
+          [FactPattern.t() | CapabilityReference.t() | RuleReference.t()],
+          MapSet.t(Var.t())
+        ) :: :ok | {:error, {:unbound_variable, Var.t()}}
+  defp check_vars_bound([], _known), do: :ok
+
+  defp check_vars_bound([%FactPattern{args: args} | rest], known) do
+    check_vars_bound(rest, add_known_vars(known, args))
+  end
+
+  defp check_vars_bound([%CapabilityReference{args: args, result: result} | rest], known) do
+    with :ok <- check_terms_bound(args, known) do
+      check_vars_bound(rest, add_known_vars(known, [result]))
+    end
+  end
+
+  defp check_vars_bound([%RuleReference{args: args, result: result} | rest], known) do
+    with :ok <- check_terms_bound(args, known) do
+      check_vars_bound(rest, add_known_vars(known, [result]))
+    end
+  end
+
+  defp check_terms_bound(terms, known) do
+    Enum.reduce_while(terms, :ok, fn
+      %Var{} = var, :ok ->
+        if MapSet.member?(known, var),
+          do: {:cont, :ok},
+          else: {:halt, {:error, {:unbound_variable, var}}}
+
+      _term, :ok ->
+        {:cont, :ok}
+    end)
+  end
+
+  defp add_known_vars(known, terms) do
+    Enum.reduce(terms, known, fn
+      %Var{} = var, acc -> MapSet.put(acc, var)
+      _term, acc -> acc
     end)
   end
 

--- a/lib/riptide/derivation/generalization_fidelity.ex
+++ b/lib/riptide/derivation/generalization_fidelity.ex
@@ -79,23 +79,7 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
         check_body(rest, graph, context)
 
       {:ok, %Definition{kind: :effect} = definition} ->
-        resolved_args = Enum.map(args, &term_to_arg/1)
-
-        case Capability.invoke(
-               definition,
-               context.tenant_id,
-               context.current_subject,
-               resolved_args
-             ) do
-          {:ok, ^result} ->
-            check_body(rest, graph, context)
-
-          {:ok, actual} ->
-            {:ok, {:fidelity_fail, {:capability_mismatch, iri, result, actual}}}
-
-          {:error, reason} ->
-            {:ok, {:fidelity_fail, {:capability_error, iri, reason}}}
-        end
+        check_effect_invocation(definition, iri, args, result, rest, graph, context)
 
       :error ->
         {:error, {:unresolvable, iri}}
@@ -118,6 +102,35 @@ defmodule Riptide.Derivation.GeneralizationFidelity do
           {:ok, {:fidelity_fail, reason}} -> {:ok, {:fidelity_fail, {:nested, iri, reason}}}
           {:error, reason} -> {:error, reason}
         end
+    end
+  end
+
+  defp check_effect_invocation(definition, iri, args, result, rest, graph, context) do
+    resolved_args = Enum.map(args, &term_to_arg/1)
+
+    case Capability.invoke(
+           definition,
+           context.tenant_id,
+           context.current_subject,
+           resolved_args
+         ) do
+      {:ok, actual} ->
+        # `Capability.invoke/4` always returns a raw Elixir string, never an
+        # RDF term. A ground `result` reconstructed via `RuleRDFCodec` (e.g.
+        # read back from a stored Job's trace) is a proper `RDF.Literal` —
+        # RDF triples can't hold a bare Elixir binary as an object, so the
+        # graph round-trip coerces it — while a `result` compared before
+        # ever touching RDF storage may still be the original raw string.
+        # `term_to_arg/1` normalizes either shape down to the same plain
+        # string for comparison.
+        if term_to_arg(result) == actual do
+          check_body(rest, graph, context)
+        else
+          {:ok, {:fidelity_fail, {:capability_mismatch, iri, result, actual}}}
+        end
+
+      {:error, reason} ->
+        {:ok, {:fidelity_fail, {:capability_error, iri, reason}}}
     end
   end
 

--- a/lib/riptide/derivation/job.ex
+++ b/lib/riptide/derivation/job.ex
@@ -11,12 +11,36 @@ defmodule Riptide.Derivation.Job do
   §4.3) to mark that it must never execute concurrently with another Job
   for the same Tenant declaring the same key. `nil` (the default) means
   this Job isn't subject to that coordination at all.
+
+  A Job written by the Tenant-scoped Task-submission endpoint (see design spec
+  `docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md`
+  §4.3-4.4) additionally carries `resolved_via` (how it was resolved),
+  `original_description` (the plain-English Task text), and — only when
+  `resolved_via: :llm_fallback` — `trace` (the full ground Rule LLMFallback
+  produced, needed by the Tenant-scoped propose endpoint to anti-unify
+  against another Job's own trace). All three `nil` for a Job written
+  directly, as every pre-6m Job already is.
   """
 
+  alias Riptide.Derivation.Rule
+
   @enforce_keys [:tenant_id, :status, :reference, :args]
-  defstruct [:tenant_id, :status, :reference, :args, :job_graph, :result, :error, :resource_key]
+  defstruct [
+    :tenant_id,
+    :status,
+    :reference,
+    :args,
+    :job_graph,
+    :result,
+    :error,
+    :resource_key,
+    :resolved_via,
+    :original_description,
+    :trace
+  ]
 
   @type reference_t :: {:capability, RDF.IRI.t()} | {:rule, RDF.IRI.t()}
+  @type resolved_via :: :discovery | :llm_fallback
 
   @type t :: %__MODULE__{
           tenant_id: String.t(),
@@ -26,6 +50,9 @@ defmodule Riptide.Derivation.Job do
           job_graph: String.t() | nil,
           result: RDF.Term.t() | nil,
           error: String.t() | nil,
-          resource_key: String.t() | nil
+          resource_key: String.t() | nil,
+          resolved_via: resolved_via() | nil,
+          original_description: String.t() | nil,
+          trace: Rule.t() | nil
         }
 end

--- a/lib/riptide/derivation/job_rdf_codec.ex
+++ b/lib/riptide/derivation/job_rdf_codec.ex
@@ -6,7 +6,7 @@ defmodule Riptide.Derivation.JobRDFCodec do
   a Job has no nested `body` literal list the way a Rule does.
   """
 
-  alias Riptide.Derivation.Job
+  alias Riptide.Derivation.{Job, Rule, RuleRDFCodec}
 
   @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
   @riptide_job RDF.iri("urn:riptide:vocab:Job")
@@ -19,6 +19,9 @@ defmodule Riptide.Derivation.JobRDFCodec do
   @riptide_job_result RDF.iri("urn:riptide:vocab:jobResult")
   @riptide_job_error RDF.iri("urn:riptide:vocab:jobError")
   @riptide_job_resource_key RDF.iri("urn:riptide:vocab:jobResourceKey")
+  @riptide_job_resolved_via RDF.iri("urn:riptide:vocab:jobResolvedVia")
+  @riptide_job_original_description RDF.iri("urn:riptide:vocab:jobOriginalDescription")
+  @riptide_job_trace RDF.iri("urn:riptide:vocab:jobTrace")
 
   @spec to_rdf(Job.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
   def to_rdf(%Job{} = job) do
@@ -41,8 +44,29 @@ defmodule Riptide.Derivation.JobRDFCodec do
         @riptide_job_resource_key,
         job.resource_key && RDF.literal(job.resource_key)
       )
+      |> maybe_add(
+        node,
+        @riptide_job_resolved_via,
+        job.resolved_via && RDF.literal(encode_resolved_via(job.resolved_via))
+      )
+      |> maybe_add(
+        node,
+        @riptide_job_original_description,
+        job.original_description && RDF.literal(job.original_description)
+      )
+      |> maybe_add_trace(node, job.trace)
 
     {node, graph}
+  end
+
+  defp maybe_add_trace(graph, _node, nil), do: graph
+
+  defp maybe_add_trace(graph, node, %Rule{} = trace) do
+    {trace_node, trace_graph} = RuleRDFCodec.to_rdf(trace)
+
+    graph
+    |> RDF.Graph.add(trace_graph)
+    |> RDF.Graph.add({node, @riptide_job_trace, trace_node})
   end
 
   defp add_reference(graph, node, {:capability, iri}),
@@ -67,6 +91,12 @@ defmodule Riptide.Derivation.JobRDFCodec do
   defp decode_status("done"), do: :done
   defp decode_status("failed"), do: :failed
 
+  defp encode_resolved_via(:discovery), do: "discovery"
+  defp encode_resolved_via(:llm_fallback), do: "llm_fallback"
+
+  defp decode_resolved_via("discovery"), do: :discovery
+  defp decode_resolved_via("llm_fallback"), do: :llm_fallback
+
   @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: Job.t()
   def from_rdf(node, graph) do
     description = RDF.Graph.get(graph, node)
@@ -84,8 +114,26 @@ defmodule Riptide.Derivation.JobRDFCodec do
       job_graph: decode_optional_string(description, @riptide_job_graph),
       result: RDF.Description.first(description, @riptide_job_result),
       error: decode_optional_string(description, @riptide_job_error),
-      resource_key: decode_optional_string(description, @riptide_job_resource_key)
+      resource_key: decode_optional_string(description, @riptide_job_resource_key),
+      resolved_via: decode_resolved_via_optional(description),
+      original_description:
+        decode_optional_string(description, @riptide_job_original_description),
+      trace: decode_trace(description, graph)
     }
+  end
+
+  defp decode_resolved_via_optional(description) do
+    case RDF.Description.first(description, @riptide_job_resolved_via) do
+      nil -> nil
+      literal -> literal |> RDF.Literal.value() |> decode_resolved_via()
+    end
+  end
+
+  defp decode_trace(description, graph) do
+    case RDF.Description.first(description, @riptide_job_trace) do
+      nil -> nil
+      trace_node -> RuleRDFCodec.from_rdf(trace_node, graph)
+    end
   end
 
   defp decode_reference(description) do

--- a/lib/riptide_web/ldp/resource_controller.ex
+++ b/lib/riptide_web/ldp/resource_controller.ex
@@ -19,6 +19,24 @@ defmodule RiptideWeb.LDP.ResourceController do
 
   @ldp_contains RDF.iri("http://www.w3.org/ns/ldp#contains")
 
+  @reserved_path_prefixes [["jobs"], ["catalog"]]
+
+  @spec reserved_path?([String.t()]) :: boolean()
+  defp reserved_path?(path_segments) do
+    Enum.any?(@reserved_path_prefixes, &List.starts_with?(path_segments, &1))
+  end
+
+  defp reject_reserved_path(conn) do
+    body =
+      Jason.encode!(%{
+        "error" => "reserved_path",
+        "message" =>
+          "this path is reserved for Riptide's own internal data; write it via its dedicated endpoint instead"
+      })
+
+    conn |> put_resp_content_type("application/json") |> send_resp(409, body)
+  end
+
   def show(conn, %{"path" => path_segments}) do
     stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
 
@@ -35,7 +53,15 @@ defmodule RiptideWeb.LDP.ResourceController do
     end
   end
 
-  def replace(conn, %{"path" => path_segments}) do
+  def replace(conn, %{"path" => path_segments} = params) do
+    if reserved_path?(path_segments) do
+      reject_reserved_path(conn)
+    else
+      do_replace(conn, params)
+    end
+  end
+
+  defp do_replace(conn, %{"path" => path_segments}) do
     stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
     {:ok, body, conn} = Plug.Conn.read_body(conn)
 
@@ -57,7 +83,15 @@ defmodule RiptideWeb.LDP.ResourceController do
     end
   end
 
-  def delete(conn, %{"path" => path_segments}) do
+  def delete(conn, %{"path" => path_segments} = params) do
+    if reserved_path?(path_segments) do
+      reject_reserved_path(conn)
+    else
+      do_delete(conn, params)
+    end
+  end
+
+  defp do_delete(conn, %{"path" => path_segments}) do
     stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
 
     case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
@@ -71,6 +105,14 @@ defmodule RiptideWeb.LDP.ResourceController do
   end
 
   def patch(conn, %{"path" => path_segments} = params) do
+    if reserved_path?(path_segments) do
+      reject_reserved_path(conn)
+    else
+      do_patch(conn, params)
+    end
+  end
+
+  defp do_patch(conn, %{"path" => path_segments} = params) do
     stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
 
     # NOTE: the endpoint's `Plug.Parsers` (see Task 6's scaffold) already
@@ -105,7 +147,15 @@ defmodule RiptideWeb.LDP.ResourceController do
     end
   end
 
-  def create_child(conn, %{"path" => path_segments}) do
+  def create_child(conn, %{"path" => path_segments} = params) do
+    if reserved_path?(path_segments) do
+      reject_reserved_path(conn)
+    else
+      do_create_child(conn, params)
+    end
+  end
+
+  defp do_create_child(conn, %{"path" => path_segments}) do
     tenant_id = conn.assigns.tenant_id
     container_stream_id = stream_id_for(tenant_id, path_segments)
     {:ok, body, conn} = Plug.Conn.read_body(conn)

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -56,6 +56,8 @@ defmodule RiptideWeb.Router do
     post "/policies", RiptideWeb.Authz.PolicyController, :create
     get "/policies", RiptideWeb.Authz.PolicyController, :index
 
+    post "/tasks", RiptideWeb.TaskController, :create
+
     post "/hub/propose", RiptideWeb.Hub.ProposeController, :propose
     post "/hub/pending-reviews/:node_id/approve", RiptideWeb.Hub.ReviewController, :approve
     post "/hub/pending-reviews/:node_id/decline", RiptideWeb.Hub.ReviewController, :decline

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -58,6 +58,11 @@ defmodule RiptideWeb.Router do
 
     post "/tasks", RiptideWeb.TaskController, :create
 
+    post "/propose", RiptideWeb.TenantProposeController, :propose
+    post "/pending-reviews/:node_id/approve", RiptideWeb.TenantReviewController, :approve
+    post "/pending-reviews/:node_id/decline", RiptideWeb.TenantReviewController, :decline
+    get "/discovery/search", RiptideWeb.TenantDiscoveryController, :search
+
     post "/hub/propose", RiptideWeb.Hub.ProposeController, :propose
     post "/hub/pending-reviews/:node_id/approve", RiptideWeb.Hub.ReviewController, :approve
     post "/hub/pending-reviews/:node_id/decline", RiptideWeb.Hub.ReviewController, :decline

--- a/lib/riptide_web/task_controller.ex
+++ b/lib/riptide_web/task_controller.ex
@@ -1,0 +1,143 @@
+defmodule RiptideWeb.TaskController do
+  @moduledoc """
+  Task submission — Discovery-first, `LLMFallback` fallback, writes a `Job` (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md` §4.4). Never
+  returns a Job's final result inline — the caller watches it execute live via the existing
+  generic `GET /tenants/:tenant_id/resources/jobs` + SSE subscription (§3), the same way any other
+  live Riptide surface is watched.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{Catalog, ContextResolver, Discovery, Job, LLMFallback, Rule}
+  alias Riptide.Derivation.Literal.CapabilityReference
+  alias Riptide.{Event, Stream.StreamServer, Stream.StreamSupervisor}
+
+  def create(conn, %{"description" => description} = params) do
+    tenant_id = conn.assigns.tenant_id
+
+    case Riptide.HubRateLimit.check_propose(tenant_id) do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_create(conn, tenant_id, description, params)
+    end
+  end
+
+  def create(conn, _params), do: send_resp(conn, 400, "")
+
+  defp handle_create(conn, tenant_id, description, params) do
+    facts = Map.get(params, "facts", [])
+    current_subject = conn.assigns[:current_subject]
+
+    case Discovery.find({:tenant, tenant_id}, description) do
+      {:ok, [{_node, rule} | _rest]} ->
+        write_discovery_job(conn, tenant_id, description, rule, facts)
+
+      {:ok, []} ->
+        resolve_via_llm_fallback(conn, tenant_id, description, facts, current_subject)
+
+      {:error, :not_ready} ->
+        send_resp(conn, 503, "")
+    end
+  end
+
+  defp resolve_via_llm_fallback(conn, tenant_id, description, facts, current_subject) do
+    graph = facts_to_graph(facts)
+    {:ok, context} = ContextResolver.resolve_all(tenant_id, current_subject)
+
+    case LLMFallback.run(description, graph, context) do
+      {:ok, trace} ->
+        write_llm_fallback_job(conn, tenant_id, description, trace)
+
+      {:error, reason} ->
+        body = Jason.encode!(%{"error" => "llm_fallback_failed", "reason" => inspect(reason)})
+        conn |> put_resp_content_type("application/json") |> send_resp(422, body)
+    end
+  end
+
+  defp write_discovery_job(conn, tenant_id, description, rule, facts) do
+    case write_task_facts(tenant_id, facts) do
+      {:ok, job_graph_stream_id} ->
+        job = %Job{
+          tenant_id: tenant_id,
+          status: :pending,
+          reference: {:rule, rule.signature.name},
+          args: [],
+          job_graph: job_graph_stream_id,
+          result: nil,
+          error: nil,
+          resolved_via: :discovery,
+          original_description: description,
+          trace: nil
+        }
+
+        finish_write(conn, tenant_id, job)
+
+      {:error, :not_ready} ->
+        send_resp(conn, 503, "")
+    end
+  end
+
+  defp write_llm_fallback_job(
+         conn,
+         tenant_id,
+         description,
+         %Rule{body: [%CapabilityReference{capability: capability_iri, args: args}]} = trace
+       ) do
+    job = %Job{
+      tenant_id: tenant_id,
+      status: :pending,
+      reference: {:capability, capability_iri},
+      args: args,
+      job_graph: nil,
+      result: nil,
+      error: nil,
+      resolved_via: :llm_fallback,
+      original_description: description,
+      trace: trace
+    }
+
+    finish_write(conn, tenant_id, job)
+  end
+
+  defp finish_write(conn, tenant_id, job) do
+    case Catalog.write_job(tenant_id, job) do
+      {:ok, node} ->
+        body =
+          Jason.encode!(%{
+            "job_node" => RDF.BlankNode.value(node),
+            "resolved_via" => Atom.to_string(job.resolved_via)
+          })
+
+        conn |> put_resp_content_type("application/json") |> send_resp(202, body)
+
+      {:error, :not_ready} ->
+        send_resp(conn, 503, "")
+    end
+  end
+
+  # Mirrors job_trigger_cluster_test.exs's own established "seed a dedicated job_graph stream
+  # before writing the Job" pattern exactly (6l), just server-driven from the Task's own submitted
+  # facts instead of hand-written in a test. A per-submission stream (not one shared, accumulating
+  # stream per Tenant) so two concurrent Task submissions against the same predicate never see each
+  # other's facts.
+  defp write_task_facts(tenant_id, facts) do
+    stream_id = Catalog.job_stream_id(tenant_id) <> "/task-graphs/" <> Uniq.UUID.uuid4()
+    graph = facts_to_graph(facts)
+
+    case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        StreamServer.append(stream_id, Event.new(stream_id, :replace, graph))
+        {:ok, stream_id}
+
+      :error ->
+        {:error, :not_ready}
+    end
+  end
+
+  defp facts_to_graph(facts) do
+    Enum.reduce(facts, RDF.Graph.new(), fn %{"subject" => s, "predicate" => p, "object" => o},
+                                           graph ->
+      RDF.Graph.add(graph, {RDF.iri(s), RDF.iri(p), RDF.literal(o)})
+    end)
+  end
+end

--- a/lib/riptide_web/tenant_discovery_controller.ex
+++ b/lib/riptide_web/tenant_discovery_controller.ex
@@ -1,0 +1,30 @@
+defmodule RiptideWeb.TenantDiscoveryController do
+  @moduledoc """
+  Tenant-scoped Discovery search — a direct analogue of
+  `RiptideWeb.Hub.DiscoveryController.search/2`, searching the caller's own Tenant catalog instead
+  of Hub's (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md` §4.5). Unlike the
+  Hub version, this lives on the ordinary `[:api, :tenant, :auth, :authz]` pipeline — reads here are
+  already gated by the caller's own Tenant authorization, so this reuses that instead of Hub's
+  separate public-surface rate limiter.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{Discovery, RuleRDFCodec}
+  alias Riptide.RDF.TurtleCodec
+
+  def search(conn, %{"q" => query}) do
+    tenant_id = conn.assigns.tenant_id
+    {:ok, entries} = Discovery.find({:tenant, tenant_id}, query)
+    {:ok, turtle} = entries |> entries_to_graph() |> TurtleCodec.encode()
+    send_resp(conn, 200, turtle)
+  end
+
+  defp entries_to_graph(entries) do
+    Enum.reduce(entries, RDF.Graph.new(), fn {_node, rule}, graph ->
+      {_node, rule_graph} = RuleRDFCodec.to_rdf(rule)
+      RDF.Graph.add(graph, rule_graph)
+    end)
+  end
+end

--- a/lib/riptide_web/tenant_propose_controller.ex
+++ b/lib/riptide_web/tenant_propose_controller.ex
@@ -1,0 +1,89 @@
+defmodule RiptideWeb.TenantProposeController do
+  @moduledoc """
+  Tenant-scoped propose — a direct analogue of `RiptideWeb.Hub.ProposeController`, `target_scope`
+  and `review_scope` both `{:tenant, tenant_id}` instead of `:hub` (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md` §4.5). Takes two
+  Job node references and reads each Job's own recorded `trace` back, rather than raw Turtle text —
+  the natural shape now that Traces are already durably recorded as part of Task resolution (§4.4).
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{AntiUnifier, Catalog, ContextResolver, DedupGate}
+
+  def propose(conn, %{"job1" => job1_id, "job2" => job2_id} = params) do
+    tenant_id = conn.assigns.tenant_id
+
+    case Riptide.HubRateLimit.check_propose(tenant_id) do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_propose(conn, tenant_id, job1_id, job2_id, params)
+    end
+  end
+
+  def propose(conn, _params), do: send_resp(conn, 400, "")
+
+  defp handle_propose(conn, tenant_id, job1_id, job2_id, params) do
+    with {:ok, trace1} <- find_job_trace(tenant_id, job1_id),
+         {:ok, trace2} <- find_job_trace(tenant_id, job2_id),
+         {:ok, candidates} <- AntiUnifier.generalize(trace1, trace2) do
+      graph = facts_to_graph(Map.get(params, "facts", []))
+      {:ok, context} = ContextResolver.resolve_all(tenant_id, conn.assigns[:current_subject])
+      scope = {:tenant, tenant_id}
+
+      case DedupGate.propose(scope, scope, candidates, graph, context) do
+        {:ok, [outcome]} -> respond_outcome(conn, outcome)
+        {:error, _reason} -> send_resp(conn, 503, "")
+      end
+    else
+      {:error, :job_has_no_trace} ->
+        body = Jason.encode!(%{"error" => "job_has_no_trace"})
+        conn |> put_resp_content_type("application/json") |> send_resp(422, body)
+
+      {:error, :not_found} ->
+        send_resp(conn, 404, "")
+
+      {:error, _reason} ->
+        send_resp(conn, 400, "")
+    end
+  end
+
+  defp respond_outcome(conn, {:queued, node, kind}) do
+    body =
+      Jason.encode!(%{
+        "outcome" => "queued",
+        "kind" => Atom.to_string(kind),
+        "node_id" => RDF.BlankNode.value(node)
+      })
+
+    conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+  end
+
+  defp respond_outcome(conn, {:rejected, reason}) do
+    body = Jason.encode!(%{"outcome" => "rejected", "reason" => inspect(reason)})
+    conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+  end
+
+  defp respond_outcome(conn, {:fidelity_failed, evidence}) do
+    body = Jason.encode!(%{"outcome" => "fidelity_failed", "evidence" => inspect(evidence)})
+    conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+  end
+
+  defp find_job_trace(tenant_id, job_id) do
+    with {:ok, jobs} <- Catalog.list_jobs(Catalog.job_stream_id(tenant_id)) do
+      jobs
+      |> Enum.find(fn {node, _job} -> RDF.BlankNode.value(node) == job_id end)
+      |> trace_from_found_job()
+    end
+  end
+
+  defp trace_from_found_job(nil), do: {:error, :not_found}
+  defp trace_from_found_job({_node, %{trace: nil}}), do: {:error, :job_has_no_trace}
+  defp trace_from_found_job({_node, %{trace: trace}}), do: {:ok, trace}
+
+  defp facts_to_graph(facts) do
+    Enum.reduce(facts, RDF.Graph.new(), fn %{"subject" => s, "predicate" => p, "object" => o},
+                                           graph ->
+      RDF.Graph.add(graph, {RDF.iri(s), RDF.iri(p), RDF.literal(o)})
+    end)
+  end
+end

--- a/lib/riptide_web/tenant_review_controller.ex
+++ b/lib/riptide_web/tenant_review_controller.ex
@@ -1,0 +1,33 @@
+defmodule RiptideWeb.TenantReviewController do
+  @moduledoc """
+  Approve/decline a Tenant-scope pending review — a direct analogue of
+  `RiptideWeb.Hub.ReviewController`, `target_scope`/`review_scope` both `{:tenant, tenant_id}`
+  (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md` §4.5).
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.DedupGate
+
+  def approve(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+    scope = {:tenant, tenant_id}
+
+    case DedupGate.approve_review(scope, scope, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+
+  def decline(conn, %{"node_id" => node_id}) do
+    tenant_id = conn.assigns.tenant_id
+
+    case DedupGate.decline_review({:tenant, tenant_id}, RDF.BlankNode.new(node_id)) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_found} -> send_resp(conn, 404, "")
+      {:error, _reason} -> send_resp(conn, 503, "")
+    end
+  end
+end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -30,7 +30,7 @@ defmodule Riptide.Derivation.CatalogTest do
   describe "stream_id helpers" do
     test "catalog_stream_id/1 for a Tenant scope" do
       assert Catalog.catalog_stream_id({:tenant, "acme"}) ==
-               "https://riptide.example/tenants/acme/catalog"
+               "https://riptide.example/tenants/acme/resources/catalog"
     end
 
     test "catalog_stream_id/1 for the Hub scope" do
@@ -39,7 +39,7 @@ defmodule Riptide.Derivation.CatalogTest do
 
     test "pending_review_stream_id/1 for a Tenant scope" do
       assert Catalog.pending_review_stream_id({:tenant, "acme"}) ==
-               "https://riptide.example/tenants/acme/catalog/pending-review"
+               "https://riptide.example/tenants/acme/resources/catalog/pending-review"
     end
   end
 

--- a/test/riptide/derivation/context_resolver_test.exs
+++ b/test/riptide/derivation/context_resolver_test.exs
@@ -305,4 +305,44 @@ defmodule Riptide.Derivation.ContextResolverTest do
     assert {:error, {:not_found, ^missing_cap}} =
              ContextResolver.resolve(tenant_id, nil, rule_iri)
   end
+
+  describe "resolve_all/2" do
+    test "returns a Context populated with every Hub capability and every Rule in scope for the tenant" do
+      scope = {:tenant, unique_tenant()}
+      on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id(scope)) end)
+      {:tenant, tenant_id} = scope
+
+      cap_entry = admit_capability!("ctxres-resolve-all-#{System.unique_integer([:positive])}")
+
+      rule =
+        admit_rule!(scope, "ctxres-resolve-all-rule-#{System.unique_integer([:positive])}", [])
+
+      rule_iri = rule.signature.name
+
+      assert {:ok, context} = ContextResolver.resolve_all(tenant_id, nil)
+      assert Map.has_key?(context.capabilities, cap_entry.name)
+      assert Map.has_key?(context.rules, rule_iri)
+      assert context.tenant_id == tenant_id
+    end
+
+    # :hub is a single, shared, non-unique stream across the whole test suite
+    # (see the "Hub vs. Tenant scope isolation" test in catalog_test.exs) —
+    # other test files admit Rules into :hub scope too, so asserting
+    # context.rules == %{} here would be flaky depending on suite run order.
+    # Comparing against Hub's own live state instead of assuming it's empty
+    # is what actually tests "a Tenant with nothing of its own contributes
+    # nothing beyond Hub passthrough."
+    test "returns a Context whose rules are exactly Hub's own entries for a Tenant with no admitted Rules yet" do
+      tenant_id = unique_tenant()
+
+      {:ok, hub_entries} = Catalog.list_entries(:hub)
+
+      expected_hub_rules =
+        Map.new(hub_entries, fn {_node, rule} -> {rule.signature.name, rule} end)
+
+      assert {:ok, context} = ContextResolver.resolve_all(tenant_id, nil)
+      assert context.rules == expected_hub_rules
+      assert context.tenant_id == tenant_id
+    end
+  end
 end

--- a/test/riptide/derivation/job_rdf_codec_test.exs
+++ b/test/riptide/derivation/job_rdf_codec_test.exs
@@ -70,4 +70,43 @@ defmodule Riptide.Derivation.JobRDFCodecTest do
 
     assert JobRDFCodec.from_rdf(node, graph) == job
   end
+
+  test "round-trips a Job with resolved_via and original_description set, no trace" do
+    job =
+      sample_job(%{
+        resolved_via: :discovery,
+        original_description: "make a QR code for this line"
+      })
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
+
+  test "round-trips a Job with a full trace (LLMFallback-resolved)" do
+    trace = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:qrCodeGenerated"),
+        parameters: [],
+        reads: [],
+        produces: [RDF.iri("urn:riptide:relation:qrCodeGenerated")]
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:qrCodeGenerated"),
+        args: [RDF.iri("urn:test:line-1"), RDF.literal("done")]
+      },
+      body: []
+    }
+
+    job =
+      sample_job(%{
+        resolved_via: :llm_fallback,
+        original_description: "make a QR code for this line",
+        trace: trace
+      })
+
+    {node, graph} = JobRDFCodec.to_rdf(job)
+
+    assert JobRDFCodec.from_rdf(node, graph) == job
+  end
 end

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -347,6 +347,80 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
     refute log =~ "manual cleanup needed"
   end
 
+  describe "reserved path guard" do
+    # These requests are expected to be rejected before ever writing
+    # anything — cleanup here is defense in depth against a future
+    # regression in the guard itself leaving real writes behind on the
+    # shared "test-tenant" fixture.
+    setup do
+      on_exit(fn ->
+        Riptide.RaTestHelpers.cleanup_stream(
+          "https://riptide.example/tenants/test-tenant/resources/jobs"
+        )
+
+        Riptide.RaTestHelpers.cleanup_stream(
+          "https://riptide.example/tenants/test-tenant/resources/catalog"
+        )
+      end)
+
+      :ok
+    end
+
+    test "PUT /resources/jobs is rejected as a reserved path" do
+      conn =
+        :put
+        |> conn("/tenants/test-tenant/resources/jobs", "")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 409
+    end
+
+    test "PATCH /resources/catalog/pending-review is rejected as a reserved path (nested prefix)" do
+      body =
+        Jason.encode!(%{
+          "additions" => "",
+          "removals" => ""
+        })
+
+      conn =
+        :patch
+        |> conn("/tenants/test-tenant/resources/catalog/pending-review", body)
+        |> put_req_header("content-type", "application/json")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 409
+    end
+
+    test "DELETE /resources/catalog is rejected as a reserved path" do
+      conn =
+        :delete
+        |> conn("/tenants/test-tenant/resources/catalog")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 409
+    end
+
+    test "POST /resources/jobs (create_child) is rejected as a reserved path" do
+      conn =
+        :post
+        |> conn("/tenants/test-tenant/resources/jobs", "")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 409
+    end
+
+    test "GET /resources/jobs is NOT blocked by the reserved-path guard" do
+      conn =
+        :get
+        |> conn("/tenants/test-tenant/resources/jobs")
+        |> RiptideWeb.Endpoint.call(@opts)
+
+      # 404 (nothing written yet) is the correct, unblocked read outcome —
+      # 409 would mean the guard incorrectly fired on a GET.
+      assert conn.status == 404
+    end
+  end
+
   describe "stream_id_for/2 and parse_stream_id/1" do
     test "parse_stream_id/1 recovers the exact tenant_id and path_segments stream_id_for/2 was built from" do
       stream_id = ResourceController.stream_id_for("acme", ["docs", "sub"])

--- a/test/riptide_web/task_controller_test.exs
+++ b/test/riptide_web/task_controller_test.exs
@@ -1,0 +1,199 @@
+defmodule RiptideWeb.TaskControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  defmodule StubLLMClient do
+    @behaviour Riptide.Derivation.LLMFallback.Client
+
+    @impl true
+    def complete(_prompt) do
+      # `capability(localName, arg1, ..., ResultVar)` is LLMFallback's own established DSL syntax
+      # for a CapabilityReference literal (confirmed live against
+      # test/riptide/derivation/llm_fallback_test.exs's own existing fixtures, e.g. "greeted(...) :-
+      # capability(greetSomeone, \"Alice\", Greeting)."). `resolve_exactly_one_binding/3` inside
+      # LLMFallback.run/3 fully grounds this before returning it — the caller never sees a free var.
+      {:ok,
+       "taskDone(<urn:test:line-1>, Result) :- capability(taskSubmitGreet, \"World\", Result)."}
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  defp register_task_submit_capability(tenant_id, local_name) do
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+    {:ok, hash} = Riptide.BlobStore.put(component_bytes)
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: RDF.iri("urn:riptide:capability:#{local_name}"),
+      kind: :effect,
+      component_hash: hash,
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    :ok = Catalog.admit_capability(entry)
+
+    :ok =
+      Riptide.Placement.add_policy(
+        tenant_id,
+        ["capabilities", local_name],
+        %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      )
+  end
+
+  test "no matching CatalogEntry: resolves via LLMFallback, writes a jobCapability Job with resolved_via and trace" do
+    tenant_id = "task-submit-llm-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+    register_task_submit_capability(tenant_id, "taskSubmitGreet")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_client, StubLLMClient)
+
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id)) end)
+
+    body = Jason.encode!(%{"description" => "mark this line done", "facts" => []})
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/tasks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 202
+    response = Jason.decode!(conn.resp_body)
+    assert response["resolved_via"] == "llm_fallback"
+    job_node = response["job_node"]
+
+    {:ok, jobs} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+    {_node, job} = Enum.find(jobs, fn {n, _j} -> RDF.BlankNode.value(n) == job_node end)
+    assert job.resolved_via == :llm_fallback
+    assert job.original_description == "mark this line done"
+    assert %Riptide.Derivation.Rule{} = job.trace
+    assert job.reference == {:capability, RDF.iri("urn:riptide:capability:taskSubmitGreet")}
+    assert job.args == [RDF.literal("World")]
+  end
+
+  test "a matching CatalogEntry: resolves via Discovery, no LLMFallback call, writes a jobRule Job with the Task's own facts as its job_graph" do
+    tenant_id = "task-submit-discovery-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    predicate_name = "tasksubmit#{System.unique_integer([:positive])}"
+    seed_predicate = "tasksubmitseed#{System.unique_integer([:positive])}"
+
+    rule = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        parameters: [%Riptide.Derivation.Var{name: "Subject"}],
+        reads: [RDF.iri("urn:riptide:relation:#{seed_predicate}")],
+        produces: [RDF.iri("urn:riptide:relation:#{predicate_name}")]
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        args: [%Riptide.Derivation.Var{name: "Subject"}, RDF.literal("done")]
+      },
+      body: [
+        %Riptide.Derivation.Literal.FactPattern{
+          predicate: RDF.iri("urn:riptide:relation:#{seed_predicate}"),
+          args: [%Riptide.Derivation.Var{name: "Subject"}, RDF.literal("v1")]
+        }
+      ]
+    }
+
+    :ok = Catalog.admit_entry({:tenant, tenant_id}, rule, nil)
+
+    body =
+      Jason.encode!(%{
+        "description" => predicate_name,
+        "facts" => [
+          %{
+            "subject" => "urn:test:subject-1",
+            "predicate" => "urn:riptide:relation:#{seed_predicate}",
+            "object" => "v1"
+          }
+        ]
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/tasks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 202
+    response = Jason.decode!(conn.resp_body)
+    assert response["resolved_via"] == "discovery"
+    job_node = response["job_node"]
+
+    {:ok, jobs} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+    {_node, job} = Enum.find(jobs, fn {n, _j} -> RDF.BlankNode.value(n) == job_node end)
+    assert job.resolved_via == :discovery
+    assert job.trace == nil
+    assert job.reference == {:rule, RDF.iri("urn:riptide:relation:#{predicate_name}")}
+    assert job.args == []
+    assert job.job_graph != nil
+
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(job.job_graph) end)
+  end
+
+  test "LLMFallback :no_match returns 422 and writes no Job" do
+    tenant_id = "task-submit-no-match-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    defmodule NoMatchClient do
+      @behaviour Riptide.Derivation.LLMFallback.Client
+      @impl true
+      def complete(_prompt), do: {:ok, "not a valid rule at all"}
+    end
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_client, NoMatchClient)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id))
+    end)
+
+    body = Jason.encode!(%{"description" => "do something nobody registered", "facts" => []})
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/tasks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 422
+    assert {:ok, []} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+  end
+end

--- a/test/riptide_web/tenant_discovery_controller_test.exs
+++ b/test/riptide_web/tenant_discovery_controller_test.exs
@@ -1,0 +1,61 @@
+defmodule RiptideWeb.TenantDiscoveryControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  test "GET /tenants/:tenant_id/discovery/search finds an admitted Tenant-scope CatalogEntry" do
+    tenant_id = "tenant-discovery-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "tenantdiscovery#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    rule = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        parameters: [],
+        reads: [],
+        produces: []
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        args: [RDF.iri("urn:test:subject"), RDF.literal("done")]
+      },
+      body: []
+    }
+
+    :ok = Catalog.admit_entry({:tenant, tenant_id}, rule, nil)
+
+    conn =
+      :get
+      |> conn("/tenants/#{tenant_id}/discovery/search?q=#{predicate_name}")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    assert conn.resp_body =~ predicate_name
+  end
+end

--- a/test/riptide_web/tenant_execution_surface_capstone_test.exs
+++ b/test/riptide_web/tenant_execution_surface_capstone_test.exs
@@ -1,0 +1,143 @@
+defmodule RiptideWeb.TenantExecutionSurfaceCapstoneTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  defmodule StubLLMClient do
+    @behaviour Riptide.Derivation.LLMFallback.Client
+    @impl true
+    def complete(prompt) do
+      # `capability(localName, arg, ResultVar)` is LLMFallback's own established DSL syntax for a
+      # CapabilityReference literal (see Task 5's own StubLLMClient comment for the confirmed
+      # precedent this mirrors). The two Task descriptions ("about alice" / "about bob") map
+      # deterministically to a different capability arg, so both resolve differently enough for
+      # AntiUnifier to generalize a real least-general-generalization from them, exactly like a
+      # real LLM resolving two structurally-similar-but-distinct requests.
+      name = if String.contains?(prompt, "alice"), do: "Alice", else: "Bob"
+
+      {:ok,
+       "capstoneDone(<urn:test:capstone-subject>, Result) :- capability(capstoneGreet, \"#{name}\", Result)."}
+    end
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_client, StubLLMClient)
+    :ok
+  end
+
+  defp register_capstone_capability(tenant_id) do
+    component_bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+    {:ok, hash} = Riptide.BlobStore.put(component_bytes)
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: RDF.iri("urn:riptide:capability:capstoneGreet"),
+      kind: :effect,
+      component_hash: hash,
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    :ok = Catalog.admit_capability(entry)
+
+    :ok =
+      Riptide.Placement.add_policy(
+        tenant_id,
+        ["capabilities", "capstoneGreet"],
+        %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
+      )
+  end
+
+  test "exit criterion: Task -> LLMFallback -> propose -> approve -> Task -> Discovery, zero LLM calls" do
+    tenant_id = "tenant-surface-capstone-" <> Uniq.UUID.uuid4()
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+    register_capstone_capability(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    # 1. First Task -> no CatalogEntry -> LLMFallback.
+    job1_node = submit_task(tenant_id, "capstone task about alice", [], "llm_fallback")
+
+    # 2. Second, similar Task -> also LLMFallback (still no CatalogEntry).
+    job2_node = submit_task(tenant_id, "capstone task about bob", [], "llm_fallback")
+
+    # 3. Propose the two Jobs' own recorded Traces against each other.
+    propose_body = Jason.encode!(%{"job1" => job1_node, "job2" => job2_node})
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/propose", propose_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert propose_conn.status == 200
+    assert Jason.decode!(propose_conn.resp_body)["outcome"] == "queued"
+
+    assert {:ok, [{review_node, _pending}]} = Catalog.list_pending_reviews({:tenant, tenant_id})
+
+    # 4. Approve it.
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/pending-reviews/#{RDF.BlankNode.value(review_node)}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+    assert {:ok, [{_node, _entry}]} = Catalog.list_entries({:tenant, tenant_id})
+
+    # 5. A third, similar Task now resolves via Discovery — zero LLMFallback calls.
+    # `Discovery.tokenize/1` (the query side) only lowercases/splits on
+    # non-alphanumeric — unlike `camel_words/1` (the predicate side), it does
+    # NOT split camelCase — so a space-separated phrase is needed for the
+    # query to word-match the "capstoneDone" predicate's own split words
+    # ["capstone", "done"] (confirmed against Riptide.Derivation.Discovery
+    # directly: "capstoneDone" as a query tokenizes to the single word
+    # "capstonedone", which never overlaps).
+    job3_node = submit_task(tenant_id, "capstone done", [], "discovery")
+
+    {:ok, jobs} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+    {_node, job3} = Enum.find(jobs, fn {n, _j} -> RDF.BlankNode.value(n) == job3_node end)
+    assert job3.resolved_via == :discovery
+    assert job3.trace == nil
+  end
+
+  defp submit_task(tenant_id, description, facts, expected_resolved_via) do
+    body = Jason.encode!(%{"description" => description, "facts" => facts})
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/tasks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 202
+    response = Jason.decode!(conn.resp_body)
+    assert response["resolved_via"] == expected_resolved_via
+    response["job_node"]
+  end
+end

--- a/test/riptide_web/tenant_propose_controller_test.exs
+++ b/test/riptide_web/tenant_propose_controller_test.exs
@@ -1,0 +1,155 @@
+defmodule RiptideWeb.TenantProposeControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.{Catalog, Job}
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  defp trace_for(subject, predicate_name) do
+    %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        parameters: [],
+        reads: [RDF.iri("urn:riptide:relation:seed")],
+        produces: [RDF.iri("urn:riptide:relation:#{predicate_name}")]
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        args: [RDF.iri(subject), RDF.literal("done")]
+      },
+      body: [
+        %Riptide.Derivation.Literal.FactPattern{
+          predicate: RDF.iri("urn:riptide:relation:seed"),
+          args: [RDF.iri(subject), RDF.literal("v1")]
+        }
+      ]
+    }
+  end
+
+  test "proposing two Job node references anti-unifies their traces and queues a review" do
+    tenant_id = "tenant-propose-test-" <> Uniq.UUID.uuid4()
+    predicate_name = "tenantpropose#{System.unique_integer([:positive])}"
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    job1 = %Job{
+      tenant_id: tenant_id,
+      status: :done,
+      reference: {:rule, RDF.iri("urn:riptide:relation:#{predicate_name}")},
+      args: [],
+      job_graph: nil,
+      result: nil,
+      error: nil,
+      resolved_via: :llm_fallback,
+      original_description: "first",
+      trace: trace_for("urn:test:alice", predicate_name)
+    }
+
+    job2 = %Job{
+      job1
+      | original_description: "second",
+        trace: trace_for("urn:test:bob", predicate_name)
+    }
+
+    {:ok, job1_node} = Catalog.write_job(tenant_id, job1)
+    {:ok, job2_node} = Catalog.write_job(tenant_id, job2)
+
+    # DedupGate.propose/5 only queues a candidate that passes fidelity
+    # checking, which re-verifies each trace's own body literals against
+    # the submitted facts graph — both traces' bodies read `seed(<subject>,
+    # "v1")`, so both grounding facts must be present or the outcome is
+    # {:fidelity_failed, _}, not {:queued, _, _} (confirmed against
+    # DedupGate.propose/5 and GeneralizationFidelity.check/3 directly).
+    body =
+      Jason.encode!(%{
+        "job1" => RDF.BlankNode.value(job1_node),
+        "job2" => RDF.BlankNode.value(job2_node),
+        "facts" => [
+          %{
+            "subject" => "urn:test:alice",
+            "predicate" => "urn:riptide:relation:seed",
+            "object" => "v1"
+          },
+          %{
+            "subject" => "urn:test:bob",
+            "predicate" => "urn:riptide:relation:seed",
+            "object" => "v1"
+          }
+        ]
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/propose", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    response = Jason.decode!(conn.resp_body)
+    assert response["outcome"] == "queued"
+
+    assert {:ok, [{_node, _pending}]} = Catalog.list_pending_reviews({:tenant, tenant_id})
+  end
+
+  test "proposing a Job with no recorded trace (Discovery-resolved) returns 422" do
+    tenant_id = "tenant-propose-no-trace-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id)) end)
+
+    job = %Job{
+      tenant_id: tenant_id,
+      status: :done,
+      reference: {:rule, RDF.iri("urn:riptide:relation:whatever")},
+      args: [],
+      job_graph: nil,
+      result: nil,
+      error: nil,
+      resolved_via: :discovery,
+      trace: nil
+    }
+
+    {:ok, job1_node} = Catalog.write_job(tenant_id, job)
+    {:ok, job2_node} = Catalog.write_job(tenant_id, job)
+
+    body =
+      Jason.encode!(%{
+        "job1" => RDF.BlankNode.value(job1_node),
+        "job2" => RDF.BlankNode.value(job2_node)
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/propose", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 422
+    assert Jason.decode!(conn.resp_body)["error"] == "job_has_no_trace"
+  end
+end

--- a/test/riptide_web/tenant_review_controller_test.exs
+++ b/test/riptide_web/tenant_review_controller_test.exs
@@ -1,0 +1,109 @@
+defmodule RiptideWeb.TenantReviewControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.{Catalog, DedupGate}
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  test "approving a Tenant-scope pending review admits it into the Tenant's own Catalog" do
+    tenant_id = "tenant-review-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    rule = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:tenantreview#{System.unique_integer([:positive])}"),
+        parameters: [],
+        reads: [],
+        produces: []
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:tenantreviewhead"),
+        args: [RDF.iri("urn:test:subject"), RDF.literal("done")]
+      },
+      body: []
+    }
+
+    pending = %DedupGate.PendingReview{
+      kind: :admit,
+      candidate: rule,
+      fidelity_evidence: [],
+      replaces: nil
+    }
+
+    {:ok, node} = Catalog.queue_pending_review({:tenant, tenant_id}, pending)
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/pending-reviews/#{RDF.BlankNode.value(node)}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    assert {:ok, [{_node, _entry}]} = Catalog.list_entries({:tenant, tenant_id})
+  end
+
+  test "declining a Tenant-scope pending review does not admit it" do
+    tenant_id = "tenant-review-decline-test-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    rule = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:tenantdecline#{System.unique_integer([:positive])}"),
+        parameters: [],
+        reads: [],
+        produces: []
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:tenantdeclinehead"),
+        args: [RDF.iri("urn:test:subject"), RDF.literal("done")]
+      },
+      body: []
+    }
+
+    pending = %DedupGate.PendingReview{
+      kind: :admit,
+      candidate: rule,
+      fidelity_evidence: [],
+      replaces: nil
+    }
+
+    {:ok, node} = Catalog.queue_pending_review({:tenant, tenant_id}, pending)
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/pending-reviews/#{RDF.BlankNode.value(node)}/decline")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    assert {:ok, []} = Catalog.list_entries({:tenant, tenant_id})
+  end
+end


### PR DESCRIPTION
## Summary
- Implements 6m — a Tenant-scoped HTTP surface for Task submission (Discovery-first, LLMFallback fallback), propose/review against the caller's own catalog, and Discovery search.
- Job/Tenant-catalog streams now live under `/resources/*path`, so reading and live-watching them is free via the already-working generic `ResourceController` + SSE machinery — no new read/watch mechanism, at the cost of one small write-guard rejecting generic PUT/PATCH/DELETE/POST on those now-reserved paths.
- `Job` gains three optional fields (`resolved_via`, `original_description`, `trace`) rather than a second Fact type, following the same precedent 6d-ii's `resource_key` already set.
- Capstone test proves the full exit criterion: two Tasks resolve via LLMFallback, their Traces get proposed and approved, and a third similar Task resolves via Discovery with zero LLMFallback calls.
- Along the way, root-caused and fixed three previously-latent bugs the capstone's real end-to-end flow was first to exercise: a `DedupGate.PendingReview` crash on an empty `fidelity_evidence` list, a raw-string-vs-RDF.Literal comparison mismatch in `GeneralizationFidelity`'s Capability re-invocation check, and an uncaught `KeyError` `ExecuteInterpreter` could raise inside a supervised `JobTrigger` Task for an unbindable Var. Details in `PROGRESS.md`'s own 6m section.

Spec: `docs/superpowers/specs/2026-09-01-phase-6m-tenant-execution-surface-design.md` (PR #122).

## Test plan
- [x] `mix test` — full suite green (559 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR