### PR TITLE
Draft: Resolve: "6o — Username/Password Authentication"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l, 6d-ii, 6m, 6n shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering; concurrent-effects design spike; Tenant-Scoped Execution Surface; Hub Resource Lifecycle) — see issue #58 for the current remaining list (6o demo, 6g-ii, 6c-iii-a/b, Capability grant/OAuth), see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l, 6d-ii, 6m, 6n, 6o shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering; concurrent-effects design spike; Tenant-Scoped Execution Surface; Hub Resource Lifecycle; Username/Password Authentication) — see issue #58 for the current remaining list (6p demo, 6g-ii, 6c-iii-a/b, Capability grant/OAuth), see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -1411,5 +1411,64 @@ the touched test files**:
    the HTTP-level test both already used correctly).
 
 **Status**: Phase 6n shipped 2026-09-01. See issue #58's own restated summary for the current
-remaining list (6o — the demo itself, pushed out from 6n's original scope — plus 6g-ii deferred,
-6c-iii-a/6c-iii-b Track B, and Capability grant flow/OAuth Track A, all ready to start).
+remaining list at the time (6o — the demo itself, pushed out from 6n's original scope — plus 6g-ii
+deferred, 6c-iii-a/6c-iii-b Track B, and Capability grant flow/OAuth Track A, all ready to start).
+6o itself was reassigned during the very next phase's own brainstorm — see below.
+
+### 6o — Username/Password Authentication
+
+**Shipped 2026-09-01** — see
+`docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`. Direct origin:
+brainstorming what was originally slotted as "6o, the demo" surfaced that the demo's own bootstrap step
+— an unauthenticated browser page proving an identity against a genuinely fresh, real Riptide instance
+— can't assume a random visitor already has an OIDC server of their own, which Riptide's only existing
+identity mechanism (`Riptide.Auth.Verifier.OIDC`) requires. Rather than bolt a demo-only auth hack onto
+6p (the demo itself, pushed back one more letter), a real username/password mechanism — independently
+useful for any Riptide deployment, not just the demo — got its own phase.
+
+**Core architectural finding, reached through several rounds of pushback during brainstorming**:
+accounts are ordinary, individually-addressable Tenant-scoped resources — one stream per account,
+addressed exactly the same way any other Tenant resource already is
+(`stream_id_for({:tenant, tenant_id}, ["accounts", username])`) — not a new storage engine and not a
+global cross-tenant "system" tenant. A global accounts tenant was seriously considered and explicitly
+rejected: investigation confirmed Riptide's own "a Tenant should be trivially movable to a different
+instance, no structural ties" principle doesn't fully hold today (the placement Ra cluster comingles
+every Tenant's Authz policies in one instance-wide structure; Hub is explicitly, deliberately
+instance-scoped, with federation named and deferred in the master design doc) — but a global accounts
+store would have been a *worse* kind of exception than either existing one, since it's specifically the
+ability to log in at all, not just some non-critical data, that would stay behind on the origin
+instance if a Tenant ever moved. Scoping accounts per-Tenant avoids introducing that new failure mode
+entirely, and — the actual payoff — makes "one Tenant, many users" fall out for free: adding a second
+account to an already-claimed Tenant needs zero new code, it's just an ordinary write through the
+*existing* generic `PUT /tenants/:id/resources/*path` route, by whoever already has write access.
+Having an account is a separate concern from being *authorized* on that Tenant's own resources, though
+— an account alone grants nothing; a real deployment still needs an explicit `POST
+/tenants/:id/policies` grant (Phase 4c, already built) for a second user to do anything, which the
+capstone test below exercises explicitly after an earlier draft of both the spec's own worked example
+and the capstone test itself missed this and asserted Bob could read Guild-A's resources right after
+signing up, with no grant at all — caught only once the capstone actually ran and got `403`.
+
+New surface: `POST /auth/signup` and `POST /auth/login`, both deliberately anonymous (no
+`Authenticate`/`Authorize` pipeline — there is no token yet to check, that's the entire point). A new
+`Riptide.Auth.Verifier.Password` verifies Riptide's own self-issued JWTs (HS256, signed with
+`Application.fetch_env!(:riptide, :password_auth_signing_key)` — a fixed dev/test default, a
+prod-required `RIPTIDE_PASSWORD_AUTH_SIGNING_KEY` env var mirroring `SECRET_KEY_BASE`'s own existing
+raise-if-missing pattern exactly), and a new `Riptide.Auth.Verifier.Composite` tries each configured
+verifier in order — now `Authenticate`'s own default, so an OIDC-issued token and a Riptide-issued one
+both work through the exact same, otherwise-unmodified pipeline. Password hashing happens client-side
+(SHA-256); the server stores that hash as-is with no additional server-side re-hash — a deliberate,
+documented tradeoff (a leaked stored value is a directly replayable credential, not just a crackable
+hash), not an oversight, and reversible later without touching anything else in this design.
+
+**One real, non-cosmetic hazard found and guarded against during implementation, not just
+theorized**: `Riptide.Auth.Verifier.OIDC.verify/1` already wraps its own call in `rescue`, but `rescue`
+does not catch a process `:exit` signal — and `JokenJwks`'s own JWKS-fetching strategy GenServer is
+only started when OIDC is actually configured (`Riptide.Application`'s own `auth_children/0`), which is
+never true on a password-auth-only deployment, the exact case this phase exists for. Without an
+explicit guard, `Composite` trying `Verifier.OIDC` first against a password-auth token on such a
+deployment could crash the request via an uncaught `:exit` instead of falling through to
+`Verifier.Password`. `Composite.verify/1` wraps every sub-verifier call in its own `rescue`/`catch
+:exit`, confirmed by a dedicated test using a deliberately `exit/1`-raising fake verifier as the first
+entry in the configured list.
+
+**Status**: Phase 6o shipped 2026-09-01.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,6 +16,10 @@ config :riptide, RiptideWeb.Endpoint,
   secret_key_base: "yC4ZYgTNRajoqvMfeUp2kBQ0op+N4b7+7GsF3gdDxTjhmf64A5mgkdNMSdsGEKDF",
   watchers: []
 
+# Fine as a fixed, checked-in value for local dev only — see config/runtime.exs for the
+# prod-required RIPTIDE_PASSWORD_AUTH_SIGNING_KEY env var this does NOT apply to.
+config :riptide, password_auth_signing_key: "dev-only-insecure-password-auth-signing-key"
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -113,6 +113,15 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
+  password_auth_signing_key =
+    System.get_env("RIPTIDE_PASSWORD_AUTH_SIGNING_KEY") ||
+      raise """
+      environment variable RIPTIDE_PASSWORD_AUTH_SIGNING_KEY is missing.
+      You can generate one by calling: mix phx.gen.secret
+      """
+
+  config :riptide, password_auth_signing_key: password_auth_signing_key
+
   host = System.get_env("PHX_HOST") || "example.com"
 
   config :riptide, RiptideWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,6 +7,8 @@ config :riptide, RiptideWeb.Endpoint,
   secret_key_base: "IhD3noZJFg5IDxNMm2ia8NRelsuC9FhbxwJRMzEv4hL5SS5+c/Mw5uCvgz7YSS5w",
   server: false
 
+config :riptide, password_auth_signing_key: "test-only-insecure-password-auth-signing-key"
+
 # Print only warnings and errors during test
 config :logger, level: :warning
 

--- a/lib/riptide/accounts.ex
+++ b/lib/riptide/accounts.ex
@@ -1,0 +1,127 @@
+defmodule Riptide.Accounts do
+  @moduledoc """
+  Signup and login for Riptide's own username/password authentication
+  (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`).
+  Both functions call the low-level stream read/write primitives directly
+  (mirroring `Riptide.Derivation.Catalog`'s own private `write_patch/3`/
+  `read_graph/1`) rather than going through
+  `RiptideWeb.LDP.ResourceController`'s generic, Authz-checked HTTP path —
+  there is no verified token yet at the point either of these run, so that
+  path isn't reachable in the first place (§4.2, §4.3 of the design spec).
+  """
+
+  alias Riptide.Accounts.{Account, RDFCodec}
+  alias Riptide.Auth.PasswordTokenConfig
+  alias Riptide.Authz.Store.Placement, as: AuthzPlacement
+  alias Riptide.Event
+  alias Riptide.RDF.Patch
+  alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias RiptideWeb.LDP.ResourceController
+
+  @spec sign_up(String.t(), String.t(), String.t()) ::
+          {:ok, %{token: String.t(), sub: String.t()}}
+          | {:error, :already_claimed}
+          | {:error, :not_ready}
+  def sign_up(tenant_id, username, password_hash_sha256) do
+    sub = Uniq.UUID.uuid4()
+
+    case AuthzPlacement.claim_tenant_if_unclaimed(tenant_id, sub) do
+      :already_claimed ->
+        {:error, :already_claimed}
+
+      :claimed ->
+        account = %Account{
+          username: username,
+          password_hash_sha256: password_hash_sha256,
+          sub: sub
+        }
+
+        with :ok <- write_account(tenant_id, username, account),
+             {:ok, token} <- PasswordTokenConfig.sign(sub) do
+          {:ok, %{token: token, sub: sub}}
+        end
+    end
+  end
+
+  @spec log_in(String.t(), String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, :invalid_credentials} | {:error, :not_ready}
+  def log_in(tenant_id, username, password_hash_sha256) do
+    with {:ok, account} <- read_account(tenant_id, username) do
+      if account.password_hash_sha256 == password_hash_sha256 do
+        PasswordTokenConfig.sign(account.sub)
+      else
+        {:error, :invalid_credentials}
+      end
+    end
+  end
+
+  defp write_account(tenant_id, username, %Account{} = account) do
+    stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["accounts", username])
+    {_node, graph} = RDFCodec.to_rdf(account)
+    write_patch(stream_id, RDF.Graph.triples(graph), [])
+  end
+
+  defp read_account(tenant_id, username) do
+    stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, ["accounts", username])
+
+    with {:ok, graph} <- read_graph(stream_id),
+         node when not is_nil(node) <- find_account_node(graph) do
+      {:ok, RDFCodec.from_rdf(node, graph)}
+    else
+      nil -> {:error, :invalid_credentials}
+      {:error, _reason} -> {:error, :invalid_credentials}
+    end
+  end
+
+  # Each account is a single-entry stream (design spec §4.1) — exactly one
+  # subject, or none at all if the stream has never been written. Mirrors
+  # `Riptide.BlobStore.LocationIndex.list_all/0`'s own `RDF.Graph.subjects/1`
+  # usage for finding relevant subjects in a folded graph.
+  defp find_account_node(graph) do
+    graph |> RDF.Graph.subjects() |> Enum.at(0)
+  end
+
+  defp write_patch(stream_id, additions, removals) do
+    case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        StreamServer.append(
+          stream_id,
+          Event.new(stream_id, :patch, %Patch{additions: additions, removals: removals})
+        )
+
+        :ok
+
+      :error ->
+        {:error, :not_ready}
+    end
+  end
+
+  defp read_graph(stream_id) do
+    case Riptide.Placement.lookup(stream_id) do
+      nil -> {:ok, RDF.Graph.new()}
+      _nodes -> read_existing_graph(stream_id)
+    end
+  end
+
+  defp read_existing_graph(stream_id) do
+    case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        case StreamServer.get_since(stream_id, 0) do
+          {:ok, events} -> {:ok, fold_events(events)}
+          {:gap, _oldest} -> {:ok, RDF.Graph.new()}
+        end
+
+      :error ->
+        {:error, :not_ready}
+    end
+  end
+
+  defp fold_events(events) do
+    Enum.reduce(events, RDF.Graph.new(), fn
+      %Event{operation: :replace, payload: payload}, _acc -> payload
+      %Event{operation: :delete}, _acc -> RDF.Graph.new()
+      %Event{operation: :patch, payload: %Patch{} = patch}, acc -> Patch.apply(acc, patch)
+    end)
+  end
+end

