### PR TITLE
Draft: Resolve: "6n — Hub Resource Lifecycle"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering) — 3 phases remaining, see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l, 6d-ii, 6m, 6n shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering; concurrent-effects design spike; Tenant-Scoped Execution Surface; Hub Resource Lifecycle) — see issue #58 for the current remaining list (6o demo, 6g-ii, 6c-iii-a/b, Capability grant/OAuth), see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -1344,3 +1344,72 @@ freelanced here. Also out of scope per the design spec §8: the demo itself (6n)
 surface, and background (non-Task-triggered) anti-unification discovery.
 
 **Status**: Phase 6m shipped 2026-09-01.
+
+### 6n — Hub Resource Lifecycle
+
+**Shipped 2026-09-01** — see
+`docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md` (spec PR #124). Direct
+origin: brainstorming 6n (originally scoped as "the demo") surfaced, while working out how to register
+a real `generate-qr-code` Capability into Riptide, two concrete gaps — Capability/Crosswalk had no
+supersede/update path at all (a gap 6k's own spec explicitly named and deferred), and Hub had zero
+generic read/watch surface for anything (`SseController`/`ReplicationChannel` rejected every
+Hub-shaped `stream_id` with `403`, since `ResourceController.parse_stream_id/1` only recognized the
+Tenant-shaped `/tenants/:id/resources/*path` form). The demo itself is pushed further out to 6o;
+convenient WASM-component-authoring tooling remains a separate, not-yet-scoped follow-up.
+
+**Core architectural finding**: rather than building a parallel Hub-specific addressing/authorization
+mechanism, `Riptide.Derivation.Catalog.scope()` (`:hub | {:tenant, id}` — already used pervasively
+inside `Catalog`/`Discovery`/`DedupGate`/`ContextResolver`) is generalized through the HTTP layer
+itself. `Riptide.Authz.evaluate/4` now takes a `scope()` instead of a bare `tenant_id` string, with
+`:hub`+`:read` hardcoded to always `:allow` and `:hub`+`:write` hardcoded to always `:deny`, both
+short-circuiting before ever consulting `Authz.Store` (which stays completely unmodified, still
+string-keyed — the Hub cases never reach it). `ResourceController.stream_id_for/2`/`parse_stream_id/1`
+are similarly widened to accept/return `scope()`, adding a `https://riptide.example/hub/resources/`
+prefix alongside the existing Tenant one. This worked because Hub's WRITE side was *already* unified
+with Tenant's own Authz mechanism (`CapabilityController` etc. all live under `/tenants/:tenant_id`
+scope) — only READ needed generalizing, eliminating what would otherwise have been a whole second,
+Hub-specific read/watch mechanism.
+
+New surface: `GET /hub/resources/*path`, reusing `ResourceController.show/2` verbatim (no write verbs
+wired for Hub — writes stay on the existing bespoke propose/review POST endpoints). `SseController`/
+`ReplicationChannel` both gained a `RiptideWeb.Plugs.ResolveHubScope` plug's `:hub`-scope counterpart
+to `ResolveTenant`, plus a `Riptide.HubRateLimit.check_read/1` guard at subscribe/join time — Hub-scoped
+reads are network-public with no per-tenant ownership check narrowing who can subscribe, so they get
+the same abuse-rate quota `Hub.DiscoveryController` already uses for `GET /hub/search`, applied once at
+connection-open time (not a per-message throttle).
+
+Capability and Crosswalk both gained the same supersede/`replaces` lifecycle Rules already have via
+`Catalog.supersede_entry/2`: `Catalog.admit_capability/2` (was `/1`) + `Catalog.supersede_capability/1`,
+mirrored exactly for Crosswalk. `PendingCapabilityReview`/`PendingCrosswalkReview` both gained an
+optional `:replaces` field (same `maybe_add_replaces/3` RDF encode/decode shape `PendingReview`
+established for Rules); `DedupGate.propose_capability/3`/`propose_crosswalk/3` (both were `/2`) accept
+it, and `approve_capability_review/2`/`approve_crosswalk_review/2` admit-with-replaces and supersede
+the old entry in one step. `Hub.CapabilityController.propose/2`/`Hub.CrosswalkController.propose/2`
+both accept an optional `"replaces"` body field. Full history is preserved throughout — supersession
+flips an RDF `rdf:type` triple (`CapabilityCatalogEntry` → `SupersededCapabilityCatalogEntry`, and the
+Crosswalk equivalent), never hard-deleting the old entry's underlying event.
+
+Capstone test (`test/riptide_web/hub_resource_lifecycle_capstone_test.exs`) proves the full exit
+criterion end-to-end over real HTTP: propose a Capability → approve → confirm it's live-readable via
+the new generic `GET /hub/resources/*path` surface (not just `Catalog.list_capabilities/0`, a library
+call rather than a public surface) → propose a replacement with `"replaces"` → approve → confirm only
+the new version is live in `list_capabilities/0` while the underlying stream still holds both events.
+
+**Two real regressions caught during implementation, both by running the full suite rather than just
+the touched test files**:
+1. Widening `Catalog.admit_capability/1` to `/2` broke three pre-existing
+   `test/riptide/derivation/job_trigger_cluster_test.exs` call sites invisibly to a literal-text
+   `grep "admit_capability("` sweep — they call it via `:erpc.call(node, Riptide.Derivation.Catalog,
+   :admit_capability, [entry])`, a dynamic `apply`-shaped call whose arity mismatch only surfaces at
+   runtime (`:undef`) inside the remote test node, not as a compile warning. Same risk confirmed absent
+   for the Crosswalk-side widening via a dedicated `:erpc.call`/`apply` sweep before committing.
+2. The DedupGate-level Capability-supersede test (mirrored for Crosswalk) initially passed the wrong
+   node as the second `propose_capability/3` call's `replaces` argument — `propose_capability/3`
+   returns the queued *review's* own node, not the catalog entry's node, so the old entry never actually
+   got flipped to `Superseded...`. Fixed by looking the real catalog node up via
+   `Catalog.list_capabilities/0` after the first approval (the same pattern the Catalog-level test and
+   the HTTP-level test both already used correctly).
+
+**Status**: Phase 6n shipped 2026-09-01. See issue #58's own restated summary for the current
+remaining list (6o — the demo itself, pushed out from 6n's original scope — plus 6g-ii deferred,
+6c-iii-a/6c-iii-b Track B, and Capability grant flow/OAuth Track A, all ready to start).

--- a/docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md
@@ -246,12 +246,7 @@ New functions in `Catalog`, direct mirrors of the existing Rule ones:
 @spec admit_capability(CapabilityCatalogEntry.t(), RDF.BlankNode.t() | nil) :: :ok | {:error, :not_ready}
 def admit_capability(%CapabilityCatalogEntry{} = entry, replaces) do
   {node, entry_graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
-
-  graph =
-    entry_graph
-    |> RDF.Graph.add({node, @rdf_type, @riptide_capability_catalog_entry})
-    |> maybe_add_supersedes(node, replaces)
-
+  graph = maybe_add_supersedes(entry_graph, node, replaces)
   write_patch(capability_stream_id(), RDF.Graph.triples(graph), [])
 end
 
@@ -265,7 +260,10 @@ def supersede_capability(node) do
 end
 ```
 
-(`admit_capability/1`'s current single-arg form becomes `admit_capability/2` with `replaces` — every
+(`CapabilityCatalogRDFCodec.to_rdf/1` already adds its own `{node, rdf:type, CapabilityCatalogEntry}`
+triple internally — confirmed by reading it directly — unlike `RuleRDFCodec.to_rdf/1`, which doesn't;
+`admit_entry/3`'s own type-triple-adding line has no equivalent needed here, only `maybe_add_supersedes/2`.
+`admit_capability/1`'s current single-arg form becomes `admit_capability/2` with `replaces` — every
 existing call site passes `nil`, matching how `admit_entry/3`'s own callers already do.)
 
 `list_capabilities/0` needs **no change** — it already filters by

--- a/docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md
@@ -1,0 +1,346 @@
+# Phase 6n — Hub Resource Lifecycle (generalized addressing + Capability/Crosswalk supersede)
+
+## 1. Context and motivation
+
+Sub-project 6 (Derivation and execution layer) is being built phase-by-phase against
+`docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md`. This phase — like 6j,
+6k, 6l, 6d-ii, and 6m before it — emerged from real need rather than the original 21-phase breakdown,
+and gets its own letter continuing that same sequence.
+
+**Direct origin.** While preparing to brainstorm the Sub-project 6 demo (6o, provisionally — pushed
+back one letter by this phase), the concrete first step is registering a real `generate-qr-code`
+Capability into Riptide. That surfaced two gaps, both confirmed by reading the code directly rather
+than assumed:
+
+1. **Capabilities (and Crosswalks) are Create+Read only.** `Riptide.Derivation.Catalog`'s Rule
+   admission already has a proven "update"/"retire" primitive — `supersede_entry/2`, a PATCH event
+   that flips an entry's `rdf:type` from `CatalogEntry` to `SupersededCatalogEntry` while its full RDF
+   description stays in the stream's history forever, plus `admit_entry/3`'s own `replaces` param
+   linking a new entry to what it supersedes. 6k's own design spec named the Capability half of this
+   gap explicitly and deferred it: *"Revoking/un-admitting a live Capability, or versioning... left for
+   later work."* Crosswalks never had it either — nobody has needed it until now.
+2. **Hub has no generic read or live-watch surface for anything.** Every Hub-scoped stream (the Rule
+   catalog, Capabilities, Crosswalks, every kind of pending review) is already internally an
+   append-only `Riptide.Event`/`Riptide.Stream.StreamServer` stream — the same mechanism 6m proved out
+   for Tenant-scoped resources. But `RiptideWeb.Realtime.SseController.subscribe/2` routes every
+   subscription through `RiptideWeb.LDP.ResourceController.parse_stream_id/1`, which only recognizes
+   the `https://riptide.example/tenants/:id/resources/*path` shape — a Hub stream_id doesn't match and
+   is rejected with `403`. This is the direct, structural consequence of 6m's own design spec
+   explicitly scoping Hub out (*"Hub's own addressing/HTTP surface — unchanged; already has its own
+   working model, not touched here"*) — that "existing model" turns out to have no read/watch story at
+   all beyond `GET /hub/search` (keyword Discovery) and `GET /hub/entries/:node_id` (single Rule by
+   node), neither of which generalizes to "list/watch everything of one kind."
+
+**The higher-order framing.** The instinct to "add CRUD to Capabilities" and "add a generic resource
+surface for Hub" are the same problem once `Riptide.Derivation.Catalog.scope/0`
+(`:hub | {:tenant, tenant_id}`) is taken seriously as the one type that should flow through the HTTP
+layer too — every function in `Catalog`/`Discovery`/`DedupGate`/`ContextResolver` is already
+scope-polymorphic; only `Riptide.Authz.evaluate/4`, `Authz.Store`, and `ResourceController`'s own
+addressing are still hardcoded to a raw `tenant_id` string. Generalizing those closes both gaps at
+once, without building a second, parallel Hub-specific controller or SSE-dispatch path.
+
+## 2. Scope
+
+- **Generalize `Catalog.scope()` through the HTTP layer.** `Riptide.Authz.evaluate/4`,
+  `RiptideWeb.LDP.ResourceController.stream_id_for/2` + `parse_stream_id/1`, and every
+  `ResourceController` action take/produce `scope :: Catalog.scope()` instead of a raw `tenant_id`
+  string. `Authz.Store`'s own implementation is untouched (§4.1).
+- **One new read route:** `GET /hub/resources/*path` — reuses `ResourceController.show/2` verbatim.
+  No write verbs are wired for it; Hub writes stay exactly as they are today (bespoke, review-gated
+  POST endpoints under `/hub/*`) (§4.2).
+- **Hub streams move under the same `/resources/*path` convention Tenant scope already uses.**
+  `Catalog.catalog_stream_id(:hub)` moves from `.../hub/catalog` to `.../hub/resources/catalog` — the
+  one literal every other Hub stream_id (crosswalks, capabilities, pending-reviews) derives from by
+  concatenation, so this one change cascades to all of them (§4.3).
+- **Capability and Crosswalk supersede**, mirroring `Catalog.supersede_entry/2` and `admit_entry/3`'s
+  `replaces` param exactly: `Catalog.supersede_capability/1`, `supersede_crosswalk/1`,
+  `admit_capability/2` (gains `replaces`), `admit_crosswalk/2` (gains `replaces`), with the
+  corresponding `DedupGate`/Hub-controller propose flows threading an optional `replaces` node through
+  (§4.4, §4.5).
+
+## 3. Non-goals
+
+- **Convenient WASM component authoring/production tooling.** Registering a real `generate-qr-code`
+  Capability still means hand-writing a WIT world and Rust source, `cargo component build`ing it, and
+  proposing the resulting bytes through the existing (now supersede-capable) flow. A more convenient
+  authoring path is real, separate follow-up work — this phase makes the *lifecycle* around a component
+  stream-native; it does not change how the component itself gets produced.
+- **The demo itself** — 6o (provisionally), built on top of this phase and 6m together.
+- **Hub's own write authorization model.** Propose/review/approve already flows through the *proposing
+  tenant's own* `{:tenant, tenant_id}` Authz-gated pipeline (confirmed by reading
+  `Hub.CapabilityController.propose/2`, which lives under `scope "/tenants/:tenant_id"` and calls
+  `DedupGate.propose_capability({:tenant, tenant_id}, entry)` — the review queue is the proposing
+  tenant's own, not Hub's). Only final admission into the shared Hub catalog skips a check, and that's
+  the existing, working governance model (approving in your own reviewed queue *is* the authorization)
+  — unchanged by this phase.
+- **`Riptide.HubRateLimit`** — reused as-is for the new read route (§4.2); not redesigned.
+
+## 4. Detailed design
+
+### 4.1 `Riptide.Authz.evaluate/4` and `Authz.Store` — scope-polymorphic, not Hub-aware inside the Store
+
+Current signature: `evaluate(tenant_id :: String.t(), path_segments, current_subject, mode)`. New:
+
+```elixir
+@spec evaluate(Catalog.scope(), [String.t()], map() | nil, Policy.mode()) :: :allow | :deny
+def evaluate(:hub, _path_segments, _current_subject, :read), do: :allow
+
+def evaluate(:hub, _path_segments, _current_subject, :write), do: :deny
+
+def evaluate({:tenant, tenant_id}, path_segments, current_subject, mode) do
+  # existing body, unchanged — store.list_policies(tenant_id, prefix) as today
+end
+```
+
+The `:hub` clauses are hardcoded short-circuits, not policy rows: Hub's read-openness is a structural
+property of what Hub *is* (`Hub.DiscoveryController`'s own moduledoc already states this — *"reads are
+inherently cross-tenant, nobody 'acts as' a Tenant to search"*), not a per-scope setting that should be
+editable/revocable through the same mechanism a Tenant's own policies are. Both `:hub` clauses return
+before ever calling `Authz.Store` — **`Authz.Store`'s behaviour and its `Placement`-backed
+implementation are completely unchanged**, so there is no `"hub"`-string-vs-real-tenant_id collision
+risk to design around at all (a concern raised and then dismissed during brainstorming: it doesn't
+arise because the Store is never consulted for `:hub`).
+
+`RiptideWeb.Plugs.Authorize` changes its two `conn.assigns.tenant_id` reads to
+`conn.assigns.scope`, and `maybe_bootstrap/4` — which calls
+`Store.claim_tenant_if_unclaimed/2`, a genuinely Tenant-only "first write claims ownership" concept —
+gets an explicit `{:tenant, tenant_id}` clause for the existing bootstrap behavior plus a catch-all
+clause (covering `:hub` and any future non-tenant scope) that rejects outright. `:hub` can never reach
+`Authorize` in practice (no write route is wired for it — see §4.2), but this keeps the function total
+and crash-free rather than relying on that never happening.
+
+### 4.2 `ResourceController` — one route added, zero new controller modules
+
+`stream_id_for/2` and `parse_stream_id/1` become scope-polymorphic, mirroring how
+`Catalog.catalog_stream_id/1` already branches on scope:
+
+```elixir
+@spec stream_id_for(Catalog.scope(), [String.t()]) :: String.t()
+def stream_id_for({:tenant, tenant_id}, path_segments),
+  do: @tenant_stream_id_prefix <> tenant_id <> @resources_segment <> Enum.join(path_segments, "/")
+
+def stream_id_for(:hub, path_segments),
+  do: @hub_stream_id_prefix <> Enum.join(path_segments, "/")
+
+@spec parse_stream_id(String.t()) :: {:ok, Catalog.scope(), [String.t()]} | :error
+def parse_stream_id(@tenant_stream_id_prefix <> rest) do
+  case String.split(rest, @resources_segment, parts: 2) do
+    [tenant_id, path] when tenant_id != "" -> {:ok, {:tenant, tenant_id}, String.split(path, "/")}
+    _ -> :error
+  end
+end
+
+def parse_stream_id(@hub_stream_id_prefix <> path) when path != "",
+  do: {:ok, :hub, String.split(path, "/")}
+
+def parse_stream_id(_other), do: :error
+```
+
+(`@hub_stream_id_prefix` is `"https://riptide.example/hub/resources/"` — the exact prefix `show/2`'s
+new route below constructs stream_ids under.)
+
+Every action (`show/2`, `replace/2`, `delete/2`, `patch/2`, `create_child/2`) changes its internal
+`conn.assigns.tenant_id` reference to `conn.assigns.scope` — mechanical, and the compiler catches every
+missed call site once the function signatures change. In practice only `show/2` is ever reached with
+`scope = :hub`, since the router change below wires only `GET` for the Hub route; the other four
+actions still only ever receive `{:tenant, tenant_id}`, unchanged in behavior.
+
+Router addition, alongside the existing routes (no change to the existing `/tenants/:tenant_id/...`
+block):
+
+```elixir
+scope "/hub" do
+  pipe_through [:api, :auth, :resolve_hub_scope, :authz]
+
+  get "/resources/*path", RiptideWeb.LDP.ResourceController, :show
+end
+```
+
+A new pipeline stage, `:resolve_hub_scope`, backed by a tiny new plug mirroring `ResolveTenant`'s own
+shape:
+
+```elixir
+defmodule RiptideWeb.Plugs.ResolveHubScope do
+  @moduledoc """
+  Assigns `conn.assigns.scope = :hub` for the `/hub/resources/*path` read route — the Hub-side
+  counterpart to `ResolveTenant` assigning `{:tenant, tenant_id}`. No route param to resolve; this
+  plug exists purely so `Authorize`/`ResourceController` see the same `conn.assigns.scope` shape
+  regardless of which scope a request is for.
+  """
+  import Plug.Conn
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts), do: assign(conn, :scope, :hub)
+end
+```
+
+`ResolveTenant` gains one additional assign alongside its existing `:tenant_id` one —
+`assign(conn, :scope, {:tenant, tenant_id})` — additive, so every other controller that still reads
+`conn.assigns.tenant_id` directly (`TaskController`, `Authz.PolicyController`, the Tenant-scoped
+propose/review/discovery controllers from 6m, etc.) is unaffected.
+
+No write verbs (`POST`/`PUT`/`PATCH`/`DELETE`) are routed under `/hub/resources/*path` at all — unlike
+Tenant scope's reserved-path write-guard (6m §4.2), there is nothing to guard here, since the routes
+simply don't exist. Hub writes stay exactly as they are: bespoke, review-gated POST endpoints under
+`/hub/*`, unchanged by this phase.
+
+There are exactly four real callers of `Authz.evaluate/4` in the codebase (confirmed by grepping, not
+assumed) — every one needs to keep working once its first argument widens from a bare `tenant_id`
+string to `Catalog.scope()`:
+
+1. **`RiptideWeb.Plugs.Authorize`** — covered above.
+2. **`RiptideWeb.Realtime.SseController.subscribe/2`** — parses `stream_id` via
+   `ResourceController.parse_stream_id/1`, then calls `evaluate/4` with whatever it returns. Once that
+   parser accepts `:hub`, this caller needs no code change to keep compiling — but it needs one
+   *behavioral* addition: before this phase, no Hub-shaped stream_id could ever reach it
+   (`parse_stream_id/1` rejected every one with `:error` → `403`), so subscribing was never a reachable
+   Hub-scoped code path and never needed Hub's abuse-rate-limit layer. Once it's reachable, `evaluate/4`'s
+   new `:hub` + `:read` short-circuit means *anyone*, unauthenticated, can open a live subscription — the
+   exact same abuse surface `HubRateLimit.check_read/1` already exists to bound for `GET /hub/search`/
+   `GET /hub/entries/:node_id`. The rule: **every entry point that reads Hub-scoped data — one-shot
+   `GET` or a live subscribe-*open* — gets exactly one `HubRateLimit.check_read/1` check**, applied once
+   when the connection opens (a subscription is one long-lived connection, not a per-event hit, so this
+   is a check at open-time, not a per-message throttle). `do_subscribe/2` gains a scope match: for
+   `{:ok, :hub, path_segments}`, check `HubRateLimit.check_read/1` before proceeding; for `{:ok,
+   {:tenant, tenant_id}, path_segments}`, unchanged.
+3. **`RiptideWeb.Realtime.ReplicationChannel.join/3`** — the WebSocket-replication sibling of
+   `SseController.subscribe/2`, following the exact same `parse_stream_id/1` → `evaluate/4` shape
+   (confirmed by reading it directly). Gets the identical treatment as #2 for the identical reason — a
+   `:hub`-scoped `"replication:<stream_id>"` channel join becomes newly reachable the same way SSE
+   subscribe does, so it needs the same `HubRateLimit.check_read/1` guard at join-time.
+4. **`Riptide.Capability.authorized?/3`** — calls `evaluate(tenant_id, path, current_subject, :invoke)`
+   where `tenant_id` is always the invoking Tenant's own id (a Capability invocation is always on behalf
+   of a real tenant; `:hub` invoking something is meaningless). This caller only needs its argument
+   wrapped — `evaluate({:tenant, tenant_id}, path, current_subject, :invoke)` — no behavioral change,
+   since `:invoke` mode was never handled by the new `:hub` clauses anyway (only `:read`/`:write` are).
+
+Both #2 and #3's new `HubRateLimit.check_read/1` calls need the same rate-limit key
+`Hub.DiscoveryController`'s own `rate_limit_key/1` already computes (`current_subject["sub"]` when
+present, else caller IP) — that helper is a private `defp` inside `Hub.DiscoveryController`, so each of
+the two new call sites needs its own 2-line copy of the same logic rather than calling it directly;
+small, deliberate duplication in the same spirit as `GeneralizationFidelity`'s own `term_to_arg/1`, not
+worth extracting a shared module for two call sites.
+
+### 4.3 Catalog stream-id convention move (Hub side)
+
+Mechanical, mirrors 6m's own Task 1 exactly, applied to the one Hub-scope literal:
+
+```elixir
+def catalog_stream_id(:hub), do: @stream_id_prefix <> "hub/resources/catalog"
+```
+
+`crosswalk_stream_id/0` (`catalog_stream_id(:hub) <> "/crosswalks"`), `capability_stream_id/0`
+(`catalog_stream_id(:hub) <> "/capabilities"`), and `pending_review_stream_id/1` (already
+scope-polymorphic, `catalog_stream_id(scope) <> "/pending-review"`) all derive from this one function
+by string concatenation — no separate change needed for any of them.
+
+### 4.4 Capability supersede
+
+New functions in `Catalog`, direct mirrors of the existing Rule ones:
+
+```elixir
+@spec admit_capability(CapabilityCatalogEntry.t(), RDF.BlankNode.t() | nil) :: :ok | {:error, :not_ready}
+def admit_capability(%CapabilityCatalogEntry{} = entry, replaces) do
+  {node, entry_graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
+
+  graph =
+    entry_graph
+    |> RDF.Graph.add({node, @rdf_type, @riptide_capability_catalog_entry})
+    |> maybe_add_supersedes(node, replaces)
+
+  write_patch(capability_stream_id(), RDF.Graph.triples(graph), [])
+end
+
+@spec supersede_capability(RDF.BlankNode.t()) :: :ok | {:error, :not_ready}
+def supersede_capability(node) do
+  write_patch(
+    capability_stream_id(),
+    [{node, @rdf_type, @riptide_superseded_capability_catalog_entry}],
+    [{node, @rdf_type, @riptide_capability_catalog_entry}]
+  )
+end
+```
+
+(`admit_capability/1`'s current single-arg form becomes `admit_capability/2` with `replaces` — every
+existing call site passes `nil`, matching how `admit_entry/3`'s own callers already do.)
+
+`list_capabilities/0` needs **no change** — it already filters by
+`nodes_of_type(graph, @riptide_capability_catalog_entry)` (confirmed by reading it directly), so a
+superseded entry's type-flip removes it from the live list automatically, the same way
+`list_entries/1` already excludes superseded Rules for free.
+
+`DedupGate.propose_capability/2` becomes `propose_capability/3`, gaining an optional `replaces` param
+and threading it into the
+`PendingCapabilityReview` it queues (mirroring `PendingReview.replaces` exactly); its approval path
+(`approve_capability_review/2`) calls `Catalog.admit_capability(entry, pending.replaces)` followed by
+`Catalog.supersede_capability(pending.replaces)` when `replaces` is non-nil — the exact
+`finish_proposal/8` shape Rules already use. `Hub.CapabilityController.propose/2`'s request body gains
+an optional `"replaces"` field (a node_id string, `RDF.BlankNode.new/1`'d the same way
+`TenantReviewController`'s existing approve/decline actions already reconstruct a node from a path
+param).
+
+### 4.5 Crosswalk supersede
+
+Identical shape to §4.4, applied to `Crosswalk`/`CrosswalkRDFCodec`/`crosswalk_stream_id/0`:
+`admit_crosswalk/2` (gains `replaces`), `supersede_crosswalk/1`, `DedupGate.propose_crosswalk/2`
+becomes `propose_crosswalk/3` (gains `replaces`), `Hub.CrosswalkController.propose/2`'s body gains an
+optional `"replaces"` field.
+`list_crosswalks/0` needs no change, for the same reason as §4.4.
+
+## 5. Data flow — worked example
+
+1. `POST /tenants/acme/hub/capabilities {"name": "urn:riptide:capability:generate-qr-code", ...,
+   "component_bytes": "<base64>"}` — proposes into `acme`'s own review queue, exactly as today.
+2. `acme` approves it: `POST /tenants/acme/hub/capability-reviews/<node>/approve` — admits into the
+   Hub catalog with `replaces: nil` (a genuinely new Capability, nothing to supersede).
+3. `GET /hub/resources/capabilities` — the entry appears, live-watchable via
+   `GET /streams/:stream_id/subscribe?stream_id=https://riptide.example/hub/resources/capabilities`
+   for the first time ever, no polling required.
+4. A bug is found in the component. `acme` proposes a fixed build:
+   `POST /tenants/acme/hub/capabilities {..., "replaces": "<old_node>"}` — same review flow, but the
+   `PendingCapabilityReview` now carries `replaces`.
+5. `acme` approves it: the new entry is admitted linked to the old one via `supersedes`, and the old
+   entry's type flips to `SupersededCapabilityCatalogEntry` in the same admission — `GET
+   /hub/resources/capabilities` immediately reflects only the new version; the old version's full RDF
+   description remains readable from the stream's own history (`GET /hub/resources/capabilities` folds
+   *current* state; nothing was deleted from the underlying event log).
+
+## 6. Error handling
+
+- `GET /hub/resources/*path` for a never-written Hub stream (e.g. before any Capability has ever been
+  admitted): `404`, mirroring `ResourceController.show/2`'s existing never-written-resource handling —
+  no new logic needed, since `current_state/1`'s `Placement.lookup/1` check is scope-agnostic already.
+- `GET /hub/resources/*path` rate-limited: `429`, via the same `HubRateLimit.check_read/1` guard
+  `Hub.DiscoveryController` already uses (exact reuse, not a new limiter).
+- Proposing a Capability/Crosswalk with `"replaces"` pointing at a node that isn't actually a live
+  (non-superseded) entry: mirrors whatever `DedupGate`'s existing Rule-merge path does for an invalid
+  `replaces` reference today (confirm exact behavior when writing the plan — likely a `{:error,
+  :not_found}`-shaped rejection at admission time, not a crash).
+
+## 7. Testing
+
+- `RiptideWeb.LDP.ResourceControllerTest`-style tests for `GET /hub/resources/*path`: never-written
+  404, a Hub-admitted Capability/Rule/Crosswalk visible after admission, rate-limit 429.
+- `Authz.evaluate/4`'s two new `:hub` clauses, unit-tested directly (read always allows, write always
+  denies) — mirroring the existing `Authz` test suite's own per-clause style.
+- `Catalog`/`DedupGate` supersede tests for both Capability and Crosswalk, mirroring
+  `catalog_test.exs`'s existing `supersede_entry/2` coverage exactly: old entry disappears from
+  `list_capabilities/0`/`list_crosswalks/0`, new entry appears, `supersedes` linkage round-trips.
+  Capstone-style test: propose → approve → propose-with-replaces → approve → verify only the new
+  version is live, old version's history still readable via a raw `StreamServer.get_since/2` read from
+  cursor 0.
+- SSE subscription and `ReplicationChannel` join to a Hub-shaped stream_id, each mirroring their
+  existing Tenant-scoped test coverage, plus a dedicated case per transport confirming
+  `HubRateLimit.check_read/1` is actually consulted at open/join time (a stubbed/exhausted limiter
+  returns `429`/`{:error, ...}` instead of opening the connection) — the one genuinely new code path
+  this phase adds to each, not just a wider-type passthrough.
+- `Riptide.Capability.authorized?/3` regression test confirming Capability invoke-authorization still
+  works unchanged after its `evaluate/4` call site wraps `tenant_id` as `{:tenant, tenant_id}`.
+
+## 8. Explicitly out of scope
+
+See §3 (Non-goals).

--- a/lib/riptide/authz.ex
+++ b/lib/riptide/authz.ex
@@ -10,9 +10,28 @@ defmodule Riptide.Authz do
   """
 
   alias Riptide.Authz.Policy
+  alias Riptide.Derivation.Catalog
 
-  @spec evaluate(String.t(), [String.t()], map() | nil, Policy.mode()) :: :allow | :deny
-  def evaluate(tenant_id, path_segments, current_subject, mode) do
+  @doc """
+  `scope == :hub` is a hardcoded short-circuit, not a policy-store lookup: Hub's read-openness is a
+  structural property of what Hub *is* (`RiptideWeb.Hub.DiscoveryController`'s own moduledoc already
+  states this), not a per-scope setting that should be editable/revocable the way a Tenant's own
+  policies are. Both `:hub` clauses return before `Authz.Store` is ever consulted — its behaviour and
+  `Placement`-backed implementation are unmodified by this, and take only a raw tenant_id string, never
+  `:hub` (design spec `docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md` §4.1).
+  """
+  @spec evaluate(Catalog.scope(), [String.t()], map() | nil, Policy.mode()) :: :allow | :deny
+  def evaluate(:hub, _path_segments, _current_subject, :read) do
+    :telemetry.execute([:riptide, :authz, :decision], %{}, %{effect: :allow, mode: :read})
+    :allow
+  end
+
+  def evaluate(:hub, _path_segments, _current_subject, :write) do
+    :telemetry.execute([:riptide, :authz, :decision], %{}, %{effect: :deny, mode: :write})
+    :deny
+  end
+
+  def evaluate({:tenant, tenant_id}, path_segments, current_subject, mode) do
     store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
 
     matching_policies =

--- a/lib/riptide/capability.ex
+++ b/lib/riptide/capability.ex
@@ -23,7 +23,7 @@ defmodule Riptide.Capability do
   @spec authorized?(Definition.t(), String.t(), map() | nil) :: boolean()
   def authorized?(%Definition{} = definition, tenant_id, current_subject) do
     path = ["capabilities", local_name(definition)]
-    Riptide.Authz.evaluate(tenant_id, path, current_subject, :invoke) == :allow
+    Riptide.Authz.evaluate({:tenant, tenant_id}, path, current_subject, :invoke) == :allow
   end
 
   defp local_name(%Definition{name: name}) do

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -58,7 +58,7 @@ defmodule Riptide.Derivation.Catalog do
   # Unchanged — Hub already has its own working, separate /hub/* HTTP surface
   # and addressing model (design spec §3); this phase touches only the
   # Tenant-scoped side.
-  def catalog_stream_id(:hub), do: @stream_id_prefix <> "hub/catalog"
+  def catalog_stream_id(:hub), do: @stream_id_prefix <> "hub/resources/catalog"
 
   @spec pending_review_stream_id(scope()) :: String.t()
   def pending_review_stream_id(scope), do: catalog_stream_id(scope) <> "/pending-review"

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -44,6 +44,9 @@ defmodule Riptide.Derivation.Catalog do
   @riptide_job_result RDF.iri("urn:riptide:vocab:jobResult")
   @riptide_job_error RDF.iri("urn:riptide:vocab:jobError")
   @riptide_capability_catalog_entry RDF.iri("urn:riptide:vocab:CapabilityCatalogEntry")
+  @riptide_superseded_capability_catalog_entry RDF.iri(
+                                                 "urn:riptide:vocab:SupersededCapabilityCatalogEntry"
+                                               )
   @riptide_pending_capability_review RDF.iri("urn:riptide:vocab:PendingCapabilityReview")
   @riptide_resolved_pending_capability_review RDF.iri(
                                                 "urn:riptide:vocab:ResolvedPendingCapabilityReview"
@@ -147,10 +150,21 @@ defmodule Riptide.Derivation.Catalog do
   @spec capability_stream_id() :: String.t()
   def capability_stream_id, do: catalog_stream_id(:hub) <> "/capabilities"
 
-  @spec admit_capability(CapabilityCatalogEntry.t()) :: :ok | {:error, :not_ready}
-  def admit_capability(%CapabilityCatalogEntry{} = entry) do
-    {_node, entry_graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
-    write_patch(capability_stream_id(), RDF.Graph.triples(entry_graph), [])
+  @spec admit_capability(CapabilityCatalogEntry.t(), RDF.BlankNode.t() | nil) ::
+          :ok | {:error, :not_ready}
+  def admit_capability(%CapabilityCatalogEntry{} = entry, replaces) do
+    {node, entry_graph} = CapabilityCatalogRDFCodec.to_rdf(entry)
+    graph = maybe_add_supersedes(entry_graph, node, replaces)
+    write_patch(capability_stream_id(), RDF.Graph.triples(graph), [])
+  end
+
+  @spec supersede_capability(RDF.BlankNode.t()) :: :ok | {:error, :not_ready}
+  def supersede_capability(node) do
+    write_patch(
+      capability_stream_id(),
+      [{node, @rdf_type, @riptide_superseded_capability_catalog_entry}],
+      [{node, @rdf_type, @riptide_capability_catalog_entry}]
+    )
   end
 
   @spec list_capabilities() ::

--- a/lib/riptide/derivation/catalog.ex
+++ b/lib/riptide/derivation/catalog.ex
@@ -34,6 +34,7 @@ defmodule Riptide.Derivation.Catalog do
   @riptide_superseded_catalog_entry RDF.iri("urn:riptide:vocab:SupersededCatalogEntry")
   @riptide_supersedes RDF.iri("urn:riptide:vocab:supersedes")
   @riptide_crosswalk RDF.iri("urn:riptide:vocab:Crosswalk")
+  @riptide_superseded_crosswalk RDF.iri("urn:riptide:vocab:SupersededCrosswalk")
   @riptide_pending_crosswalk_review RDF.iri("urn:riptide:vocab:PendingCrosswalkReview")
   @riptide_resolved_pending_crosswalk_review RDF.iri(
                                                "urn:riptide:vocab:ResolvedPendingCrosswalkReview"
@@ -103,10 +104,20 @@ defmodule Riptide.Derivation.Catalog do
     )
   end
 
-  @spec admit_crosswalk(Crosswalk.t()) :: :ok | {:error, :not_ready}
-  def admit_crosswalk(%Crosswalk{} = crosswalk) do
-    {_node, crosswalk_graph} = CrosswalkRDFCodec.to_rdf(crosswalk)
-    write_patch(crosswalk_stream_id(), RDF.Graph.triples(crosswalk_graph), [])
+  @spec admit_crosswalk(Crosswalk.t(), RDF.BlankNode.t() | nil) :: :ok | {:error, :not_ready}
+  def admit_crosswalk(%Crosswalk{} = crosswalk, replaces) do
+    {node, crosswalk_graph} = CrosswalkRDFCodec.to_rdf(crosswalk)
+    graph = maybe_add_supersedes(crosswalk_graph, node, replaces)
+    write_patch(crosswalk_stream_id(), RDF.Graph.triples(graph), [])
+  end
+
+  @spec supersede_crosswalk(RDF.BlankNode.t()) :: :ok | {:error, :not_ready}
+  def supersede_crosswalk(node) do
+    write_patch(
+      crosswalk_stream_id(),
+      [{node, @rdf_type, @riptide_superseded_crosswalk}],
+      [{node, @rdf_type, @riptide_crosswalk}]
+    )
   end
 
   @spec list_crosswalks() :: {:ok, [{RDF.BlankNode.t(), Crosswalk.t()}]} | {:error, :not_ready}

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -164,25 +164,31 @@ defmodule Riptide.Derivation.DedupGate.PendingCrosswalkReview do
   A proposed Crosswalk awaiting the proposing Tenant's own review (design
   spec `docs/superpowers/specs/2026-08-30-phase-6i-crosswalks-and-installation-design.md`
   §6). Deliberately much simpler than `PendingReview` — a Crosswalk has no
-  `kind`/`replaces` (no Reject/Merge/Admit classification against existing
-  Crosswalks; out of scope, spec §3) and no fidelity evidence (never
-  applicable to a Crosswalk in the first place, same reasoning as
-  `PendingReview.fidelity_evidence`'s own `:not_applicable` case).
+  `kind` (no Reject/Merge/Admit classification against existing Crosswalks;
+  out of scope, spec §3) and no fidelity evidence (never applicable to a
+  Crosswalk in the first place, same reasoning as
+  `PendingReview.fidelity_evidence`'s own `:not_applicable` case) — but it
+  can still supersede a previous version of itself, the same `replaces`
+  shape `PendingReview`/`PendingCapabilityReview` already established
+  (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md`
+  §4.5).
   """
 
   alias Riptide.Derivation.{Crosswalk, CrosswalkRDFCodec}
 
   @enforce_keys [:candidate]
-  defstruct [:candidate]
+  defstruct [:candidate, :replaces]
 
-  @type t :: %__MODULE__{candidate: Crosswalk.t()}
+  @type t :: %__MODULE__{candidate: Crosswalk.t(), replaces: RDF.BlankNode.t() | nil}
 
   @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
   @riptide_pending_crosswalk_review RDF.iri("urn:riptide:vocab:PendingCrosswalkReview")
   @riptide_candidate RDF.iri("urn:riptide:vocab:candidate")
+  @riptide_replaces RDF.iri("urn:riptide:vocab:replaces")
 
   @spec to_rdf(t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
-  def to_rdf(%__MODULE__{candidate: candidate}) do
+  def to_rdf(%__MODULE__{candidate: candidate, replaces: replaces}) do
     node = RDF.BlankNode.new()
     {candidate_node, candidate_graph} = CrosswalkRDFCodec.to_rdf(candidate)
 
@@ -190,15 +196,26 @@ defmodule Riptide.Derivation.DedupGate.PendingCrosswalkReview do
       candidate_graph
       |> RDF.Graph.add({node, @rdf_type, @riptide_pending_crosswalk_review})
       |> RDF.Graph.add({node, @riptide_candidate, candidate_node})
+      |> maybe_add_replaces(node, replaces)
 
     {node, graph}
   end
+
+  defp maybe_add_replaces(graph, _node, nil), do: graph
+
+  defp maybe_add_replaces(graph, node, replaces),
+    do: RDF.Graph.add(graph, {node, @riptide_replaces, replaces})
 
   @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: t()
   def from_rdf(node, graph) do
     description = RDF.Graph.get(graph, node)
     candidate_node = RDF.Description.first(description, @riptide_candidate)
-    %__MODULE__{candidate: CrosswalkRDFCodec.from_rdf(candidate_node, graph)}
+    replaces = RDF.Description.first(description, @riptide_replaces)
+
+    %__MODULE__{
+      candidate: CrosswalkRDFCodec.from_rdf(candidate_node, graph),
+      replaces: replaces
+    }
   end
 end
 
@@ -372,23 +389,30 @@ defmodule Riptide.Derivation.DedupGate do
     end
   end
 
-  @spec propose_crosswalk(Catalog.scope(), Crosswalk.t()) ::
+  @spec propose_crosswalk(Catalog.scope(), Crosswalk.t(), RDF.BlankNode.t() | nil) ::
           {:ok, RDF.BlankNode.t()} | {:error, term()}
-  def propose_crosswalk(review_scope, %Crosswalk{} = crosswalk) do
-    Catalog.queue_crosswalk_review(review_scope, %PendingCrosswalkReview{candidate: crosswalk})
+  def propose_crosswalk(review_scope, %Crosswalk{} = crosswalk, replaces) do
+    Catalog.queue_crosswalk_review(review_scope, %PendingCrosswalkReview{
+      candidate: crosswalk,
+      replaces: replaces
+    })
   end
 
   @spec approve_crosswalk_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
   def approve_crosswalk_review(review_scope, node) do
     with {:ok, pending_reviews} <- Catalog.list_crosswalk_pending_reviews(review_scope),
          {_node, pending} <- List.keyfind(pending_reviews, node, 0, :not_found) do
-      :ok = Catalog.admit_crosswalk(pending.candidate)
+      :ok = Catalog.admit_crosswalk(pending.candidate, pending.replaces)
+      maybe_supersede_crosswalk(pending.replaces)
       Catalog.resolve_crosswalk_review(review_scope, node)
     else
       :not_found -> {:error, :not_found}
       error -> error
     end
   end
+
+  defp maybe_supersede_crosswalk(nil), do: :ok
+  defp maybe_supersede_crosswalk(node), do: Catalog.supersede_crosswalk(node)
 
   @spec decline_crosswalk_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
   def decline_crosswalk_review(review_scope, node),

--- a/lib/riptide/derivation/dedup_gate.ex
+++ b/lib/riptide/derivation/dedup_gate.ex
@@ -207,24 +207,31 @@ defmodule Riptide.Derivation.DedupGate.PendingCapabilityReview do
   A proposed Capability awaiting the proposing Tenant's own review (design
   spec
   `docs/superpowers/specs/2026-08-31-phase-6k-dynamic-capability-registration-design.md`
-  §6). Deliberately as simple as `PendingCrosswalkReview` — a
-  `CapabilityCatalogEntry` isn't a generalization of anything, so there's
-  nothing to anti-unify or replay-test.
+  §6). A `CapabilityCatalogEntry` isn't a generalization of anything, so
+  there's nothing to anti-unify or replay-test — but it can still supersede
+  a previous version of itself, the same `replaces` shape `PendingReview`
+  already established for Rules (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md`
+  §4.4).
   """
 
   alias Riptide.Derivation.{CapabilityCatalogEntry, CapabilityCatalogRDFCodec}
 
   @enforce_keys [:candidate]
-  defstruct [:candidate]
+  defstruct [:candidate, :replaces]
 
-  @type t :: %__MODULE__{candidate: CapabilityCatalogEntry.t()}
+  @type t :: %__MODULE__{
+          candidate: CapabilityCatalogEntry.t(),
+          replaces: RDF.BlankNode.t() | nil
+        }
 
   @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
   @riptide_pending_capability_review RDF.iri("urn:riptide:vocab:PendingCapabilityReview")
   @riptide_candidate RDF.iri("urn:riptide:vocab:candidate")
+  @riptide_replaces RDF.iri("urn:riptide:vocab:replaces")
 
   @spec to_rdf(t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
-  def to_rdf(%__MODULE__{candidate: candidate}) do
+  def to_rdf(%__MODULE__{candidate: candidate, replaces: replaces}) do
     node = RDF.BlankNode.new()
     {candidate_node, candidate_graph} = CapabilityCatalogRDFCodec.to_rdf(candidate)
 
@@ -232,15 +239,26 @@ defmodule Riptide.Derivation.DedupGate.PendingCapabilityReview do
       candidate_graph
       |> RDF.Graph.add({node, @rdf_type, @riptide_pending_capability_review})
       |> RDF.Graph.add({node, @riptide_candidate, candidate_node})
+      |> maybe_add_replaces(node, replaces)
 
     {node, graph}
   end
+
+  defp maybe_add_replaces(graph, _node, nil), do: graph
+
+  defp maybe_add_replaces(graph, node, replaces),
+    do: RDF.Graph.add(graph, {node, @riptide_replaces, replaces})
 
   @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: t()
   def from_rdf(node, graph) do
     description = RDF.Graph.get(graph, node)
     candidate_node = RDF.Description.first(description, @riptide_candidate)
-    %__MODULE__{candidate: CapabilityCatalogRDFCodec.from_rdf(candidate_node, graph)}
+    replaces = RDF.Description.first(description, @riptide_replaces)
+
+    %__MODULE__{
+      candidate: CapabilityCatalogRDFCodec.from_rdf(candidate_node, graph),
+      replaces: replaces
+    }
   end
 end
 
@@ -376,23 +394,30 @@ defmodule Riptide.Derivation.DedupGate do
   def decline_crosswalk_review(review_scope, node),
     do: Catalog.resolve_crosswalk_review(review_scope, node)
 
-  @spec propose_capability(Catalog.scope(), CapabilityCatalogEntry.t()) ::
+  @spec propose_capability(Catalog.scope(), CapabilityCatalogEntry.t(), RDF.BlankNode.t() | nil) ::
           {:ok, RDF.BlankNode.t()} | {:error, term()}
-  def propose_capability(review_scope, %CapabilityCatalogEntry{} = entry) do
-    Catalog.queue_capability_review(review_scope, %PendingCapabilityReview{candidate: entry})
+  def propose_capability(review_scope, %CapabilityCatalogEntry{} = entry, replaces) do
+    Catalog.queue_capability_review(review_scope, %PendingCapabilityReview{
+      candidate: entry,
+      replaces: replaces
+    })
   end
 
   @spec approve_capability_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
   def approve_capability_review(review_scope, node) do
     with {:ok, pending_reviews} <- Catalog.list_capability_pending_reviews(review_scope),
          {_node, pending} <- List.keyfind(pending_reviews, node, 0, :not_found) do
-      :ok = Catalog.admit_capability(pending.candidate)
+      :ok = Catalog.admit_capability(pending.candidate, pending.replaces)
+      maybe_supersede_capability(pending.replaces)
       Catalog.resolve_capability_review(review_scope, node)
     else
       :not_found -> {:error, :not_found}
       error -> error
     end
   end
+
+  defp maybe_supersede_capability(nil), do: :ok
+  defp maybe_supersede_capability(node), do: Catalog.supersede_capability(node)
 
   @spec decline_capability_review(Catalog.scope(), RDF.BlankNode.t()) :: :ok | {:error, term()}
   def decline_capability_review(review_scope, node),

--- a/lib/riptide_web/hub/capability_controller.ex
+++ b/lib/riptide_web/hub/capability_controller.ex
@@ -32,7 +32,7 @@ defmodule RiptideWeb.Hub.CapabilityController do
            "timeout_ms" => timeout_ms,
            "memory_limits" => memory_limits_params,
            "component_bytes" => component_bytes_b64
-         }
+         } = params
        ) do
     with {:ok, kind} <- parse_kind(kind_string),
          {:ok, bytes} <- Base.decode64(component_bytes_b64),
@@ -47,7 +47,9 @@ defmodule RiptideWeb.Hub.CapabilityController do
         memory_limits: parse_memory_limits(memory_limits_params)
       }
 
-      case DedupGate.propose_capability({:tenant, tenant_id}, entry) do
+      replaces = parse_replaces(params)
+
+      case DedupGate.propose_capability({:tenant, tenant_id}, entry, replaces) do
         {:ok, node} ->
           body = Jason.encode!(%{"outcome" => "queued", "node_id" => RDF.BlankNode.value(node)})
           conn |> put_resp_content_type("application/json") |> send_resp(200, body)
@@ -76,6 +78,11 @@ defmodule RiptideWeb.Hub.CapabilityController do
       max_tables: Map.get(params, "max_tables")
     }
   end
+
+  defp parse_replaces(%{"replaces" => node_id}) when is_binary(node_id),
+    do: RDF.BlankNode.new(node_id)
+
+  defp parse_replaces(_params), do: nil
 
   def approve(conn, %{"node_id" => node_id}) do
     tenant_id = conn.assigns.tenant_id

--- a/lib/riptide_web/hub/crosswalk_controller.ex
+++ b/lib/riptide_web/hub/crosswalk_controller.ex
@@ -27,7 +27,7 @@ defmodule RiptideWeb.Hub.CrosswalkController do
            "subject_predicate" => subject_predicate,
            "object_predicate" => object_predicate,
            "match_type" => match_type_string
-         }
+         } = params
        ) do
     case parse_match_type(match_type_string) do
       nil ->
@@ -40,7 +40,9 @@ defmodule RiptideWeb.Hub.CrosswalkController do
           match_type: match_type
         }
 
-        case DedupGate.propose_crosswalk({:tenant, tenant_id}, crosswalk) do
+        replaces = parse_replaces(params)
+
+        case DedupGate.propose_crosswalk({:tenant, tenant_id}, crosswalk, replaces) do
           {:ok, node} ->
             body =
               Jason.encode!(%{"outcome" => "queued", "node_id" => RDF.BlankNode.value(node)})
@@ -66,6 +68,11 @@ defmodule RiptideWeb.Hub.CrosswalkController do
   defp parse_match_type("narrow_match"), do: :narrow_match
   defp parse_match_type("related_match"), do: :related_match
   defp parse_match_type(_other), do: nil
+
+  defp parse_replaces(%{"replaces" => node_id}) when is_binary(node_id),
+    do: RDF.BlankNode.new(node_id)
+
+  defp parse_replaces(_params), do: nil
 
   def approve(conn, %{"node_id" => node_id}) do
     tenant_id = conn.assigns.tenant_id

--- a/lib/riptide_web/ldp/resource_controller.ex
+++ b/lib/riptide_web/ldp/resource_controller.ex
@@ -38,7 +38,7 @@ defmodule RiptideWeb.LDP.ResourceController do
   end
 
   def show(conn, %{"path" => path_segments}) do
-    stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
+    stream_id = stream_id_for(conn.assigns.scope, path_segments)
 
     case current_state(stream_id) do
       {:ok, graph} ->
@@ -62,7 +62,7 @@ defmodule RiptideWeb.LDP.ResourceController do
   end
 
   defp do_replace(conn, %{"path" => path_segments}) do
-    stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
+    stream_id = stream_id_for(conn.assigns.scope, path_segments)
     {:ok, body, conn} = Plug.Conn.read_body(conn)
 
     case TurtleCodec.decode(body) do
@@ -92,7 +92,7 @@ defmodule RiptideWeb.LDP.ResourceController do
   end
 
   defp do_delete(conn, %{"path" => path_segments}) do
-    stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
+    stream_id = stream_id_for(conn.assigns.scope, path_segments)
 
     case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
       :ok ->
@@ -113,7 +113,7 @@ defmodule RiptideWeb.LDP.ResourceController do
   end
 
   defp do_patch(conn, %{"path" => path_segments} = params) do
-    stream_id = stream_id_for(conn.assigns.tenant_id, path_segments)
+    stream_id = stream_id_for(conn.assigns.scope, path_segments)
 
     # NOTE: the endpoint's `Plug.Parsers` (see Task 6's scaffold) already
     # parses and consumes the request body for `content-type:
@@ -157,7 +157,7 @@ defmodule RiptideWeb.LDP.ResourceController do
 
   defp do_create_child(conn, %{"path" => path_segments}) do
     tenant_id = conn.assigns.tenant_id
-    container_stream_id = stream_id_for(tenant_id, path_segments)
+    container_stream_id = stream_id_for(conn.assigns.scope, path_segments)
     {:ok, body, conn} = Plug.Conn.read_body(conn)
 
     case TurtleCodec.decode(body) do
@@ -249,30 +249,45 @@ defmodule RiptideWeb.LDP.ResourceController do
     :ok
   end
 
-  @stream_id_prefix "https://riptide.example/tenants/"
+  @tenant_stream_id_prefix "https://riptide.example/tenants/"
+  @hub_stream_id_prefix "https://riptide.example/hub/resources/"
   @resources_segment "/resources/"
 
-  @spec stream_id_for(String.t(), [String.t()]) :: String.t()
-  def stream_id_for(tenant_id, path_segments) do
-    @stream_id_prefix <> tenant_id <> @resources_segment <> Enum.join(path_segments, "/")
+  @spec stream_id_for(Riptide.Derivation.Catalog.scope(), [String.t()]) :: String.t()
+  def stream_id_for({:tenant, tenant_id}, path_segments) do
+    @tenant_stream_id_prefix <> tenant_id <> @resources_segment <> Enum.join(path_segments, "/")
+  end
+
+  def stream_id_for(:hub, path_segments) do
+    @hub_stream_id_prefix <> Enum.join(path_segments, "/")
   end
 
   # The exact inverse of `stream_id_for/2` — used by Phase 4c's authorization
-  # layer (`RiptideWeb.Realtime.SseController`/`ReplicationChannel`, Tasks 7-8)
-  # to recover which tenant/resource an opaque, client-supplied `stream_id`
+  # layer (`RiptideWeb.Realtime.SseController`/`ReplicationChannel`) to
+  # recover which scope/resource an opaque, client-supplied `stream_id`
   # addresses, since neither transport constructs one from a path
-  # server-side (see Phase 4a design spec §5, Phase 4c design spec §7).
-  # `stream_id_for/2`'s format is a pure, deterministic, reversible string —
-  # no hashing or randomness — so parsing it back apart needs no new
-  # persisted state, at the cost of staying coupled to this exact format:
-  # the round-trip tests in `resource_controller_test.exs` exist specifically
-  # to catch a future change here breaking that coupling silently.
-  @spec parse_stream_id(String.t()) :: {:ok, String.t(), [String.t()]} | :error
-  def parse_stream_id(@stream_id_prefix <> rest) do
+  # server-side (see Phase 4a design spec §5, Phase 4c design spec §7, and
+  # design spec `docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md`
+  # §4.2 for the Hub-scope addition). `stream_id_for/2`'s format is a pure,
+  # deterministic, reversible string — no hashing or randomness — so parsing
+  # it back apart needs no new persisted state, at the cost of staying
+  # coupled to this exact format: the round-trip tests in
+  # `resource_controller_test.exs` exist specifically to catch a future
+  # change here breaking that coupling silently.
+  @spec parse_stream_id(String.t()) ::
+          {:ok, Riptide.Derivation.Catalog.scope(), [String.t()]} | :error
+  def parse_stream_id(@tenant_stream_id_prefix <> rest) do
     case String.split(rest, @resources_segment, parts: 2) do
-      [tenant_id, path] when tenant_id != "" -> {:ok, tenant_id, String.split(path, "/")}
-      _ -> :error
+      [tenant_id, path] when tenant_id != "" ->
+        {:ok, {:tenant, tenant_id}, String.split(path, "/")}
+
+      _ ->
+        :error
     end
+  end
+
+  def parse_stream_id(@hub_stream_id_prefix <> path) when path != "" do
+    {:ok, :hub, String.split(path, "/")}
   end
 
   def parse_stream_id(_other), do: :error

--- a/lib/riptide_web/plugs/authorize.ex
+++ b/lib/riptide_web/plugs/authorize.ex
@@ -21,14 +21,14 @@ defmodule RiptideWeb.Plugs.Authorize do
 
   @impl true
   def call(conn, _opts) do
-    tenant_id = conn.assigns.tenant_id
+    scope = conn.assigns.scope
     current_subject = conn.assigns.current_subject
     path_segments = Map.get(conn.params, "path") || []
     mode = mode_for(conn.method)
 
-    case Riptide.Authz.evaluate(tenant_id, path_segments, current_subject, mode) do
+    case Riptide.Authz.evaluate(scope, path_segments, current_subject, mode) do
       :allow -> conn
-      :deny -> maybe_bootstrap(conn, tenant_id, current_subject, mode)
+      :deny -> maybe_bootstrap(conn, scope, current_subject, mode)
     end
   rescue
     _ -> service_unavailable(conn)
@@ -52,7 +52,7 @@ defmodule RiptideWeb.Plugs.Authorize do
   # token, so this should not be reachable in practice; kept as defense in
   # depth rather than trusting that invariant to hold from this call site
   # alone.
-  defp maybe_bootstrap(conn, tenant_id, %{"sub" => sub}, :write)
+  defp maybe_bootstrap(conn, {:tenant, tenant_id}, %{"sub" => sub}, :write)
        when not is_nil(sub) do
     store = Application.get_env(:riptide, :authz_store, Riptide.Authz.Store.Placement)
 
@@ -62,7 +62,9 @@ defmodule RiptideWeb.Plugs.Authorize do
     end
   end
 
-  defp maybe_bootstrap(conn, _tenant_id, _current_subject, _mode), do: reject(conn)
+  # Covers :hub (never reaches Authorize in practice — no write route exists for it) and any
+  # future non-tenant scope; keeps this function total instead of relying on that never happening.
+  defp maybe_bootstrap(conn, _scope, _current_subject, _mode), do: reject(conn)
 
   defp mode_for("GET"), do: :read
   defp mode_for(_other), do: :write

--- a/lib/riptide_web/plugs/resolve_hub_scope.ex
+++ b/lib/riptide_web/plugs/resolve_hub_scope.ex
@@ -1,0 +1,18 @@
+defmodule RiptideWeb.Plugs.ResolveHubScope do
+  @moduledoc """
+  Assigns `conn.assigns.scope = :hub` for the `/hub/resources/*path` read route — the Hub-side
+  counterpart to `RiptideWeb.Plugs.ResolveTenant` assigning `{:tenant, tenant_id}`. No route param to
+  resolve; this plug exists purely so `Authorize`/`RiptideWeb.LDP.ResourceController` see the same
+  `conn.assigns.scope` shape regardless of which scope a request is for (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md` §4.2).
+  """
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts), do: assign(conn, :scope, :hub)
+end

--- a/lib/riptide_web/plugs/resolve_tenant.ex
+++ b/lib/riptide_web/plugs/resolve_tenant.ex
@@ -21,6 +21,12 @@ defmodule RiptideWeb.Plugs.ResolveTenant do
   since none of the delimiter characters (`/`) can appear on either side of
   the join. An invalid tenant_id is treated exactly like an unresolvable
   one: halt with `400`.
+
+  Also assigns `conn.assigns.scope = {:tenant, tenant_id}` — additive alongside the existing
+  `tenant_id` assign, so callers that already read `tenant_id` directly (`TaskController`,
+  `Authz.PolicyController`, etc.) are unaffected; `RiptideWeb.Plugs.Authorize` and
+  `RiptideWeb.LDP.ResourceController` read `scope` instead, matching
+  `RiptideWeb.Plugs.ResolveHubScope`'s own shape for the Hub side.
   """
   import Plug.Conn
   require Logger
@@ -41,7 +47,10 @@ defmodule RiptideWeb.Plugs.ResolveTenant do
       {:ok, tenant_id} ->
         if Regex.match?(@safe_tenant_id, tenant_id) do
           Logger.metadata(tenant_id: tenant_id)
-          assign(conn, :tenant_id, tenant_id)
+
+          conn
+          |> assign(:tenant_id, tenant_id)
+          |> assign(:scope, {:tenant, tenant_id})
         else
           reject(conn)
         end

--- a/lib/riptide_web/realtime/replication_channel.ex
+++ b/lib/riptide_web/realtime/replication_channel.ex
@@ -24,17 +24,17 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
   @impl true
   def join("replication:" <> stream_id, %{"after" => cursor}, socket) do
     case ResourceController.parse_stream_id(stream_id) do
-      {:ok, tenant_id, path_segments} ->
-        Logger.metadata(tenant_id: tenant_id)
+      {:ok, scope, path_segments} ->
+        maybe_log_tenant_metadata(scope)
         maybe_set_subject_metadata(socket.assigns.current_subject)
 
         case Riptide.Authz.evaluate(
-               tenant_id,
+               scope,
                path_segments,
                socket.assigns.current_subject,
                :read
              ) do
-          :allow -> check_new_stream_rate_limit(stream_id, cursor, socket)
+          :allow -> join_with_rate_limit(scope, stream_id, cursor, socket)
           _ -> {:error, %{"reason" => "unauthorized"}}
         end
 
@@ -59,6 +59,33 @@ defmodule RiptideWeb.Realtime.ReplicationChannel do
 
   defp maybe_set_subject_metadata(claims) do
     if sub = claims["sub"], do: Logger.metadata(subject: sub)
+  end
+
+  defp maybe_log_tenant_metadata({:tenant, tenant_id}), do: Logger.metadata(tenant_id: tenant_id)
+  defp maybe_log_tenant_metadata(:hub), do: :ok
+
+  # Hub-scoped reads are network-public (no tenant/authz ownership check
+  # narrows who can join), so — like RiptideWeb.Hub.DiscoveryController and
+  # RiptideWeb.Realtime.SseController.subscribe_with_rate_limit/3 — they get
+  # their own subject-keyed quota here. Tenant-scoped joins keep relying
+  # solely on RiptideWeb.Plugs.Authorize/Riptide.Authz for access control,
+  # unchanged.
+  defp join_with_rate_limit(:hub, stream_id, cursor, socket) do
+    case socket |> rate_limit_key() |> Riptide.HubRateLimit.check_read() do
+      :allow -> check_new_stream_rate_limit(stream_id, cursor, socket)
+      :deny -> {:error, %{"reason" => "rate_limited"}}
+    end
+  end
+
+  defp join_with_rate_limit({:tenant, _tenant_id}, stream_id, cursor, socket) do
+    check_new_stream_rate_limit(stream_id, cursor, socket)
+  end
+
+  defp rate_limit_key(socket) do
+    case socket.assigns.current_subject do
+      %{"sub" => sub} when is_binary(sub) -> sub
+      _ -> "anonymous"
+    end
   end
 
   # Joining before a stream's first write is intentional (a client watching

--- a/lib/riptide_web/realtime/sse_controller.ex
+++ b/lib/riptide_web/realtime/sse_controller.ex
@@ -10,11 +10,11 @@ defmodule RiptideWeb.Realtime.SseController do
 
   def subscribe(conn, %{"stream_id" => stream_id}) do
     case ResourceController.parse_stream_id(stream_id) do
-      {:ok, tenant_id, path_segments} ->
-        Logger.metadata(tenant_id: tenant_id)
+      {:ok, scope, path_segments} ->
+        maybe_log_tenant_metadata(scope)
 
-        case Riptide.Authz.evaluate(tenant_id, path_segments, conn.assigns.current_subject, :read) do
-          :allow -> do_subscribe(conn, stream_id)
+        case Riptide.Authz.evaluate(scope, path_segments, conn.assigns.current_subject, :read) do
+          :allow -> subscribe_with_rate_limit(conn, scope, stream_id)
           _ -> send_resp(conn, 403, "")
         end
 
@@ -37,6 +37,32 @@ defmodule RiptideWeb.Realtime.SseController do
     :exit, reason ->
       Logger.warning("SseController.subscribe/2 caught exit: #{inspect(reason)}")
       send_resp(conn, 503, "")
+  end
+
+  defp maybe_log_tenant_metadata({:tenant, tenant_id}), do: Logger.metadata(tenant_id: tenant_id)
+  defp maybe_log_tenant_metadata(:hub), do: :ok
+
+  # Hub-scoped reads are network-public (no tenant/authz ownership check
+  # narrows who can subscribe), so — like RiptideWeb.Hub.DiscoveryController
+  # — they get their own subject/IP-keyed quota here. Tenant-scoped reads
+  # keep relying solely on RiptideWeb.Plugs.Authorize/Riptide.Authz for
+  # access control, unchanged.
+  defp subscribe_with_rate_limit(conn, :hub, stream_id) do
+    case conn |> rate_limit_key() |> Riptide.HubRateLimit.check_read() do
+      :allow -> do_subscribe(conn, stream_id)
+      :deny -> send_resp(conn, 429, "")
+    end
+  end
+
+  defp subscribe_with_rate_limit(conn, {:tenant, _tenant_id}, stream_id) do
+    do_subscribe(conn, stream_id)
+  end
+
+  defp rate_limit_key(conn) do
+    case conn.assigns.current_subject do
+      %{"sub" => sub} when is_binary(sub) -> sub
+      _ -> conn.remote_ip |> :inet.ntoa() |> to_string()
+    end
   end
 
   defp do_subscribe(conn, stream_id) do

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -24,6 +24,10 @@ defmodule RiptideWeb.Router do
     plug RiptideWeb.Plugs.Authorize
   end
 
+  pipeline :resolve_hub_scope do
+    plug RiptideWeb.Plugs.ResolveHubScope
+  end
+
   scope "/" do
     pipe_through :api
 
@@ -42,6 +46,12 @@ defmodule RiptideWeb.Router do
 
     get "/search", RiptideWeb.Hub.DiscoveryController, :search
     get "/entries/:node_id", RiptideWeb.Hub.DiscoveryController, :show
+  end
+
+  scope "/hub" do
+    pipe_through [:api, :auth, :resolve_hub_scope, :authz]
+
+    get "/resources/*path", RiptideWeb.LDP.ResourceController, :show
   end
 
   scope "/tenants/:tenant_id" do

--- a/test/bench/core_bench_test.exs
+++ b/test/bench/core_bench_test.exs
@@ -121,7 +121,7 @@ defmodule Riptide.Bench.CoreBench do
           Placement.lookup(placement_stream_id)
         end,
         "Authz.evaluate/4 (single :public policy, depth-1 path)" => fn ->
-          Authz.evaluate(authz_tenant, ["doc"], nil, :read)
+          Authz.evaluate({:tenant, authz_tenant}, ["doc"], nil, :read)
         end
       },
       time: 3,

--- a/test/bench/http_server_test.exs
+++ b/test/bench/http_server_test.exs
@@ -70,7 +70,7 @@ defmodule Riptide.Bench.HttpServer do
         matcher: :public
       })
 
-    read_stream_id = ResourceController.stream_id_for(@tenant_id, [@read_path_segment])
+    read_stream_id = ResourceController.stream_id_for({:tenant, @tenant_id}, [@read_path_segment])
     :ok = StreamSupervisor.ensure_ready(read_stream_id)
 
     # A representative small-to-medium resource body (10 triples) for the

--- a/test/riptide/authz_test.exs
+++ b/test/riptide/authz_test.exs
@@ -44,7 +44,7 @@ defmodule Riptide.AuthzTest do
 
   test "denies when no policy matches at all (default-deny)" do
     FakeStore.start(%{})
-    assert Authz.evaluate("acme", ["docs"], %{"sub" => "user-1"}, :read) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], %{"sub" => "user-1"}, :read) == :deny
   end
 
   test "a :public matcher allows anyone, including anonymous, for the modes it lists" do
@@ -52,9 +52,9 @@ defmodule Riptide.AuthzTest do
       {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
     })
 
-    assert Authz.evaluate("acme", ["docs"], nil, :read) == :allow
-    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone"}, :read) == :allow
-    assert Authz.evaluate("acme", ["docs"], nil, :write) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :read) == :allow
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], %{"sub" => "someone"}, :read) == :allow
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :write) == :deny
   end
 
   test "an :authenticated matcher allows any non-nil subject but not anonymous" do
@@ -62,8 +62,8 @@ defmodule Riptide.AuthzTest do
       {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :authenticated}]
     })
 
-    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone"}, :read) == :allow
-    assert Authz.evaluate("acme", ["docs"], nil, :read) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], %{"sub" => "someone"}, :read) == :allow
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :read) == :deny
   end
 
   test "an {:agent, subject} matcher only allows that exact subject" do
@@ -73,8 +73,10 @@ defmodule Riptide.AuthzTest do
       ]
     })
 
-    assert Authz.evaluate("acme", ["docs"], %{"sub" => "owner"}, :write) == :allow
-    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone-else"}, :write) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], %{"sub" => "owner"}, :write) == :allow
+
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], %{"sub" => "someone-else"}, :write) ==
+             :deny
   end
 
   test "a policy only grants the modes it explicitly lists" do
@@ -82,8 +84,8 @@ defmodule Riptide.AuthzTest do
       {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
     })
 
-    assert Authz.evaluate("acme", ["docs"], nil, :read) == :allow
-    assert Authz.evaluate("acme", ["docs"], nil, :write) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :read) == :allow
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :write) == :deny
   end
 
   test "deny overrides allow when both match the same request" do
@@ -95,9 +97,9 @@ defmodule Riptide.AuthzTest do
     })
 
     # Anonymous: only the :public allow matches -> allow.
-    assert Authz.evaluate("acme", ["docs"], nil, :read) == :allow
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :read) == :allow
     # Authenticated: both the :public allow and the :authenticated deny match -> deny wins.
-    assert Authz.evaluate("acme", ["docs"], %{"sub" => "someone"}, :read) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], %{"sub" => "someone"}, :read) == :deny
   end
 
   test "a policy on an ancestor container is inherited by a deeper resource" do
@@ -105,7 +107,7 @@ defmodule Riptide.AuthzTest do
       {"acme", []} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
     })
 
-    assert Authz.evaluate("acme", ["docs", "sub", "deep"], nil, :read) == :allow
+    assert Authz.evaluate({:tenant, "acme"}, ["docs", "sub", "deep"], nil, :read) == :allow
   end
 
   test "a policy on a sibling path prefix does not apply to an unrelated resource" do
@@ -113,6 +115,17 @@ defmodule Riptide.AuthzTest do
       {"acme", ["other"]} => [%Policy{effect: :allow, modes: [:read], matcher: :public}]
     })
 
-    assert Authz.evaluate("acme", ["docs"], nil, :read) == :deny
+    assert Authz.evaluate({:tenant, "acme"}, ["docs"], nil, :read) == :deny
+  end
+
+  test "scope :hub always allows :read regardless of any policy" do
+    FakeStore.start(%{})
+    assert Authz.evaluate(:hub, ["catalog"], nil, :read) == :allow
+    assert Authz.evaluate(:hub, ["catalog"], %{"sub" => "someone"}, :read) == :allow
+  end
+
+  test "scope :hub always denies :write, never consulting the Store" do
+    FakeStore.start(%{})
+    assert Authz.evaluate(:hub, ["catalog"], %{"sub" => "someone"}, :write) == :deny
   end
 end

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -34,7 +34,7 @@ defmodule Riptide.Derivation.CatalogTest do
     end
 
     test "catalog_stream_id/1 for the Hub scope" do
-      assert Catalog.catalog_stream_id(:hub) == "https://riptide.example/hub/catalog"
+      assert Catalog.catalog_stream_id(:hub) == "https://riptide.example/hub/resources/catalog"
     end
 
     test "pending_review_stream_id/1 for a Tenant scope" do

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -96,6 +96,47 @@ defmodule Riptide.Derivation.CatalogTest do
     end
   end
 
+  describe "admit_capability/2 + supersede_capability/1" do
+    test "a superseded capability disappears from list_capabilities/0; admitting with replaces: writes the supersedes link" do
+      name = RDF.iri("urn:riptide:capability:supersede-cap-#{System.unique_integer([:positive])}")
+
+      old_entry = %Riptide.Derivation.CapabilityCatalogEntry{
+        name: name,
+        kind: :effect,
+        component_hash: String.duplicate("b", 64),
+        function: "run",
+        fuel_limit: 10_000_000,
+        timeout_ms: 5_000,
+        memory_limits: %{
+          max_memory_size: nil,
+          max_table_elements: nil,
+          max_instances: nil,
+          max_tables: nil
+        }
+      }
+
+      # Deliberately no on_exit cleanup — Catalog.capability_stream_id/0 is a
+      # single, shared, non-unique stream across the whole test suite (like
+      # :hub's own Rule catalog); see this file's own "Hub vs. Tenant scope
+      # isolation" test for why force-deleting it here would be unsafe
+      # (races any other test concurrently or subsequently writing to the
+      # same stream). This test's own `name` is already unique-suffixed and
+      # its assertions are scoped to just that name, so accumulation from
+      # other tests doesn't affect it.
+      :ok = Catalog.admit_capability(old_entry, nil)
+      {:ok, entries} = Catalog.list_capabilities()
+      {old_node, ^old_entry} = Enum.find(entries, fn {_n, e} -> e.name == name end)
+
+      new_entry = %{old_entry | function: "run_v2"}
+      :ok = Catalog.admit_capability(new_entry, old_node)
+      :ok = Catalog.supersede_capability(old_node)
+
+      {:ok, entries_after} = Catalog.list_capabilities()
+      matching = Enum.filter(entries_after, fn {_n, e} -> e.name == name end)
+      assert [{_node, ^new_entry}] = matching
+    end
+  end
+
   describe "queue_pending_review/2 + list_pending_reviews/1 — real round-trip" do
     test "a queued PendingReview is found live by list_pending_reviews/1" do
       scope = unique_tenant()

--- a/test/riptide/derivation/catalog_test.exs
+++ b/test/riptide/derivation/catalog_test.exs
@@ -236,10 +236,48 @@ defmodule Riptide.Derivation.CatalogTest do
         match_type: :exact_match
       }
 
-      :ok = Catalog.admit_crosswalk(crosswalk)
+      :ok = Catalog.admit_crosswalk(crosswalk, nil)
 
       assert {:ok, entries} = Catalog.list_crosswalks()
       assert Enum.any?(entries, fn {_node, entry} -> entry == crosswalk end)
+    end
+  end
+
+  describe "admit_crosswalk/2 + supersede_crosswalk/1" do
+    test "a superseded crosswalk disappears from list_crosswalks/0; admitting with replaces: writes the supersedes link" do
+      subject_predicate =
+        rel("supersede-crosswalk-subject-#{System.unique_integer([:positive])}")
+
+      old_crosswalk = %Crosswalk{
+        subject_predicate: subject_predicate,
+        object_predicate:
+          rel("crosswalktest-deploymentQueued#{System.unique_integer([:positive])}"),
+        match_type: :exact_match
+      }
+
+      # Deliberately no on_exit cleanup — Catalog.crosswalk_stream_id/0 is a
+      # single, shared, non-unique stream across the whole test suite; see
+      # this file's own "Hub vs. Tenant scope isolation" test for why
+      # force-deleting it here would be unsafe. This test's own
+      # `subject_predicate` is already unique-suffixed and its assertions
+      # are scoped to just that predicate, so accumulation from other tests
+      # doesn't affect it.
+      :ok = Catalog.admit_crosswalk(old_crosswalk, nil)
+      {:ok, entries} = Catalog.list_crosswalks()
+
+      {old_node, ^old_crosswalk} =
+        Enum.find(entries, fn {_n, c} -> c.subject_predicate == subject_predicate end)
+
+      new_crosswalk = %{old_crosswalk | match_type: :close_match}
+      :ok = Catalog.admit_crosswalk(new_crosswalk, old_node)
+      :ok = Catalog.supersede_crosswalk(old_node)
+
+      {:ok, entries_after} = Catalog.list_crosswalks()
+
+      matching =
+        Enum.filter(entries_after, fn {_n, c} -> c.subject_predicate == subject_predicate end)
+
+      assert [{_node, ^new_crosswalk}] = matching
     end
   end
 end

--- a/test/riptide/derivation/context_resolver_test.exs
+++ b/test/riptide/derivation/context_resolver_test.exs
@@ -43,7 +43,7 @@ defmodule Riptide.Derivation.ContextResolverTest do
     }
 
     review_scope = {:tenant, "ctxres-review-#{System.unique_integer([:positive])}"}
-    {:ok, node} = DedupGate.propose_capability(review_scope, entry)
+    {:ok, node} = DedupGate.propose_capability(review_scope, entry, nil)
     :ok = DedupGate.approve_capability_review(review_scope, node)
 
     on_exit(fn ->

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -708,7 +708,7 @@ defmodule Riptide.Derivation.DedupGateTest do
     end
   end
 
-  describe "propose_crosswalk/2 + approve_crosswalk_review/1 + decline_crosswalk_review/1" do
+  describe "propose_crosswalk/3 + approve_crosswalk_review/1 + decline_crosswalk_review/1" do
     test "a proposed Crosswalk is queued, then approval admits it to the Hub crosswalk catalog" do
       review_scope = unique_tenant()
 
@@ -722,7 +722,7 @@ defmodule Riptide.Derivation.DedupGateTest do
         match_type: :close_match
       }
 
-      assert {:ok, node} = DedupGate.propose_crosswalk(review_scope, crosswalk)
+      assert {:ok, node} = DedupGate.propose_crosswalk(review_scope, crosswalk, nil)
       assert :ok == DedupGate.approve_crosswalk_review(review_scope, node)
 
       assert {:ok, entries} = Catalog.list_crosswalks()
@@ -744,12 +744,75 @@ defmodule Riptide.Derivation.DedupGateTest do
         match_type: :broad_match
       }
 
-      {:ok, node} = DedupGate.propose_crosswalk(review_scope, crosswalk)
+      {:ok, node} = DedupGate.propose_crosswalk(review_scope, crosswalk, nil)
       assert :ok == DedupGate.decline_crosswalk_review(review_scope, node)
 
       assert {:ok, entries} = Catalog.list_crosswalks()
       refute Enum.any?(entries, fn {_n, c} -> c == crosswalk end)
     end
+  end
+
+  test "PendingCrosswalkReview.to_rdf/1 + from_rdf/2 round-trips a nil replaces" do
+    crosswalk = %Crosswalk{
+      subject_predicate: rel("crosswalkroundtrip-a#{System.unique_integer([:positive])}"),
+      object_predicate: rel("crosswalkroundtrip-b#{System.unique_integer([:positive])}"),
+      match_type: :exact_match
+    }
+
+    pending = %PendingCrosswalkReview{candidate: crosswalk, replaces: nil}
+    {node, graph} = PendingCrosswalkReview.to_rdf(pending)
+    assert PendingCrosswalkReview.from_rdf(node, graph) == pending
+  end
+
+  test "PendingCrosswalkReview.to_rdf/1 + from_rdf/2 round-trips a non-nil replaces" do
+    crosswalk = %Crosswalk{
+      subject_predicate: rel("crosswalkroundtrip-c#{System.unique_integer([:positive])}"),
+      object_predicate: rel("crosswalkroundtrip-d#{System.unique_integer([:positive])}"),
+      match_type: :exact_match
+    }
+
+    replaces_node = RDF.BlankNode.new()
+    pending = %PendingCrosswalkReview{candidate: crosswalk, replaces: replaces_node}
+    {node, graph} = PendingCrosswalkReview.to_rdf(pending)
+    assert PendingCrosswalkReview.from_rdf(node, graph) == pending
+  end
+
+  test "propose_crosswalk/3 + approve_crosswalk_review/2 with replaces: admits the new entry and supersedes the old one" do
+    review_scope = unique_tenant()
+
+    subject_predicate = rel("crosswalksupersede-#{System.unique_integer([:positive])}")
+
+    old_crosswalk = %Crosswalk{
+      subject_predicate: subject_predicate,
+      object_predicate: rel("crosswalksupersede-obj#{System.unique_integer([:positive])}"),
+      match_type: :exact_match
+    }
+
+    {:ok, old_review_node} = DedupGate.propose_crosswalk(review_scope, old_crosswalk, nil)
+    :ok = DedupGate.approve_crosswalk_review(review_scope, old_review_node)
+
+    # propose_crosswalk/3 returns the queued *review's* own node, not the
+    # catalog entry's node — the `replaces` argument on the next propose
+    # call needs the latter, so it's looked up from the catalog itself
+    # (mirrors the equivalent Capability-level test's own fix above).
+    {:ok, entries_before} = Catalog.list_crosswalks()
+
+    {old_catalog_node, ^old_crosswalk} =
+      Enum.find(entries_before, fn {_n, c} -> c.subject_predicate == subject_predicate end)
+
+    new_crosswalk = %{old_crosswalk | match_type: :close_match}
+
+    {:ok, review_node} =
+      DedupGate.propose_crosswalk(review_scope, new_crosswalk, old_catalog_node)
+
+    :ok = DedupGate.approve_crosswalk_review(review_scope, review_node)
+
+    {:ok, entries} = Catalog.list_crosswalks()
+
+    matching =
+      Enum.filter(entries, fn {_n, c} -> c.subject_predicate == subject_predicate end)
+
+    assert [{_node, ^new_crosswalk}] = matching
   end
 
   describe "PendingCapabilityReview round-trip" do

--- a/test/riptide/derivation/dedup_gate_test.exs
+++ b/test/riptide/derivation/dedup_gate_test.exs
@@ -768,7 +768,7 @@ defmodule Riptide.Derivation.DedupGateTest do
     end
   end
 
-  describe "propose_capability/2 + approve_capability_review/2 + decline_capability_review/2" do
+  describe "propose_capability/3 + approve_capability_review/2 + decline_capability_review/2" do
     test "a proposed Capability is queued, then approval admits it to the Hub capability catalog" do
       review_scope = unique_tenant()
 
@@ -778,7 +778,7 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       entry = sample_capability(%{})
 
-      assert {:ok, node} = DedupGate.propose_capability(review_scope, entry)
+      assert {:ok, node} = DedupGate.propose_capability(review_scope, entry, nil)
       assert :ok == DedupGate.approve_capability_review(review_scope, node)
 
       assert {:ok, entries} = Catalog.list_capabilities()
@@ -796,11 +796,52 @@ defmodule Riptide.Derivation.DedupGateTest do
 
       entry = sample_capability(%{})
 
-      {:ok, node} = DedupGate.propose_capability(review_scope, entry)
+      {:ok, node} = DedupGate.propose_capability(review_scope, entry, nil)
       assert :ok == DedupGate.decline_capability_review(review_scope, node)
 
       assert {:ok, entries} = Catalog.list_capabilities()
       refute Enum.any?(entries, fn {_n, e} -> e == entry end)
     end
+  end
+
+  test "PendingCapabilityReview.to_rdf/1 + from_rdf/2 round-trips a nil replaces" do
+    entry = sample_capability(%{})
+    pending = %PendingCapabilityReview{candidate: entry, replaces: nil}
+    {node, graph} = PendingCapabilityReview.to_rdf(pending)
+    assert PendingCapabilityReview.from_rdf(node, graph) == pending
+  end
+
+  test "PendingCapabilityReview.to_rdf/1 + from_rdf/2 round-trips a non-nil replaces" do
+    entry = sample_capability(%{})
+    replaces_node = RDF.BlankNode.new()
+    pending = %PendingCapabilityReview{candidate: entry, replaces: replaces_node}
+    {node, graph} = PendingCapabilityReview.to_rdf(pending)
+    assert PendingCapabilityReview.from_rdf(node, graph) == pending
+  end
+
+  test "propose_capability/3 + approve_capability_review/2 with replaces: admits the new entry and supersedes the old one" do
+    review_scope = unique_tenant()
+    old_entry = sample_capability(%{})
+
+    {:ok, old_review_node} = DedupGate.propose_capability(review_scope, old_entry, nil)
+    :ok = DedupGate.approve_capability_review(review_scope, old_review_node)
+
+    # `propose_capability/3` returns the queued *review's* own node, not the
+    # catalog entry's node — the `replaces` argument on the next propose
+    # call needs the latter, so it's looked up from the catalog itself, the
+    # same way the Catalog-level "admit_capability/2 + supersede_capability/1"
+    # test above does.
+    {:ok, entries_before} = Catalog.list_capabilities()
+
+    {old_catalog_node, ^old_entry} =
+      Enum.find(entries_before, fn {_n, e} -> e.name == old_entry.name end)
+
+    new_entry = %{old_entry | function: "run_v2"}
+    {:ok, review_node} = DedupGate.propose_capability(review_scope, new_entry, old_catalog_node)
+    :ok = DedupGate.approve_capability_review(review_scope, review_node)
+
+    {:ok, entries} = Catalog.list_capabilities()
+    matching = Enum.filter(entries, fn {_n, e} -> e.name == new_entry.name end)
+    assert [{_node, ^new_entry}] = matching
   end
 end

--- a/test/riptide/derivation/install_test.exs
+++ b/test/riptide/derivation/install_test.exs
@@ -124,7 +124,7 @@ defmodule Riptide.Derivation.InstallTest do
         match_type: :exact_match
       }
 
-      :ok = Catalog.admit_crosswalk(crosswalk)
+      :ok = Catalog.admit_crosswalk(crosswalk, nil)
       {:ok, crosswalks} = Catalog.list_crosswalks()
       {crosswalk_node, ^crosswalk} = Enum.find(crosswalks, fn {_node, c} -> c == crosswalk end)
 

--- a/test/riptide/derivation/job_trigger_cluster_test.exs
+++ b/test/riptide/derivation/job_trigger_cluster_test.exs
@@ -48,7 +48,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
       }
     }
 
-    :ok = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :admit_capability, [entry])
+    :ok = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :admit_capability, [entry, nil])
 
     # Capability.invoke/4 goes through the real, default-deny authz store
     # (Riptide.Authz.Store.Placement) unconditionally — no FakeStore swap
@@ -208,7 +208,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
       }
     }
 
-    :ok = :erpc.call(node_a, Riptide.Derivation.Catalog, :admit_capability, [entry])
+    :ok = :erpc.call(node_a, Riptide.Derivation.Catalog, :admit_capability, [entry, nil])
 
     local_name = cap_name |> RDF.IRI.to_string() |> String.trim_leading("urn:riptide:capability:")
 
@@ -313,7 +313,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
       }
     }
 
-    :ok = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :admit_capability, [entry])
+    :ok = :erpc.call(hd_node(peers), Riptide.Derivation.Catalog, :admit_capability, [entry, nil])
 
     local_name = cap_name |> RDF.IRI.to_string() |> String.trim_leading("urn:riptide:capability:")
 

--- a/test/riptide_web/authz/policy_controller_test.exs
+++ b/test/riptide_web/authz/policy_controller_test.exs
@@ -139,7 +139,7 @@ defmodule RiptideWeb.Authz.PolicyControllerTest do
 
     on_exit(fn ->
       Riptide.RaTestHelpers.cleanup_stream(
-        ResourceController.stream_id_for(tenant_id, ["shared-doc"])
+        ResourceController.stream_id_for({:tenant, tenant_id}, ["shared-doc"])
       )
     end)
 

--- a/test/riptide_web/hub/capability_controller_test.exs
+++ b/test/riptide_web/hub/capability_controller_test.exs
@@ -121,4 +121,73 @@ defmodule RiptideWeb.Hub.CapabilityControllerTest do
     assert {:ok, entries} = Catalog.list_capabilities()
     refute Enum.any?(entries, fn {_n, e} -> e.name == RDF.iri(name) end)
   end
+
+  test "proposing a Capability with replaces: admits the new version and supersedes the old one" do
+    tenant_id = "capability-replaces-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    name = "urn:riptide:capability:httpcapreplaces-#{System.unique_integer([:positive])}"
+
+    base_body = %{
+      "name" => name,
+      "kind" => "effect",
+      "function" => "run",
+      "fuel_limit" => 10_000_000,
+      "timeout_ms" => 5_000,
+      "memory_limits" => %{
+        "max_memory_size" => nil,
+        "max_table_elements" => nil,
+        "max_instances" => nil,
+        "max_tables" => nil
+      },
+      "component_bytes" => Base.encode64(:crypto.strong_rand_bytes(64))
+    }
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", Jason.encode!(base_body))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    old_node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{old_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    {:ok, entries_before} = Catalog.list_capabilities()
+    {old_hub_node, _entry} = Enum.find(entries_before, fn {_n, e} -> e.name == RDF.iri(name) end)
+
+    replaces_body = Map.put(base_body, "replaces", RDF.BlankNode.value(old_hub_node))
+
+    propose_replacement_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", Jason.encode!(replaces_body))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    new_node_id = Jason.decode!(propose_replacement_conn.resp_body)["node_id"]
+
+    approve_replacement_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{new_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_replacement_conn.status == 200
+
+    {:ok, entries_after} = Catalog.list_capabilities()
+    matching = Enum.filter(entries_after, fn {_n, e} -> e.name == RDF.iri(name) end)
+    assert length(matching) == 1
+  end
 end

--- a/test/riptide_web/hub/crosswalk_controller_test.exs
+++ b/test/riptide_web/hub/crosswalk_controller_test.exs
@@ -70,4 +70,73 @@ defmodule RiptideWeb.Hub.CrosswalkControllerTest do
              c.subject_predicate == RDF.iri(subject) and c.object_predicate == RDF.iri(object)
            end)
   end
+
+  test "proposing a Crosswalk with replaces: admits the new version and supersedes the old one" do
+    tenant_id = "crosswalk-replaces-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    subject = rel("crosswalkhttpreplaces-#{System.unique_integer([:positive])}")
+    object = rel("crosswalkhttpreplaces-obj#{System.unique_integer([:positive])}")
+
+    base_body = %{
+      "subject_predicate" => subject,
+      "object_predicate" => object,
+      "match_type" => "exact_match"
+    }
+
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/crosswalks", Jason.encode!(base_body))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    old_node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/crosswalk-reviews/#{old_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    {:ok, entries_before} = Catalog.list_crosswalks()
+
+    {old_hub_node, _entry} =
+      Enum.find(entries_before, fn {_n, c} -> c.subject_predicate == RDF.iri(subject) end)
+
+    replaces_body =
+      base_body
+      |> Map.put("match_type", "close_match")
+      |> Map.put("replaces", RDF.BlankNode.value(old_hub_node))
+
+    propose_replacement_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/crosswalks", Jason.encode!(replaces_body))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    new_node_id = Jason.decode!(propose_replacement_conn.resp_body)["node_id"]
+
+    approve_replacement_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/crosswalk-reviews/#{new_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_replacement_conn.status == 200
+
+    {:ok, entries_after} = Catalog.list_crosswalks()
+
+    matching =
+      Enum.filter(entries_after, fn {_n, c} -> c.subject_predicate == RDF.iri(subject) end)
+
+    assert length(matching) == 1
+  end
 end

--- a/test/riptide_web/hub_resource_lifecycle_capstone_test.exs
+++ b/test/riptide_web/hub_resource_lifecycle_capstone_test.exs
@@ -1,0 +1,107 @@
+defmodule RiptideWeb.HubResourceLifecycleCapstoneTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.Catalog
+  alias Riptide.Stream.StreamServer
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  test "exit criterion: propose -> approve -> live-readable via GET /hub/resources -> propose-with-replaces -> approve -> only the new version live" do
+    tenant_id = "hub-lifecycle-capstone-" <> Uniq.UUID.uuid4()
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.pending_review_stream_id({:tenant, tenant_id}))
+    end)
+
+    name = "urn:riptide:capability:capstone-qr-#{System.unique_integer([:positive])}"
+
+    body = %{
+      "name" => name,
+      "kind" => "effect",
+      "function" => "generate",
+      "fuel_limit" => 10_000_000,
+      "timeout_ms" => 5_000,
+      "memory_limits" => %{
+        "max_memory_size" => nil,
+        "max_table_elements" => nil,
+        "max_instances" => nil,
+        "max_tables" => nil
+      },
+      "component_bytes" => Base.encode64(:crypto.strong_rand_bytes(64))
+    }
+
+    # 1. Propose + approve, exactly as today.
+    propose_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", Jason.encode!(body))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    node_id = Jason.decode!(propose_conn.resp_body)["node_id"]
+
+    approve_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_conn.status == 200
+
+    # 2. Live-readable via the NEW generic Hub surface — this is the actual exit criterion, not
+    # just Catalog.list_capabilities/0 (a library call, not a public surface).
+    read_conn =
+      :get |> conn("/hub/resources/catalog/capabilities") |> RiptideWeb.Endpoint.call(@opts)
+
+    assert read_conn.status == 200
+    assert read_conn.resp_body =~ name
+
+    {:ok, entries} = Catalog.list_capabilities()
+    {old_node, _entry} = Enum.find(entries, fn {_n, e} -> e.name == RDF.iri(name) end)
+
+    # 3. Propose a replacement, approve it.
+    replaces_body = Map.put(body, "replaces", RDF.BlankNode.value(old_node))
+
+    propose_replacement_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capabilities", Jason.encode!(replaces_body))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    new_node_id = Jason.decode!(propose_replacement_conn.resp_body)["node_id"]
+
+    approve_replacement_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/hub/capability-reviews/#{new_node_id}/approve")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert approve_replacement_conn.status == 200
+
+    # 4. Only the new version is live — full history preserved underneath, never hard-deleted.
+    {:ok, entries_after} = Catalog.list_capabilities()
+    matching = Enum.filter(entries_after, fn {_n, e} -> e.name == RDF.iri(name) end)
+    assert length(matching) == 1
+
+    stream_id = Catalog.capability_stream_id()
+    {:ok, all_events} = StreamServer.get_since(stream_id, 0)
+    assert length(all_events) >= 2
+  end
+end

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -6,6 +6,7 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
   import ExUnit.CaptureLog
 
   alias Riptide.Authz.{Policy, Store}
+  alias Riptide.Derivation.{CapabilityCatalogEntry, Catalog}
   alias RiptideWeb.LDP.ResourceController
 
   @opts RiptideWeb.Endpoint.init([])
@@ -422,20 +423,73 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
   end
 
   describe "stream_id_for/2 and parse_stream_id/1" do
-    test "parse_stream_id/1 recovers the exact tenant_id and path_segments stream_id_for/2 was built from" do
-      stream_id = ResourceController.stream_id_for("acme", ["docs", "sub"])
-      assert ResourceController.parse_stream_id(stream_id) == {:ok, "acme", ["docs", "sub"]}
+    test "parse_stream_id/1 recovers the exact scope and path_segments stream_id_for/2 was built from" do
+      stream_id = ResourceController.stream_id_for({:tenant, "acme"}, ["docs", "sub"])
+
+      assert ResourceController.parse_stream_id(stream_id) ==
+               {:ok, {:tenant, "acme"}, ["docs", "sub"]}
     end
 
-    test "parse_stream_id/1 round-trips for a single-segment path" do
-      stream_id = ResourceController.stream_id_for("acme", ["doc"])
-      assert ResourceController.parse_stream_id(stream_id) == {:ok, "acme", ["doc"]}
+    test "parse_stream_id/1 round-trips for a single-segment Tenant path" do
+      stream_id = ResourceController.stream_id_for({:tenant, "acme"}, ["doc"])
+      assert ResourceController.parse_stream_id(stream_id) == {:ok, {:tenant, "acme"}, ["doc"]}
     end
 
-    test "parse_stream_id/1 returns :error for a stream_id not shaped like a tenant resource" do
+    test "parse_stream_id/1 round-trips for a Hub path" do
+      stream_id = ResourceController.stream_id_for(:hub, ["catalog"])
+      assert ResourceController.parse_stream_id(stream_id) == {:ok, :hub, ["catalog"]}
+    end
+
+    test "parse_stream_id/1 round-trips for a nested Hub path" do
+      stream_id = ResourceController.stream_id_for(:hub, ["catalog", "capabilities"])
+
+      assert ResourceController.parse_stream_id(stream_id) ==
+               {:ok, :hub, ["catalog", "capabilities"]}
+    end
+
+    test "parse_stream_id/1 returns :error for a stream_id not shaped like a Tenant or Hub resource" do
       assert ResourceController.parse_stream_id("not-a-real-stream-id") == :error
       assert ResourceController.parse_stream_id("https://riptide.example/health") == :error
     end
+  end
+
+  test "GET /hub/resources/*path for a never-written Hub resource returns 404" do
+    conn =
+      :get
+      |> conn("/hub/resources/never-written-#{System.unique_integer([:positive])}")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 404
+  end
+
+  test "GET /hub/resources/*path returns the current state of an admitted Hub Capability" do
+    name = "urn:riptide:capability:hubread-#{System.unique_integer([:positive])}"
+
+    entry = %CapabilityCatalogEntry{
+      name: RDF.iri(name),
+      kind: :effect,
+      component_hash: String.duplicate("b", 64),
+      function: "run",
+      fuel_limit: 10_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    # `admit_capability/1` here, not `/2` — Task 6 of this same plan
+    # (docs/superpowers/plans/2026-09-01-phase-6n-hub-resource-lifecycle.md)
+    # hasn't landed yet at this point in the sequence and will change this
+    # to /2 (gaining a `replaces` param); when it does, this call site needs
+    # the same update every other `admit_capability/1` caller gets.
+    :ok = Catalog.admit_capability(entry)
+
+    conn = :get |> conn("/hub/resources/catalog/capabilities") |> RiptideWeb.Endpoint.call(@opts)
+    assert conn.status == 200
+    assert conn.resp_body =~ name
   end
 
   test "a %2F-encoded slash inside the tenant_id path segment is rejected with 400, not silently aliased" do

--- a/test/riptide_web/ldp/resource_controller_test.exs
+++ b/test/riptide_web/ldp/resource_controller_test.exs
@@ -485,7 +485,7 @@ defmodule RiptideWeb.LDP.ResourceControllerTest do
     # hasn't landed yet at this point in the sequence and will change this
     # to /2 (gaining a `replaces` param); when it does, this call site needs
     # the same update every other `admit_capability/1` caller gets.
-    :ok = Catalog.admit_capability(entry)
+    :ok = Catalog.admit_capability(entry, nil)
 
     conn = :get |> conn("/hub/resources/catalog/capabilities") |> RiptideWeb.Endpoint.call(@opts)
     assert conn.status == 200

--- a/test/riptide_web/plugs/authorize_test.exs
+++ b/test/riptide_web/plugs/authorize_test.exs
@@ -32,6 +32,7 @@ defmodule RiptideWeb.Plugs.AuthorizeTest do
     |> conn("/tenants/#{tenant_id}/resources/" <> Enum.join(path_segments, "/"))
     |> Map.update!(:params, &Map.put(&1, "path", path_segments))
     |> assign(:tenant_id, tenant_id)
+    |> assign(:scope, {:tenant, tenant_id})
     |> assign(:current_subject, current_subject)
   end
 

--- a/test/riptide_web/plugs/resolve_hub_scope_test.exs
+++ b/test/riptide_web/plugs/resolve_hub_scope_test.exs
@@ -1,0 +1,13 @@
+defmodule RiptideWeb.Plugs.ResolveHubScopeTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias RiptideWeb.Plugs.ResolveHubScope
+
+  test "assigns conn.assigns.scope = :hub unconditionally" do
+    conn = conn(:get, "/hub/resources/catalog")
+    conn = ResolveHubScope.call(conn, ResolveHubScope.init([]))
+
+    assert conn.assigns.scope == :hub
+  end
+end

--- a/test/riptide_web/realtime/replication_channel_test.exs
+++ b/test/riptide_web/realtime/replication_channel_test.exs
@@ -264,6 +264,52 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
     assert Logger.metadata()[:subject] == "user-1"
   end
 
+  test "joining a Hub-shaped topic succeeds for an admitted Hub resource" do
+    name = "urn:riptide:capability:wshub-#{System.unique_integer([:positive])}"
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: RDF.iri(name),
+      kind: :effect,
+      component_hash: String.duplicate("b", 64),
+      function: "run",
+      fuel_limit: 10_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    # `admit_capability/1` here, not `/2` — Task 6 of this same plan
+    # (docs/superpowers/plans/2026-09-01-phase-6n-hub-resource-lifecycle.md)
+    # hasn't landed yet at this point in the sequence. Deliberately no
+    # on_exit cleanup either — see sse_controller_test.exs's identical new
+    # test for why (shared, non-unique Hub stream).
+    :ok = Riptide.Derivation.Catalog.admit_capability(entry)
+
+    stream_id = "https://riptide.example/hub/resources/catalog/capabilities"
+    {:ok, socket} = connect(Socket, %{})
+
+    assert {:ok, _reply, _socket} =
+             subscribe_and_join(socket, ReplicationChannel, "replication:" <> stream_id, %{
+               "after" => 0
+             })
+  end
+
+  test "joining a Hub-shaped topic is rate-limited" do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :hub_read_rate_limit, 0)
+
+    stream_id = "https://riptide.example/hub/resources/catalog"
+    {:ok, socket} = connect(Socket, %{})
+
+    assert {:error, %{"reason" => "rate_limited"}} =
+             subscribe_and_join(socket, ReplicationChannel, "replication:" <> stream_id, %{
+               "after" => 0
+             })
+  end
+
   describe "new-stream rate limiting (atom-exhaustion guard)" do
     setup do
       Riptide.AppEnvTestHelpers.put_env(:riptide, :new_stream_rate_limit, 2)

--- a/test/riptide_web/realtime/replication_channel_test.exs
+++ b/test/riptide_web/realtime/replication_channel_test.exs
@@ -51,7 +51,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   # call — mirrors `sse_controller_test.exs`'s `unique_stream_id/0`.
   defp unique_stream_id,
     do:
-      ResourceController.stream_id_for("ws-test-tenant", [
+      ResourceController.stream_id_for({:tenant, "ws-test-tenant"}, [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -189,7 +189,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
 
   test "joining a topic shaped like a tenant resource with no matching policy is denied, not crashed" do
     tenant_id = "ws-authz-test-" <> Uniq.UUID.uuid4()
-    stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+    stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["doc"])
 
     {:ok, socket} = connect(Socket, %{})
 
@@ -201,7 +201,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
 
   test "joining a topic shaped like a tenant resource with a public read policy succeeds" do
     tenant_id = "ws-authz-test-" <> Uniq.UUID.uuid4()
-    stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+    stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["doc"])
     on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
 
     :ok =
@@ -278,7 +278,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
     end
 
     defp new_ratelimit_stream_id do
-      ResourceController.stream_id_for("ws-ratelimit-test-tenant", [
+      ResourceController.stream_id_for({:tenant, "ws-ratelimit-test-tenant"}, [
         "doc-#{System.unique_integer([:positive])}"
       ])
     end

--- a/test/riptide_web/realtime/replication_channel_test.exs
+++ b/test/riptide_web/realtime/replication_channel_test.exs
@@ -9,6 +9,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   require Logger
 
   alias Riptide.Authz.{Policy, Store}
+  alias Riptide.Derivation.{CapabilityCatalogEntry, Catalog}
   alias Riptide.Event
   alias Riptide.RDF.Patch
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
@@ -267,7 +268,7 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
   test "joining a Hub-shaped topic succeeds for an admitted Hub resource" do
     name = "urn:riptide:capability:wshub-#{System.unique_integer([:positive])}"
 
-    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+    entry = %CapabilityCatalogEntry{
       name: RDF.iri(name),
       kind: :effect,
       component_hash: String.duplicate("b", 64),
@@ -282,12 +283,9 @@ defmodule RiptideWeb.Realtime.ReplicationChannelTest do
       }
     }
 
-    # `admit_capability/1` here, not `/2` — Task 6 of this same plan
-    # (docs/superpowers/plans/2026-09-01-phase-6n-hub-resource-lifecycle.md)
-    # hasn't landed yet at this point in the sequence. Deliberately no
-    # on_exit cleanup either — see sse_controller_test.exs's identical new
-    # test for why (shared, non-unique Hub stream).
-    :ok = Riptide.Derivation.Catalog.admit_capability(entry)
+    # Deliberately no on_exit cleanup — see sse_controller_test.exs's
+    # identical new test for why (shared, non-unique Hub stream).
+    :ok = Catalog.admit_capability(entry, nil)
 
     stream_id = "https://riptide.example/hub/resources/catalog/capabilities"
     {:ok, socket} = connect(Socket, %{})

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -5,6 +5,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   require Logger
 
   alias Riptide.Authz.{Policy, Store}
+  alias Riptide.Derivation.{CapabilityCatalogEntry, Catalog}
   alias Riptide.Event
   alias Riptide.Stream.{StreamServer, StreamSupervisor}
   alias RiptideWeb.LDP.ResourceController
@@ -342,7 +343,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
     test "subscribing to a Hub-shaped stream_id succeeds for an admitted Hub resource" do
       name = "urn:riptide:capability:ssehub-#{System.unique_integer([:positive])}"
 
-      entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      entry = %CapabilityCatalogEntry{
         name: RDF.iri(name),
         kind: :effect,
         component_hash: String.duplicate("b", 64),
@@ -357,10 +358,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
         }
       }
 
-      # `admit_capability/1` here, not `/2` — Task 6 of this same plan
-      # (docs/superpowers/plans/2026-09-01-phase-6n-hub-resource-lifecycle.md)
-      # hasn't landed yet at this point in the sequence.
-      :ok = Riptide.Derivation.Catalog.admit_capability(entry)
+      :ok = Catalog.admit_capability(entry, nil)
 
       # Deliberately no on_exit cleanup — the capability stream is a single,
       # shared, non-unique stream across the whole test suite; see

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -338,6 +338,53 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
       assert conn.status == 503
     end
+
+    test "subscribing to a Hub-shaped stream_id succeeds for an admitted Hub resource" do
+      name = "urn:riptide:capability:ssehub-#{System.unique_integer([:positive])}"
+
+      entry = %Riptide.Derivation.CapabilityCatalogEntry{
+        name: RDF.iri(name),
+        kind: :effect,
+        component_hash: String.duplicate("b", 64),
+        function: "run",
+        fuel_limit: 10_000_000,
+        timeout_ms: 5_000,
+        memory_limits: %{
+          max_memory_size: nil,
+          max_table_elements: nil,
+          max_instances: nil,
+          max_tables: nil
+        }
+      }
+
+      # `admit_capability/1` here, not `/2` — Task 6 of this same plan
+      # (docs/superpowers/plans/2026-09-01-phase-6n-hub-resource-lifecycle.md)
+      # hasn't landed yet at this point in the sequence.
+      :ok = Riptide.Derivation.Catalog.admit_capability(entry)
+
+      # Deliberately no on_exit cleanup — the capability stream is a single,
+      # shared, non-unique stream across the whole test suite; see
+      # catalog_test.exs's own "Hub vs. Tenant scope isolation" test for why
+      # force-deleting it here would be unsafe. This test's own name is
+      # already unique-suffixed.
+      stream_id = "https://riptide.example/hub/resources/catalog/capabilities"
+      path = "/streams/#{URI.encode_www_form(stream_id)}/subscribe"
+
+      conn = :get |> conn(path) |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 200
+    end
+
+    test "subscribing to a Hub-shaped stream_id is rate-limited" do
+      Riptide.AppEnvTestHelpers.put_env(:riptide, :hub_read_rate_limit, 0)
+
+      stream_id = "https://riptide.example/hub/resources/catalog"
+      path = "/streams/#{URI.encode_www_form(stream_id)}/subscribe"
+
+      conn = :get |> conn(path) |> RiptideWeb.Endpoint.call(@opts)
+
+      assert conn.status == 429
+    end
   end
 
   defp eventually(fun, attempts_left \\ 50) do

--- a/test/riptide_web/realtime/sse_controller_test.exs
+++ b/test/riptide_web/realtime/sse_controller_test.exs
@@ -39,7 +39,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
   defp unique_stream_id,
     do:
-      ResourceController.stream_id_for("sse-test-tenant", [
+      ResourceController.stream_id_for({:tenant, "sse-test-tenant"}, [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -51,7 +51,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   # "authentication" describe block's own `setup` below.
   defp unique_auth_stream_id,
     do:
-      ResourceController.stream_id_for("sse-auth-test-tenant", [
+      ResourceController.stream_id_for({:tenant, "sse-auth-test-tenant"}, [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -86,7 +86,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
   test "subscribing with a cursor older than the retention window returns 409 with a gap signal" do
     stream_id =
-      ResourceController.stream_id_for("sse-gap-test-tenant", [
+      ResourceController.stream_id_for({:tenant, "sse-gap-test-tenant"}, [
         "doc-#{System.unique_integer([:positive])}"
       ])
 
@@ -183,7 +183,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
     end
 
     defp new_ratelimit_stream_id do
-      ResourceController.stream_id_for("sse-ratelimit-test-tenant", [
+      ResourceController.stream_id_for({:tenant, "sse-ratelimit-test-tenant"}, [
         "doc-#{System.unique_integer([:positive])}"
       ])
     end
@@ -265,7 +265,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
   describe "authorization" do
     test "subscribing to a stream_id shaped like a tenant resource with no matching policy is denied with 403" do
       tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
-      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+      stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["doc"])
 
       conn =
         :get
@@ -277,7 +277,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
     test "subscribing to a stream_id shaped like a tenant resource with a public read policy succeeds" do
       tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
-      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+      stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["doc"])
       on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(stream_id) end)
 
       :ok =
@@ -308,7 +308,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
 
     test "sets tenant_id in Logger metadata even when authorization denies the request" do
       tenant_id = "sse-authz-test-" <> Uniq.UUID.uuid4()
-      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+      stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["doc"])
 
       conn =
         :get
@@ -329,7 +329,7 @@ defmodule RiptideWeb.Realtime.SseControllerTest do
       ])
 
       tenant_id = "sse-authz-down-test-" <> Uniq.UUID.uuid4()
-      stream_id = ResourceController.stream_id_for(tenant_id, ["doc"])
+      stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["doc"])
 
       conn =
         :get

--- a/test/riptide_web/task_controller_test.exs
+++ b/test/riptide_web/task_controller_test.exs
@@ -59,7 +59,7 @@ defmodule RiptideWeb.TaskControllerTest do
       }
     }
 
-    :ok = Catalog.admit_capability(entry)
+    :ok = Catalog.admit_capability(entry, nil)
 
     :ok =
       Riptide.Placement.add_policy(

--- a/test/riptide_web/tenant_execution_surface_capstone_test.exs
+++ b/test/riptide_web/tenant_execution_surface_capstone_test.exs
@@ -57,7 +57,7 @@ defmodule RiptideWeb.TenantExecutionSurfaceCapstoneTest do
       }
     }
 
-    :ok = Catalog.admit_capability(entry)
+    :ok = Catalog.admit_capability(entry, nil)
 
     :ok =
       Riptide.Placement.add_policy(


### PR DESCRIPTION
## Summary
- Generalizes Riptide.Derivation.Catalog's existing scope() abstraction through the HTTP layer — Authz.evaluate/4, ResourceController's addressing, SseController, ReplicationChannel — giving Hub a generic read+watch surface (GET /hub/resources/*path) for the first time.
- Capability and Crosswalk gain the same supersede/replaces lifecycle Rules already have via Catalog.supersede_entry/2 — full history preserved, nothing hard-deleted.
- Capstone test proves the full exit criterion: propose -> approve -> live-readable via the new generic Hub surface -> propose-with-replaces -> approve -> only the new version live.

Spec: `docs/superpowers/specs/2026-09-01-phase-6n-hub-resource-lifecycle-design.md` (PR #124).

## Test plan
- [x] `mix test` — full suite green (581 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` — clean
- [ ] CI green on the PR