--- a/lib/riptide/accounts/account.ex
+++ b/lib/riptide/accounts/account.ex
@@ -1,0 +1,21 @@
+defmodule Riptide.Accounts.Account do
+  @moduledoc """
+  A single Tenant-scoped login credential — one independently-addressable
+  stream per account (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`
+  §4.1), not a member of any shared/global structure. `password_hash_sha256`
+  is the client-computed SHA-256 hex digest, stored as-is (§3, §6 of the same
+  spec) — this module never sees a raw password. `sub` is a freshly-minted
+  UUID, decoupled from both `username` and whichever Tenant this account
+  lives under.
+  """
+
+  @enforce_keys [:username, :password_hash_sha256, :sub]
+  defstruct [:username, :password_hash_sha256, :sub]
+
+  @type t :: %__MODULE__{
+          username: String.t(),
+          password_hash_sha256: String.t(),
+          sub: String.t()
+        }
+end

--- a/lib/riptide/accounts/rdf_codec.ex
+++ b/lib/riptide/accounts/rdf_codec.ex
@@ -1,0 +1,45 @@
+defmodule Riptide.Accounts.RDFCodec do
+  @moduledoc """
+  Reifies a `Riptide.Accounts.Account` as RDF triples and reads it back,
+  following the exact same reification style
+  `Riptide.Derivation.CapabilityCatalogRDFCodec` already established.
+  """
+
+  alias Riptide.Accounts.Account
+
+  @rdf_type RDF.iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
+  @riptide_account RDF.iri("urn:riptide:vocab:Account")
+  @riptide_username RDF.iri("urn:riptide:vocab:username")
+  @riptide_password_hash_sha256 RDF.iri("urn:riptide:vocab:passwordHashSha256")
+  @riptide_account_subject RDF.iri("urn:riptide:vocab:accountSubject")
+
+  @spec to_rdf(Account.t()) :: {RDF.BlankNode.t(), RDF.Graph.t()}
+  def to_rdf(%Account{} = account) do
+    node = RDF.BlankNode.new()
+
+    graph =
+      RDF.Graph.new()
+      |> RDF.Graph.add({node, @rdf_type, @riptide_account})
+      |> RDF.Graph.add({node, @riptide_username, RDF.literal(account.username)})
+      |> RDF.Graph.add(
+        {node, @riptide_password_hash_sha256, RDF.literal(account.password_hash_sha256)}
+      )
+      |> RDF.Graph.add({node, @riptide_account_subject, RDF.literal(account.sub)})
+
+    {node, graph}
+  end
+
+  @spec from_rdf(RDF.Resource.t(), RDF.Graph.t()) :: Account.t()
+  def from_rdf(node, graph) do
+    description = RDF.Graph.get(graph, node)
+
+    %Account{
+      username: description |> RDF.Description.first(@riptide_username) |> RDF.Literal.value(),
+      password_hash_sha256:
+        description
+        |> RDF.Description.first(@riptide_password_hash_sha256)
+        |> RDF.Literal.value(),
+      sub: description |> RDF.Description.first(@riptide_account_subject) |> RDF.Literal.value()
+    }
+  end
+end

--- a/lib/riptide/application.ex
+++ b/lib/riptide/application.ex
@@ -32,6 +32,7 @@ defmodule Riptide.Application do
         Riptide.Telemetry,
         Riptide.NewStreamRateLimit,
         Riptide.HubRateLimit,
+        Riptide.PasswordAuthRateLimit,
         {Plug.Cowboy, scheme: :http, plug: RiptideWeb.MetricsEndpoint, options: [port: 9090]},
         Riptide.Stream.Placement,
         Riptide.SupervisedProcess.SessionTracker,

--- a/lib/riptide/auth/password_token_config.ex
+++ b/lib/riptide/auth/password_token_config.ex
@@ -1,0 +1,62 @@
+defmodule Riptide.Auth.PasswordTokenConfig do
+  @moduledoc """
+  `Joken.Config` token configuration for Riptide's own self-issued
+  username/password JWTs (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`
+  §4.5) — mirrors `Riptide.Auth.TokenConfig`'s own shape, but signs and
+  verifies against a single shared secret (`Application.fetch_env!(:riptide,
+  :password_auth_signing_key)`) rather than fetching a signer from an
+  external JWKS endpoint: there is no external party for a self-issued token,
+  so the signer and verifier are always the same deployment.
+
+  `iss`/`aud` are fixed, self-referential literals (not app-config-driven
+  the way OIDC's are) — there is no external issuer to match against, only
+  "did this Riptide instance itself issue this token."
+  """
+  use Joken.Config
+
+  @issuer "riptide-password-auth"
+  @audience "riptide-password-auth"
+  @required_claims ~w(exp iss aud sub)
+
+  @impl Joken.Config
+  def token_config do
+    default_claims(skip: [:iss, :aud])
+    |> add_claim("iss", fn -> @issuer end, &(&1 == @issuer))
+    |> add_claim("aud", fn -> @audience end, &(&1 == @audience))
+  end
+
+  @spec sign(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def sign(sub) when is_binary(sub) do
+    case generate_and_sign(%{"sub" => sub}, signer()) do
+      {:ok, token, _claims} -> {:ok, token}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc """
+  Same as the generated `verify_and_validate/2`, plus an explicit
+  present-and-non-null check for `exp`/`iss`/`aud`/`sub` — mirrors
+  `Riptide.Auth.TokenConfig.verify_and_validate_required_claims/1`'s own
+  reasoning exactly (a validly-signed token that simply omits one of these
+  would otherwise skip that claim's check entirely).
+  """
+  @spec verify_and_validate_required_claims(Joken.bearer_token()) ::
+          {:ok, Joken.claims()} | {:error, Joken.error_reason()}
+  def verify_and_validate_required_claims(bearer_token) do
+    with {:ok, claims} <- verify_and_validate(bearer_token, signer()) do
+      require_claims(claims)
+    end
+  end
+
+  defp require_claims(claims) do
+    case Enum.filter(@required_claims, &is_nil(Map.get(claims, &1))) do
+      [] -> {:ok, claims}
+      missing -> {:error, {:missing_claims, missing}}
+    end
+  end
+
+  defp signer do
+    Joken.Signer.create("HS256", Application.fetch_env!(:riptide, :password_auth_signing_key))
+  end
+end

--- a/lib/riptide/auth/verifier/composite.ex
+++ b/lib/riptide/auth/verifier/composite.ex
@@ -1,0 +1,51 @@
+defmodule Riptide.Auth.Verifier.Composite do
+  @moduledoc """
+  Tries each configured `Riptide.Auth.Verifier` in order, returning the
+  first success or the last failure if none succeed — this is what lets an
+  OIDC-issued token and a Riptide-issued password-auth token both work
+  through `RiptideWeb.Plugs.Authenticate` unmodified (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`
+  §4.5). The default configured list
+  (`Application.get_env(:riptide, :auth_verifiers, [...])`) is
+  `[Riptide.Auth.Verifier.OIDC, Riptide.Auth.Verifier.Password]`.
+
+  Each sub-verifier's `verify/1` call is wrapped in its own `rescue`/`catch
+  :exit` here, rather than trusting every implementation to already be
+  exit-safe: `Riptide.Auth.Verifier.OIDC`'s own `rescue` does not catch a
+  `GenServer.call` `:exit` signal, which is exactly what happens if OIDC's
+  own `Riptide.Auth.JwksStrategy` was never started (a deployment running
+  password-auth-only, with no `:oidc_jwks_url` configured — see
+  `config/runtime.exs`). Without this, trying `Verifier.OIDC` first against
+  a password-auth token on such a deployment could crash the request
+  instead of falling through to the next verifier.
+  """
+  @behaviour Riptide.Auth.Verifier
+
+  @impl true
+  def verify(token) when is_binary(token) do
+    verifiers =
+      Application.get_env(:riptide, :auth_verifiers, [
+        Riptide.Auth.Verifier.OIDC,
+        Riptide.Auth.Verifier.Password
+      ])
+
+    try_verifiers(verifiers, token, {:error, :no_verifiers_configured})
+  end
+
+  defp try_verifiers([], _token, last_error), do: last_error
+
+  defp try_verifiers([verifier | rest], token, _last_error) do
+    case safe_verify(verifier, token) do
+      {:ok, _claims} = success -> success
+      {:error, _reason} = error -> try_verifiers(rest, token, error)
+    end
+  end
+
+  defp safe_verify(verifier, token) do
+    verifier.verify(token)
+  rescue
+    error -> {:error, error}
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+end

--- a/lib/riptide/auth/verifier/password.ex
+++ b/lib/riptide/auth/verifier/password.ex
@@ -1,0 +1,18 @@
+defmodule Riptide.Auth.Verifier.Password do
+  @moduledoc """
+  `Riptide.Auth.Verifier` implementation for Riptide's own self-issued
+  username/password JWTs — mirrors `Riptide.Auth.Verifier.OIDC`'s exact
+  shape, delegating to `Riptide.Auth.PasswordTokenConfig` instead of
+  `Riptide.Auth.TokenConfig`.
+  """
+  @behaviour Riptide.Auth.Verifier
+
+  alias Riptide.Auth.PasswordTokenConfig
+
+  @impl true
+  def verify(token) when is_binary(token) do
+    PasswordTokenConfig.verify_and_validate_required_claims(token)
+  rescue
+    error -> {:error, error}
+  end
+end

--- a/lib/riptide/password_auth_rate_limit.ex
+++ b/lib/riptide/password_auth_rate_limit.ex
@@ -1,0 +1,53 @@
+defmodule Riptide.PasswordAuthRateLimit do
+  @moduledoc """
+  Rate-limits `POST /auth/signup`/`POST /auth/login` (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`
+  §4.6) — mirrors `Riptide.HubRateLimit`'s exact shape (`Hammer`,
+  `:fix_window_per_key`, same window-boundary-undercounting reasoning).
+  Both routes are deliberately anonymous (no subject exists yet at this
+  point in the request, by definition), so both limiters are keyed by
+  caller IP, never a tenant_id or username (either of which is free to
+  mint and would make the limit trivially bypassable).
+
+  Two independent limiters: `check_login/1` gets the tighter default (brute-
+  force protection against a known account); `check_signup/1`'s own limit
+  exists primarily against automated account-creation spam.
+  """
+
+  use Hammer, backend: :ets, algorithm: :fix_window_per_key
+
+  @default_signup_limit 10
+  @default_signup_scale_ms :timer.minutes(1)
+  @default_login_limit 20
+  @default_login_scale_ms :timer.minutes(1)
+
+  @spec check_signup(String.t()) :: :allow | :deny
+  def check_signup(ip) do
+    limit = Application.get_env(:riptide, :password_auth_signup_rate_limit, @default_signup_limit)
+
+    scale_ms =
+      Application.get_env(
+        :riptide,
+        :password_auth_signup_rate_scale_ms,
+        @default_signup_scale_ms
+      )
+
+    case hit("password_auth_signup:#{ip}", scale_ms, limit) do
+      {:allow, _count} -> :allow
+      {:deny, _retry_after} -> :deny
+    end
+  end
+
+  @spec check_login(String.t()) :: :allow | :deny
+  def check_login(ip) do
+    limit = Application.get_env(:riptide, :password_auth_login_rate_limit, @default_login_limit)
+
+    scale_ms =
+      Application.get_env(:riptide, :password_auth_login_rate_scale_ms, @default_login_scale_ms)
+
+    case hit("password_auth_login:#{ip}", scale_ms, limit) do
+      {:allow, _count} -> :allow
+      {:deny, _retry_after} -> :deny
+    end
+  end
+end

--- a/lib/riptide_web/auth/login_controller.ex
+++ b/lib/riptide_web/auth/login_controller.ex
@@ -1,0 +1,46 @@
+defmodule RiptideWeb.Auth.LoginController do
+  @moduledoc """
+  `POST /auth/login` — deliberately anonymous (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`
+  §4.3). Not routed through `RiptideWeb.Plugs.Authenticate`/`Authorize` —
+  there is no token yet to check; that's the entire point of this route.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  def create(conn, params) do
+    case conn |> caller_ip() |> Riptide.PasswordAuthRateLimit.check_login() do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_create(conn, params)
+    end
+  end
+
+  defp handle_create(conn, %{
+         "tenant_id" => tenant_id,
+         "username" => username,
+         "password_hash" => password_hash
+       })
+       when is_binary(tenant_id) and is_binary(username) and is_binary(password_hash) do
+    case Riptide.Accounts.log_in(tenant_id, username, password_hash) do
+      {:ok, token} ->
+        body = Jason.encode!(%{"token" => token})
+        conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+      {:error, :invalid_credentials} ->
+        send_resp(conn, 401, "")
+
+      {:error, :not_ready} ->
+        send_resp(conn, 503, "")
+    end
+  rescue
+    _ -> send_resp(conn, 503, "")
+  catch
+    :exit, _ -> send_resp(conn, 503, "")
+  end
+
+  defp handle_create(conn, _params), do: send_resp(conn, 400, "")
+
+  # Same reasoning as SignupController's own caller_ip/1 — this route never
+  # goes through the :auth pipeline, so it's always IP, never a subject.
+  defp caller_ip(conn), do: conn.remote_ip |> :inet.ntoa() |> to_string()
+end

--- a/lib/riptide_web/auth/signup_controller.ex
+++ b/lib/riptide_web/auth/signup_controller.ex
@@ -1,0 +1,63 @@
+defmodule RiptideWeb.Auth.SignupController do
+  @moduledoc """
+  `POST /auth/signup` — deliberately anonymous (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md`
+  §4.2): creates a brand-new Tenant and its first account together. Not
+  routed through `RiptideWeb.Plugs.Authenticate`/`Authorize` — there is no
+  token yet to check.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+  require Logger
+
+  @password_hash_pattern ~r/^[0-9a-f]{64}$/
+
+  def create(conn, params) do
+    case conn |> caller_ip() |> Riptide.PasswordAuthRateLimit.check_signup() do
+      :deny -> send_resp(conn, 429, "")
+      :allow -> handle_create(conn, params)
+    end
+  end
+
+  defp handle_create(conn, %{
+         "tenant_id" => tenant_id,
+         "username" => username,
+         "password_hash" => password_hash
+       })
+       when is_binary(tenant_id) and is_binary(username) and is_binary(password_hash) do
+    if valid_identifier?(tenant_id) and valid_identifier?(username) and
+         Regex.match?(@password_hash_pattern, password_hash) do
+      case Riptide.Accounts.sign_up(tenant_id, username, password_hash) do
+        {:ok, %{token: token, sub: sub}} ->
+          body = Jason.encode!(%{"token" => token, "sub" => sub})
+          conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+
+        {:error, :already_claimed} ->
+          send_resp(conn, 409, "")
+
+        {:error, :not_ready} ->
+          send_resp(conn, 503, "")
+      end
+    else
+      send_resp(conn, 400, "")
+    end
+  rescue
+    _ -> send_resp(conn, 503, "")
+  catch
+    :exit, _ -> send_resp(conn, 503, "")
+  end
+
+  defp handle_create(conn, _params), do: send_resp(conn, 400, "")
+
+  # `tenant_id`/`username` become stream_id path segments
+  # (`RiptideWeb.LDP.ResourceController.stream_id_for/2`, which joins on
+  # "/") — a "/" in either would corrupt addressing, so both are rejected
+  # here before any claim/write is attempted.
+  defp valid_identifier?(value), do: value != "" and not String.contains?(value, "/")
+
+  # Unlike Hub.DiscoveryController's own rate_limit_key/1 (which this
+  # otherwise mirrors), this route never goes through the :auth pipeline at
+  # all — conn.assigns[:current_subject] can never be set here, so there is
+  # no subject-vs-IP branch to make; it's always IP.
+  defp caller_ip(conn), do: conn.remote_ip |> :inet.ntoa() |> to_string()
+end

--- a/lib/riptide_web/plugs/authenticate.ex
+++ b/lib/riptide_web/plugs/authenticate.ex
@@ -3,8 +3,9 @@ defmodule RiptideWeb.Plugs.Authenticate do
   Extracts a bearer token (see `extract_token/1`) and verifies it via the
   configured `Riptide.Auth.Verifier`
   (`Application.get_env(:riptide, :auth_verifier)`, defaulting to
-  `Riptide.Auth.Verifier.OIDC`) — mirrors `RiptideWeb.Plugs.ResolveTenant`'s
-  config-driven swap (Phase 4a).
+  `Riptide.Auth.Verifier.Composite` (tries OIDC, then Riptide's own password
+  auth)) — mirrors `RiptideWeb.Plugs.ResolveTenant`'s config-driven swap
+  (Phase 4a).
 
   Unlike `ResolveTenant`, authentication is optional at this layer: no token
   present assigns `conn.assigns.current_subject` to `nil` and lets the
@@ -38,7 +39,7 @@ defmodule RiptideWeb.Plugs.Authenticate do
         assign(conn, :current_subject, nil)
 
       token ->
-        verifier = Application.get_env(:riptide, :auth_verifier, Riptide.Auth.Verifier.OIDC)
+        verifier = Application.get_env(:riptide, :auth_verifier, Riptide.Auth.Verifier.Composite)
 
         case verifier.verify(token) do
           {:ok, claims} ->

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -35,6 +35,13 @@ defmodule RiptideWeb.Router do
     get "/health/ready", RiptideWeb.HealthController, :ready
   end
 
+  scope "/auth" do
+    pipe_through [:api]
+
+    post "/signup", RiptideWeb.Auth.SignupController, :create
+    post "/login", RiptideWeb.Auth.LoginController, :create
+  end
+
   scope "/" do
     pipe_through [:api, :auth_query_param]
 

--- a/test/riptide/accounts/rdf_codec_test.exs
+++ b/test/riptide/accounts/rdf_codec_test.exs
@@ -1,0 +1,17 @@
+defmodule Riptide.Accounts.RDFCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Riptide.Accounts.{Account, RDFCodec}
+
+  test "to_rdf/1 + from_rdf/2 round-trips an Account" do
+    account = %Account{
+      username: "alice",
+      password_hash_sha256: String.duplicate("a", 64),
+      sub: "11111111-1111-1111-1111-111111111111"
+    }
+
+    {node, graph} = RDFCodec.to_rdf(account)
+
+    assert RDFCodec.from_rdf(node, graph) == account
+  end
+end

--- a/test/riptide/accounts_test.exs
+++ b/test/riptide/accounts_test.exs
@@ -2,6 +2,7 @@ defmodule Riptide.AccountsTest do
   use ExUnit.Case, async: false
 
   alias Riptide.Accounts
+  alias Riptide.Auth.Verifier.Password
 
   setup do
     Riptide.AppEnvTestHelpers.put_env(
@@ -25,7 +26,7 @@ defmodule Riptide.AccountsTest do
       assert is_binary(token)
       assert is_binary(sub)
 
-      assert {:ok, claims} = Riptide.Auth.Verifier.Password.verify(token)
+      assert {:ok, claims} = Password.verify(token)
       assert claims["sub"] == sub
     end
 
@@ -47,7 +48,7 @@ defmodule Riptide.AccountsTest do
       {:ok, %{sub: sub}} = Accounts.sign_up(tenant_id, "alice", password_hash)
 
       assert {:ok, token} = Accounts.log_in(tenant_id, "alice", password_hash)
-      assert {:ok, claims} = Riptide.Auth.Verifier.Password.verify(token)
+      assert {:ok, claims} = Password.verify(token)
       assert claims["sub"] == sub
     end
 

--- a/test/riptide/accounts_test.exs
+++ b/test/riptide/accounts_test.exs
@@ -1,0 +1,75 @@
+defmodule Riptide.AccountsTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Accounts
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    :ok
+  end
+
+  defp unique_tenant, do: "acct-tenant-#{System.unique_integer([:positive])}"
+
+  describe "sign_up/3" do
+    test "creates a brand-new Tenant and its first account, returning a usable token" do
+      tenant_id = unique_tenant()
+
+      assert {:ok, %{token: token, sub: sub}} =
+               Accounts.sign_up(tenant_id, "alice", String.duplicate("a", 64))
+
+      assert is_binary(token)
+      assert is_binary(sub)
+
+      assert {:ok, claims} = Riptide.Auth.Verifier.Password.verify(token)
+      assert claims["sub"] == sub
+    end
+
+    test "a second sign_up against the same tenant_id returns :already_claimed" do
+      tenant_id = unique_tenant()
+
+      assert {:ok, _} = Accounts.sign_up(tenant_id, "alice", String.duplicate("a", 64))
+
+      assert {:error, :already_claimed} =
+               Accounts.sign_up(tenant_id, "mallory", String.duplicate("b", 64))
+    end
+  end
+
+  describe "log_in/3" do
+    test "correct credentials succeed and return a token bound to the account's own sub" do
+      tenant_id = unique_tenant()
+      password_hash = String.duplicate("c", 64)
+
+      {:ok, %{sub: sub}} = Accounts.sign_up(tenant_id, "alice", password_hash)
+
+      assert {:ok, token} = Accounts.log_in(tenant_id, "alice", password_hash)
+      assert {:ok, claims} = Riptide.Auth.Verifier.Password.verify(token)
+      assert claims["sub"] == sub
+    end
+
+    test "wrong password_hash returns :invalid_credentials" do
+      tenant_id = unique_tenant()
+      {:ok, _} = Accounts.sign_up(tenant_id, "alice", String.duplicate("c", 64))
+
+      assert {:error, :invalid_credentials} =
+               Accounts.log_in(tenant_id, "alice", String.duplicate("d", 64))
+    end
+
+    test "nonexistent username under an existing tenant returns :invalid_credentials" do
+      tenant_id = unique_tenant()
+      {:ok, _} = Accounts.sign_up(tenant_id, "alice", String.duplicate("c", 64))
+
+      assert {:error, :invalid_credentials} =
+               Accounts.log_in(tenant_id, "nobody", String.duplicate("c", 64))
+    end
+
+    test "nonexistent tenant_id returns :invalid_credentials" do
+      assert {:error, :invalid_credentials} =
+               Accounts.log_in(unique_tenant(), "alice", String.duplicate("c", 64))
+    end
+  end
+end

--- a/test/riptide/auth/password_token_config_test.exs
+++ b/test/riptide/auth/password_token_config_test.exs
@@ -1,0 +1,46 @@
+defmodule Riptide.Auth.PasswordTokenConfigTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Auth.PasswordTokenConfig
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    :ok
+  end
+
+  test "sign/1 + verify_and_validate_required_claims/1 round-trips a valid token" do
+    {:ok, token} = PasswordTokenConfig.sign("11111111-1111-1111-1111-111111111111")
+
+    assert {:ok, claims} = PasswordTokenConfig.verify_and_validate_required_claims(token)
+    assert claims["sub"] == "11111111-1111-1111-1111-111111111111"
+  end
+
+  test "a token signed with a different key fails verification" do
+    {:ok, token} = PasswordTokenConfig.sign("11111111-1111-1111-1111-111111111111")
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_signing_key, "a-different-key")
+
+    assert {:error, _reason} = PasswordTokenConfig.verify_and_validate_required_claims(token)
+  end
+
+  test "a token with an expired exp claim fails verification" do
+    signer = Joken.Signer.create("HS256", "test-signing-key-fixture")
+
+    {:ok, expired_token, _claims} =
+      PasswordTokenConfig.generate_and_sign(
+        %{
+          "sub" => "11111111-1111-1111-1111-111111111111",
+          "exp" => System.system_time(:second) - 10
+        },
+        signer
+      )
+
+    assert {:error, _reason} =
+             PasswordTokenConfig.verify_and_validate_required_claims(expired_token)
+  end
+end

--- a/test/riptide/auth/verifier/composite_test.exs
+++ b/test/riptide/auth/verifier/composite_test.exs
@@ -1,0 +1,57 @@
+defmodule Riptide.Auth.Verifier.CompositeTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Auth.PasswordTokenConfig
+  alias Riptide.Auth.Verifier.Composite
+
+  defmodule AlwaysFails do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify(_token), do: {:error, :always_fails}
+  end
+
+  defmodule AlwaysExits do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify(_token), do: exit(:simulated_unreachable_dependency)
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    :ok
+  end
+
+  test "verify/1 succeeds via the first configured verifier that accepts the token" do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifiers, [
+      AlwaysFails,
+      Riptide.Auth.Verifier.Password
+    ])
+
+    {:ok, token} = PasswordTokenConfig.sign("11111111-1111-1111-1111-111111111111")
+
+    assert {:ok, claims} = Composite.verify(token)
+    assert claims["sub"] == "11111111-1111-1111-1111-111111111111"
+  end
+
+  test "verify/1 tolerates an earlier verifier raising :exit instead of returning {:error, _}" do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifiers, [
+      AlwaysExits,
+      Riptide.Auth.Verifier.Password
+    ])
+
+    {:ok, token} = PasswordTokenConfig.sign("11111111-1111-1111-1111-111111111111")
+
+    assert {:ok, _claims} = Composite.verify(token)
+  end
+
+  test "verify/1 fails with the last verifier's own error when none succeed" do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifiers, [AlwaysFails, AlwaysFails])
+
+    assert {:error, :always_fails} = Composite.verify("any-token")
+  end
+end

--- a/test/riptide/auth/verifier/password_test.exs
+++ b/test/riptide/auth/verifier/password_test.exs
@@ -1,0 +1,27 @@
+defmodule Riptide.Auth.Verifier.PasswordTest do
+  use ExUnit.Case, async: false
+
+  alias Riptide.Auth.PasswordTokenConfig
+  alias Riptide.Auth.Verifier.Password
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    :ok
+  end
+
+  test "verify/1 succeeds for a token PasswordTokenConfig itself signed" do
+    {:ok, token} = PasswordTokenConfig.sign("11111111-1111-1111-1111-111111111111")
+
+    assert {:ok, claims} = Password.verify(token)
+    assert claims["sub"] == "11111111-1111-1111-1111-111111111111"
+  end
+
+  test "verify/1 fails for garbage input" do
+    assert {:error, _reason} = Password.verify("not-a-real-token")
+  end
+end

--- a/test/riptide/password_auth_rate_limit_test.exs
+++ b/test/riptide/password_auth_rate_limit_test.exs
@@ -1,0 +1,61 @@
+defmodule Riptide.PasswordAuthRateLimitTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_signup_rate_limit, 2)
+
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signup_rate_scale_ms,
+      :timer.minutes(1)
+    )
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_login_rate_limit, 2)
+
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_login_rate_scale_ms,
+      :timer.minutes(1)
+    )
+
+    :ok
+  end
+
+  test "check_signup/1 allows up to the configured limit, then denies" do
+    ip = "signup-ip-#{System.unique_integer([:positive])}"
+
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip) == :deny
+  end
+
+  test "check_signup/1 tracks distinct IPs independently" do
+    ip_a = "signup-ip-a-#{System.unique_integer([:positive])}"
+    ip_b = "signup-ip-b-#{System.unique_integer([:positive])}"
+
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip_a) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip_a) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip_a) == :deny
+
+    assert Riptide.PasswordAuthRateLimit.check_signup(ip_b) == :allow
+  end
+
+  test "check_login/1 allows up to the configured limit, then denies" do
+    ip = "login-ip-#{System.unique_integer([:positive])}"
+
+    assert Riptide.PasswordAuthRateLimit.check_login(ip) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_login(ip) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_login(ip) == :deny
+  end
+
+  test "check_login/1 tracks distinct IPs independently" do
+    ip_a = "login-ip-a-#{System.unique_integer([:positive])}"
+    ip_b = "login-ip-b-#{System.unique_integer([:positive])}"
+
+    assert Riptide.PasswordAuthRateLimit.check_login(ip_a) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_login(ip_a) == :allow
+    assert Riptide.PasswordAuthRateLimit.check_login(ip_a) == :deny
+
+    assert Riptide.PasswordAuthRateLimit.check_login(ip_b) == :allow
+  end
+end

--- a/test/riptide_web/auth/login_controller_test.exs
+++ b/test/riptide_web/auth/login_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule RiptideWeb.Auth.LoginControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_signup_rate_limit, 1_000)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_login_rate_limit, 1_000)
+    :ok
+  end
+
+  defp unique_tenant, do: "loginctl-tenant-#{System.unique_integer([:positive])}"
+
+  defp sign_up!(tenant_id, username, password_hash) do
+    body =
+      Jason.encode!(%{
+        "tenant_id" => tenant_id,
+        "username" => username,
+        "password_hash" => password_hash
+      })
+
+    conn =
+      :post
+      |> conn("/auth/signup", body)
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    :ok
+  end
+
+  defp login_conn(tenant_id, username, password_hash) do
+    body =
+      Jason.encode!(%{
+        "tenant_id" => tenant_id,
+        "username" => username,
+        "password_hash" => password_hash
+      })
+
+    :post
+    |> conn("/auth/login", body)
+    |> put_req_header("content-type", "application/json")
+    |> RiptideWeb.Endpoint.call(@opts)
+  end
+
+  test "correct credentials return 200 with a usable token" do
+    tenant_id = unique_tenant()
+    password_hash = String.duplicate("b", 64)
+    :ok = sign_up!(tenant_id, "alice", password_hash)
+
+    conn = login_conn(tenant_id, "alice", password_hash)
+
+    assert conn.status == 200
+    assert is_binary(Jason.decode!(conn.resp_body)["token"])
+  end
+
+  test "wrong password, wrong username, and a nonexistent tenant all return the same 401 shape" do
+    tenant_id = unique_tenant()
+    password_hash = String.duplicate("b", 64)
+    :ok = sign_up!(tenant_id, "alice", password_hash)
+
+    wrong_password = login_conn(tenant_id, "alice", String.duplicate("c", 64))
+    wrong_username = login_conn(tenant_id, "nobody", password_hash)
+    wrong_tenant = login_conn(unique_tenant(), "alice", password_hash)
+
+    assert wrong_password.status == 401
+    assert wrong_username.status == 401
+    assert wrong_tenant.status == 401
+    assert wrong_password.resp_body == wrong_username.resp_body
+    assert wrong_username.resp_body == wrong_tenant.resp_body
+  end
+
+  test "login is rate-limited" do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_login_rate_limit, 0)
+
+    conn = login_conn(unique_tenant(), "alice", String.duplicate("b", 64))
+
+    assert conn.status == 429
+  end
+end

--- a/test/riptide_web/auth/signup_controller_test.exs
+++ b/test/riptide_web/auth/signup_controller_test.exs
@@ -1,0 +1,99 @@
+defmodule RiptideWeb.Auth.SignupControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_signup_rate_limit, 1_000)
+    :ok
+  end
+
+  defp unique_tenant, do: "signupctl-tenant-#{System.unique_integer([:positive])}"
+
+  defp signup_body(overrides \\ %{}) do
+    Jason.encode!(
+      Map.merge(
+        %{
+          "tenant_id" => unique_tenant(),
+          "username" => "alice",
+          "password_hash" => String.duplicate("a", 64)
+        },
+        overrides
+      )
+    )
+  end
+
+  test "valid signup returns 200 with a usable token" do
+    conn =
+      :post
+      |> conn("/auth/signup", signup_body())
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+    body = Jason.decode!(conn.resp_body)
+    assert is_binary(body["token"])
+    assert is_binary(body["sub"])
+  end
+
+  test "signing up against an already-claimed tenant_id returns 409" do
+    tenant_id = unique_tenant()
+    body = signup_body(%{"tenant_id" => tenant_id})
+
+    first_conn =
+      :post
+      |> conn("/auth/signup", body)
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert first_conn.status == 200
+
+    second_conn =
+      :post
+      |> conn("/auth/signup", signup_body(%{"tenant_id" => tenant_id, "username" => "mallory"}))
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert second_conn.status == 409
+  end
+
+  test "a tenant_id containing '/' returns 400 without claiming anything" do
+    conn =
+      :post
+      |> conn("/auth/signup", signup_body(%{"tenant_id" => "has/slash"}))
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 400
+  end
+
+  test "a username containing '/' returns 400" do
+    conn =
+      :post
+      |> conn("/auth/signup", signup_body(%{"username" => "has/slash"}))
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 400
+  end
+
+  test "signup is rate-limited" do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_signup_rate_limit, 0)
+
+    conn =
+      :post
+      |> conn("/auth/signup", signup_body())
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 429
+  end
+end

--- a/test/riptide_web/username_password_auth_capstone_test.exs
+++ b/test/riptide_web/username_password_auth_capstone_test.exs
@@ -1,0 +1,120 @@
+defmodule RiptideWeb.UsernamePasswordAuthCapstoneTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Accounts.Account
+  alias Riptide.Accounts.RDFCodec, as: AccountRDFCodec
+  alias Riptide.RDF.TurtleCodec
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(
+      :riptide,
+      :password_auth_signing_key,
+      "test-signing-key-fixture"
+    )
+
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_signup_rate_limit, 1_000)
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :password_auth_login_rate_limit, 1_000)
+    :ok
+  end
+
+  test "signup -> invite a teammate via the existing generic write route -> both log in independently -> both tokens work through the existing Authenticate/Authorize pipeline" do
+    tenant_id = "capstone-tenant-#{System.unique_integer([:positive])}"
+
+    # 1. Alice signs up, creating the Tenant and her own account together.
+    signup_body =
+      Jason.encode!(%{
+        "tenant_id" => tenant_id,
+        "username" => "alice",
+        "password_hash" => String.duplicate("a", 64)
+      })
+
+    signup_conn =
+      :post
+      |> conn("/auth/signup", signup_body)
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert signup_conn.status == 200
+    alice_token = Jason.decode!(signup_conn.resp_body)["token"]
+
+    # 2. Alice invites Bob by writing a second account fact directly, using her own
+    # token via the EXISTING generic write route (PUT, not POST — a client-named
+    # path segment, not an auto-generated one) — zero new server code for this step.
+    bob_account = %Account{
+      username: "bob",
+      password_hash_sha256: String.duplicate("b", 64),
+      sub: Uniq.UUID.uuid4()
+    }
+
+    {_node, bob_graph} = AccountRDFCodec.to_rdf(bob_account)
+    {:ok, bob_turtle} = TurtleCodec.encode(bob_graph)
+
+    invite_conn =
+      :put
+      |> conn("/tenants/#{tenant_id}/resources/accounts/bob", bob_turtle)
+      |> put_req_header("authorization", "Bearer #{alice_token}")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert invite_conn.status == 201
+
+    # 2b. Having an account (a login) is a separate thing from being authorized to
+    # read/write Guild-A's own resources — Bob's account alone grants him nothing
+    # there yet. Alice, as the tenant's owner, grants Bob's own subject a policy via
+    # the EXISTING, already-built policy endpoint (Phase 4c) — no new code for this
+    # either.
+    grant_policy_body =
+      Jason.encode!(%{
+        "effect" => "allow",
+        "modes" => ["read", "write"],
+        "matcher" => %{"agent" => bob_account.sub}
+      })
+
+    grant_policy_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/policies", grant_policy_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer #{alice_token}")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert grant_policy_conn.status == 201
+
+    # 3. Bob logs in independently.
+    bob_login_body =
+      Jason.encode!(%{
+        "tenant_id" => tenant_id,
+        "username" => "bob",
+        "password_hash" => String.duplicate("b", 64)
+      })
+
+    bob_login_conn =
+      :post
+      |> conn("/auth/login", bob_login_body)
+      |> put_req_header("content-type", "application/json")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert bob_login_conn.status == 200
+    bob_token = Jason.decode!(bob_login_conn.resp_body)["token"]
+
+    # 4. Both tokens independently pass through the EXISTING Authenticate/Authorize
+    # pipeline for an ordinary Tenant-scoped resource read — nothing downstream of
+    # authentication needed to change at all.
+    alice_read_conn =
+      :get
+      |> conn("/tenants/#{tenant_id}/resources/accounts/bob")
+      |> put_req_header("authorization", "Bearer #{alice_token}")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    bob_read_conn =
+      :get
+      |> conn("/tenants/#{tenant_id}/resources/accounts/bob")
+      |> put_req_header("authorization", "Bearer #{bob_token}")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert alice_read_conn.status == 200
+    assert bob_read_conn.status == 200
+  end
+end


### PR DESCRIPTION
## Summary
- Adds Riptide's first self-service, no-external-infrastructure-required authentication mechanism: POST /auth/signup and POST /auth/login.
- Accounts are ordinary, individually-addressable Tenant-scoped resources -- no new storage engine, no global cross-tenant "system" tenant (considered and rejected during brainstorming -- see the design spec's own §4.1 rationale). A Tenant can hold many accounts natively; adding a second account to an existing Tenant needs zero new code, just the existing generic write route -- though it still needs an explicit Authz policy grant (Phase 4c, already built) to actually gain access, which the capstone test exercises after an earlier draft of both the spec and the test missed this and got 403.
- New Riptide.Auth.Verifier.Password (self-issued JWTs) + Riptide.Auth.Verifier.Composite, so OIDC-issued and password-issued tokens both work through the unchanged Authenticate plug. Composite defensively wraps each sub-verifier's own call in rescue/catch :exit, since Verifier.OIDC's own rescue alone doesn't catch a GenServer :exit from its JWKS strategy process when OIDC isn't configured -- exactly the case this phase exists for.
- Client-side password hashing; server stores the hash as-is -- an explicit, documented tradeoff (see the design spec §6).

Demo itself (6p) builds on top of this phase plus 6m and 6n.

Spec: `docs/superpowers/specs/2026-09-01-phase-6o-username-password-auth-design.md` (PR #126, includes a follow-up commit fixing the worked example's PUT-vs-POST and missing-policy-grant issues found during implementation).

## Test plan
- [x] `mix test` -- full suite green (609 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` -- clean
- [ ] CI green on the PR