### PR TITLE
Draft: Resolve: "6p-i — Demo Backend Additions"

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,7 +16,7 @@ first place to check for current status, not a historical log.
 | 3 | Clustering / horizontal scale / HA | **Shipped** (phases 3a-3e) — see below |
 | 4 | Security & multi-tenancy (auth, ACP, TLS) | **Shipped** (phases 4a-4d) — see below |
 | 5 | Observability & operability (metrics, logging, health probes) | **Shipped** (phases 5a-5c) — see below |
-| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l, 6d-ii, 6m, 6n, 6o shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering; concurrent-effects design spike; Tenant-Scoped Execution Surface; Hub Resource Lifecycle; Username/Password Authentication) — see issue #58 for the current remaining list (6p demo, 6g-ii, 6c-iii-a/b, Capability grant/OAuth), see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
+| 6 | Derivation and execution layer | **6c-i-a, 6c-i-b, 6b-i, 6d-i, 6e-i, 6e-ii, 6e-iii, 6f, 6g-i, 6a, 6b-ii, 6h-i, 6h-ii, 6c-ii, 6i, 6j, 6k, 6l, 6d-ii, 6m, 6n, 6o, 6p-i shipped** (Rule/Signature representation and parser; fact-pattern matching and joins; WASI execution substrate; mechanical wiring; anti-unification algorithm; Generalization Fidelity replay harness; DedupGate orchestration; LLM fallback loop; exact/keyword Discovery; bitemporal fact shape; supervised long-running process primitive; Pattern Hub threat model; Pattern Hub deployment; recursion and fixpoint evaluation; ontology Crosswalks and Installation; large object/blob storage; dynamic Capability registration; reactive Job-triggering; concurrent-effects design spike; Tenant-Scoped Execution Surface; Hub Resource Lifecycle; Username/Password Authentication; Demo Backend Additions) — see issue #58 for the current remaining list (6p-ii demo WASM components, 6p-iii the demo page, 6g-ii, 6c-iii-a/b, Capability grant/OAuth), see `docs/superpowers/specs/2026-08-27-derivation-and-execution-layer-design.md` |
 
 Sequencing rationale: persistence first, since clustering/HA are meaningless without durable
 storage to replicate, and every other sub-project assumes data actually survives a restart.
@@ -1472,3 +1472,50 @@ deployment could crash the request via an uncaught `:exit` instead of falling th
 entry in the configured list.
 
 **Status**: Phase 6o shipped 2026-09-01.
+
+### 6p-i — Demo Backend Additions
+
+**Shipped 2026-09-01** — see
+`docs/superpowers/specs/2026-09-01-phase-6p-i-demo-backend-additions-design.md`. Direct origin:
+brainstorming the Sub-project 6 demo (6p, pushed back from 6o once that letter was reassigned to
+username/password authentication) found two of its six planned beats needed real backend surface that
+didn't exist yet — "two players, one chest" (6d-ii's concurrent-effects guarantee) needed a way to mark
+two Task submissions as mutually exclusive, and "ask a question, not just store data" (6c-ii's
+recursive/fixpoint rule evaluation) needed *any* HTTP surface at all for `QueryInterpreter`, confirmed
+by direct search to be 100% library-only before this phase. 6p was split into three sub-phases during
+brainstorming (6p-i backend, 6p-ii the demo's own WASM components, 6p-iii the demo page itself), each
+with its own spec → plan → implementation cycle — this is the first, with no dependency on the other
+two.
+
+`Job.resource_key` is renamed to `Job.mutex_key` throughout — struct field, RDF predicate
+(`urn:riptide:vocab:jobResourceKey` → `urn:riptide:vocab:jobMutexKey`), and, deliberately going beyond
+the literal field rename, `JobTrigger`'s own internal ETS table names and local variable names too
+(`@resource_locks_table` → `@mutex_locks_table`, etc.) — the old name collided with Riptide's own, much
+more prominent LDP "resource" concept (`/resources/*path`), and leaving it in the file's own internal
+naming would have left the exact same collision one layer deeper right next to the freshly-renamed
+public field. Confirmed no real deployment/data exists anywhere using the old predicate, so this was a
+clean rename, not a migration. `TaskController` now threads an optional `mutex_key` from the
+`POST /tasks` JSON body into both Job-construction paths (Discovery-resolved and LLMFallback-resolved)
+— previously silently dropped even if a caller sent one.
+
+New `POST /tenants/:tenant_id/query` reuses existing storage entirely rather than inventing any new
+wire format: the ruleset is the Tenant's own already-admitted Catalog (`Catalog.list_entries/1`,
+unchanged), the starting facts come from reading one caller-named existing Tenant resource
+(`{"starting_resource_path": ["characters", "alice"]}`), and the response is the resulting graph as
+Turtle — the same "return the current full graph" shape `ResourceController.show/2` already uses,
+confirmed correct by reading `QueryInterpreter.loop/5` directly (the returned graph is the union of
+starting facts and everything derived, not a diff). Deliberately diverges from `show/2`'s own semantics
+in one place: a `starting_resource_path` that's never been written evaluates against an empty starting
+graph (`200`), not `404` — a legitimate query outcome, not a broken request.
+
+**One real gap caught only by actually running the capstone test, not assumed from the design**: the
+first capstone attempt asserted both same-`mutex_key` Jobs would be `:done` within a 10-second window
+and failed — Alice's Job completed but Bob's stayed `:pending` indefinitely at that timeout. Root cause,
+confirmed by inspecting the actual Job states rather than guessing: whichever Job loses the mutex race
+on its own `{:job_written, stream_id}` broadcast is skipped that round and only retried on
+`JobTrigger`'s own 30-second periodic sweep (no test-config override for
+`:job_trigger_sweep_interval_ms`) — exactly the same timing property `job_trigger_cluster_test.exs`'s
+own pre-existing "sharing a resource_key" (now "mutex_key") test already documented and budgeted 50
+seconds for, which this new capstone test's own first draft simply hadn't matched.
+
+**Status**: Phase 6p-i shipped 2026-09-01.

--- a/lib/riptide/derivation/job.ex
+++ b/lib/riptide/derivation/job.ex
@@ -6,7 +6,7 @@ defmodule Riptide.Derivation.Job do
   §5. Plain writes, never reviewed (unlike a `CapabilityCatalogEntry` or
   Rule Catalog admission).
 
-  A Job may declare `resource_key` (see design spec
+  A Job may declare `mutex_key` (see design spec
   `docs/superpowers/specs/2026-09-01-phase-6d-ii-concurrent-effects-design.md`
   §4.3) to mark that it must never execute concurrently with another Job
   for the same Tenant declaring the same key. `nil` (the default) means
@@ -33,7 +33,7 @@ defmodule Riptide.Derivation.Job do
     :job_graph,
     :result,
     :error,
-    :resource_key,
+    :mutex_key,
     :resolved_via,
     :original_description,
     :trace
@@ -50,7 +50,7 @@ defmodule Riptide.Derivation.Job do
           job_graph: String.t() | nil,
           result: RDF.Term.t() | nil,
           error: String.t() | nil,
-          resource_key: String.t() | nil,
+          mutex_key: String.t() | nil,
           resolved_via: resolved_via() | nil,
           original_description: String.t() | nil,
           trace: Rule.t() | nil

--- a/lib/riptide/derivation/job_rdf_codec.ex
+++ b/lib/riptide/derivation/job_rdf_codec.ex
@@ -18,7 +18,7 @@ defmodule Riptide.Derivation.JobRDFCodec do
   @riptide_job_graph RDF.iri("urn:riptide:vocab:jobGraph")
   @riptide_job_result RDF.iri("urn:riptide:vocab:jobResult")
   @riptide_job_error RDF.iri("urn:riptide:vocab:jobError")
-  @riptide_job_resource_key RDF.iri("urn:riptide:vocab:jobResourceKey")
+  @riptide_job_mutex_key RDF.iri("urn:riptide:vocab:jobMutexKey")
   @riptide_job_resolved_via RDF.iri("urn:riptide:vocab:jobResolvedVia")
   @riptide_job_original_description RDF.iri("urn:riptide:vocab:jobOriginalDescription")
   @riptide_job_trace RDF.iri("urn:riptide:vocab:jobTrace")
@@ -41,8 +41,8 @@ defmodule Riptide.Derivation.JobRDFCodec do
       |> maybe_add(node, @riptide_job_error, job.error && RDF.literal(job.error))
       |> maybe_add(
         node,
-        @riptide_job_resource_key,
-        job.resource_key && RDF.literal(job.resource_key)
+        @riptide_job_mutex_key,
+        job.mutex_key && RDF.literal(job.mutex_key)
       )
       |> maybe_add(
         node,
@@ -114,7 +114,7 @@ defmodule Riptide.Derivation.JobRDFCodec do
       job_graph: decode_optional_string(description, @riptide_job_graph),
       result: RDF.Description.first(description, @riptide_job_result),
       error: decode_optional_string(description, @riptide_job_error),
-      resource_key: decode_optional_string(description, @riptide_job_resource_key),
+      mutex_key: decode_optional_string(description, @riptide_job_mutex_key),
       resolved_via: decode_resolved_via_optional(description),
       original_description:
         decode_optional_string(description, @riptide_job_original_description),

--- a/lib/riptide/derivation/job_trigger.ex
+++ b/lib/riptide/derivation/job_trigger.ex
@@ -7,21 +7,21 @@ defmodule Riptide.Derivation.JobTrigger do
   reactively via `Riptide.Derivation.Catalog`'s own `{:job_written,
   stream_id}` broadcast and self-healingly via `Riptide.PeriodicSweep`.
 
-  A Job may declare `resource_key` — see design spec
+  A Job may declare `mutex_key` — see design spec
   `docs/superpowers/specs/2026-09-01-phase-6d-ii-concurrent-effects-design.md`
   §4 — to mark that it must never execute concurrently with another Job for
   the same Tenant declaring the same key. Because every Job for a Tenant is
   already guaranteed to be evaluated by this same, uniquely Ra-elected
   process (the property `RaCluster.stream_leader?/1` already gives, §4.1),
   enforcing that is purely local, in-memory bookkeeping — two `:ets` tables
-  owned by this process (`@resource_locks_table` for the currently-in-flight
-  set, `@resource_monitors_table` to map a monitored Task's `reference()`
-  back to the resource it holds, for crash-safe release) — not a new
+  owned by this process (`@mutex_locks_table` for the currently-in-flight
+  set, `@mutex_monitors_table` to map a monitored Task's `reference()`
+  back to the mutex it holds, for crash-safe release) — not a new
   distributed primitive. Both tables die with this process, by design: on
   crash or planned leadership handover, whatever they held stops mattering
   (§4.4), and the newly-started/newly-leading process begins with an empty
   set — the same at-least-once contract Job execution already has,
-  `resource_key` or not.
+  `mutex_key` or not.
   """
 
   use Riptide.PeriodicSweep,
@@ -45,18 +45,18 @@ defmodule Riptide.Derivation.JobTrigger do
   # execute here — see test_run_exclusively/2's own comment for how tests
   # preserve that), so this doesn't weaken the actual guarantee; it only
   # lets tests assert against table contents directly
-  # (`:ets.lookup(@resource_locks_table, ...)`) without a bespoke
+  # (`:ets.lookup(@mutex_locks_table, ...)`) without a bespoke
   # inspection API.
-  @resource_locks_table :job_trigger_resource_locks
-  @resource_monitors_table :job_trigger_resource_monitors
+  @mutex_locks_table :job_trigger_mutex_locks
+  @mutex_monitors_table :job_trigger_mutex_monitors
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_opts), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
   @impl GenServer
   def init(:ok) do
-    :ets.new(@resource_locks_table, [:set, :public, :named_table])
-    :ets.new(@resource_monitors_table, [:set, :public, :named_table])
+    :ets.new(@mutex_locks_table, [:set, :public, :named_table])
+    :ets.new(@mutex_monitors_table, [:set, :public, :named_table])
     Phoenix.PubSub.subscribe(Riptide.PubSub, @jobs_topic)
     schedule_sweep()
     {:ok, %{}}
@@ -71,10 +71,10 @@ defmodule Riptide.Derivation.JobTrigger do
   end
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
-    case :ets.lookup(@resource_monitors_table, ref) do
-      [{^ref, resource}] ->
-        :ets.delete(@resource_monitors_table, ref)
-        :ets.delete(@resource_locks_table, resource)
+    case :ets.lookup(@mutex_monitors_table, ref) do
+      [{^ref, mutex}] ->
+        :ets.delete(@mutex_monitors_table, ref)
+        :ets.delete(@mutex_locks_table, mutex)
 
       [] ->
         :ok
@@ -84,8 +84,8 @@ defmodule Riptide.Derivation.JobTrigger do
   end
 
   @impl GenServer
-  def handle_call({:run_exclusively, resource, fun}, _from, state) do
-    {:reply, run_exclusively(resource, fun), state}
+  def handle_call({:run_exclusively, mutex, fun}, _from, state) do
+    {:reply, run_exclusively(mutex, fun), state}
   end
 
   @impl Riptide.PeriodicSweep
@@ -99,7 +99,7 @@ defmodule Riptide.Derivation.JobTrigger do
   # against whatever process calls IT — correct in production, since
   # try_spawn_execution/3 always calls it from within this GenServer's own
   # process (handle_info and periodic_sweep both execute here already,
-  # unchanged from before this module gained resource-key exclusion). A
+  # unchanged from before this module gained mutex-key exclusion). A
   # test calling run_exclusively/2 directly would instead make the TEST
   # process own the monitor, so the crash-safe cleanup in
   # handle_info({:DOWN, ...}) above — which only ever runs inside THIS
@@ -111,17 +111,17 @@ defmodule Riptide.Derivation.JobTrigger do
   # process calling GenServer.call on itself deadlocks.
   @doc false
   @spec test_run_exclusively({String.t(), String.t()} | nil, (-> term())) :: :ok | :skipped
-  def test_run_exclusively(resource, fun) do
-    GenServer.call(__MODULE__, {:run_exclusively, resource, fun})
+  def test_run_exclusively(mutex, fun) do
+    GenServer.call(__MODULE__, {:run_exclusively, mutex, fun})
   end
 
-  # Runs `fun` under `@execution_supervisor`, exclusively for `resource` (a
-  # `{tenant_id, resource_key}` pair) if given — `nil` skips exclusion
-  # entirely (most Jobs don't declare a resource_key, design spec §4.3).
+  # Runs `fun` under `@execution_supervisor`, exclusively for `mutex` (a
+  # `{tenant_id, mutex_key}` pair) if given — `nil` skips exclusion
+  # entirely (most Jobs don't declare a mutex_key, design spec §4.3).
   # `:ets.insert_new/2` is the whole reservation: an atomic "claim this key
   # only if nobody already holds it," so there's no separate
   # check-then-claim race. Returns `:skipped` (not an error) when the
-  # resource is already held — the caller is expected to just retry on its
+  # mutex is already held — the caller is expected to just retry on its
   # own next sweep, the same as any other transient condition already is.
   @doc false
   @spec run_exclusively({String.t(), String.t()} | nil, (-> term())) :: :ok | :skipped
@@ -130,11 +130,11 @@ defmodule Riptide.Derivation.JobTrigger do
     :ok
   end
 
-  def run_exclusively(resource, fun) do
-    if :ets.insert_new(@resource_locks_table, {resource}) do
+  def run_exclusively(mutex, fun) do
+    if :ets.insert_new(@mutex_locks_table, {mutex}) do
       {:ok, pid} = Task.Supervisor.start_child(@execution_supervisor, fun)
       ref = Process.monitor(pid)
-      :ets.insert(@resource_monitors_table, {ref, resource})
+      :ets.insert(@mutex_monitors_table, {ref, mutex})
       :ok
     else
       :skipped
@@ -159,11 +159,11 @@ defmodule Riptide.Derivation.JobTrigger do
     end
   end
 
-  defp try_spawn_execution(stream_id, node, %Job{resource_key: nil} = job) do
+  defp try_spawn_execution(stream_id, node, %Job{mutex_key: nil} = job) do
     run_exclusively(nil, fn -> execute(stream_id, node, job) end)
   end
 
-  defp try_spawn_execution(stream_id, node, %Job{tenant_id: tenant_id, resource_key: key} = job) do
+  defp try_spawn_execution(stream_id, node, %Job{tenant_id: tenant_id, mutex_key: key} = job) do
     run_exclusively({tenant_id, key}, fn -> execute(stream_id, node, job) end)
   end
 

--- a/lib/riptide_web/router.ex
+++ b/lib/riptide_web/router.ex
@@ -74,6 +74,7 @@ defmodule RiptideWeb.Router do
     get "/policies", RiptideWeb.Authz.PolicyController, :index
 
     post "/tasks", RiptideWeb.TaskController, :create
+    post "/query", RiptideWeb.TenantQueryController, :create
 
     post "/propose", RiptideWeb.TenantProposeController, :propose
     post "/pending-reviews/:node_id/approve", RiptideWeb.TenantReviewController, :approve

--- a/lib/riptide_web/task_controller.ex
+++ b/lib/riptide_web/task_controller.ex
@@ -26,27 +26,28 @@ defmodule RiptideWeb.TaskController do
 
   defp handle_create(conn, tenant_id, description, params) do
     facts = Map.get(params, "facts", [])
+    mutex_key = Map.get(params, "mutex_key")
     current_subject = conn.assigns[:current_subject]
 
     case Discovery.find({:tenant, tenant_id}, description) do
       {:ok, [{_node, rule} | _rest]} ->
-        write_discovery_job(conn, tenant_id, description, rule, facts)
+        write_discovery_job(conn, tenant_id, description, rule, facts, mutex_key)
 
       {:ok, []} ->
-        resolve_via_llm_fallback(conn, tenant_id, description, facts, current_subject)
+        resolve_via_llm_fallback(conn, tenant_id, description, facts, current_subject, mutex_key)
 
       {:error, :not_ready} ->
         send_resp(conn, 503, "")
     end
   end
 
-  defp resolve_via_llm_fallback(conn, tenant_id, description, facts, current_subject) do
+  defp resolve_via_llm_fallback(conn, tenant_id, description, facts, current_subject, mutex_key) do
     graph = facts_to_graph(facts)
     {:ok, context} = ContextResolver.resolve_all(tenant_id, current_subject)
 
     case LLMFallback.run(description, graph, context) do
       {:ok, trace} ->
-        write_llm_fallback_job(conn, tenant_id, description, trace)
+        write_llm_fallback_job(conn, tenant_id, description, trace, mutex_key)
 
       {:error, reason} ->
         body = Jason.encode!(%{"error" => "llm_fallback_failed", "reason" => inspect(reason)})
@@ -54,7 +55,7 @@ defmodule RiptideWeb.TaskController do
     end
   end
 
-  defp write_discovery_job(conn, tenant_id, description, rule, facts) do
+  defp write_discovery_job(conn, tenant_id, description, rule, facts, mutex_key) do
     case write_task_facts(tenant_id, facts) do
       {:ok, job_graph_stream_id} ->
         job = %Job{
@@ -65,6 +66,7 @@ defmodule RiptideWeb.TaskController do
           job_graph: job_graph_stream_id,
           result: nil,
           error: nil,
+          mutex_key: mutex_key,
           resolved_via: :discovery,
           original_description: description,
           trace: nil
@@ -81,7 +83,8 @@ defmodule RiptideWeb.TaskController do
          conn,
          tenant_id,
          description,
-         %Rule{body: [%CapabilityReference{capability: capability_iri, args: args}]} = trace
+         %Rule{body: [%CapabilityReference{capability: capability_iri, args: args}]} = trace,
+         mutex_key
        ) do
     job = %Job{
       tenant_id: tenant_id,
@@ -91,6 +94,7 @@ defmodule RiptideWeb.TaskController do
       job_graph: nil,
       result: nil,
       error: nil,
+      mutex_key: mutex_key,
       resolved_via: :llm_fallback,
       original_description: description,
       trace: trace

--- a/lib/riptide_web/tenant_query_controller.ex
+++ b/lib/riptide_web/tenant_query_controller.ex
@@ -1,0 +1,83 @@
+defmodule RiptideWeb.TenantQueryController do
+  @moduledoc """
+  `POST /tenants/:tenant_id/query` — the first HTTP surface anywhere for
+  `Riptide.Derivation.QueryInterpreter`'s recursive/fixpoint evaluation
+  (design spec
+  `docs/superpowers/specs/2026-09-01-phase-6p-i-demo-backend-additions-design.md`
+  §4.3). Reuses existing storage entirely: the ruleset is the Tenant's own
+  already-admitted Catalog, the starting facts come from one caller-named
+  existing Tenant resource.
+  """
+
+  use Phoenix.Controller, formats: [:json]
+
+  alias Riptide.Derivation.{Catalog, QueryInterpreter}
+  alias Riptide.Event
+  alias Riptide.RDF.{Patch, TurtleCodec}
+  alias Riptide.Stream.{StreamServer, StreamSupervisor}
+  alias RiptideWeb.LDP.ResourceController
+
+  def create(conn, %{"starting_resource_path" => path_segments})
+      when is_list(path_segments) and path_segments != [] do
+    tenant_id = conn.assigns.tenant_id
+
+    with {:ok, entries} <- Catalog.list_entries({:tenant, tenant_id}),
+         {:ok, starting_graph} <- read_starting_graph(tenant_id, path_segments),
+         {:ok, result_graph} <-
+           QueryInterpreter.evaluate(
+             Enum.map(entries, fn {_node, rule} -> rule end),
+             starting_graph
+           ) do
+      {:ok, turtle} = TurtleCodec.encode(result_graph)
+      conn |> put_resp_content_type("text/turtle") |> send_resp(200, turtle)
+    else
+      {:error, :not_ready} ->
+        send_resp(conn, 503, "")
+
+      {:error, reason} ->
+        body = Jason.encode!(%{"error" => "query_evaluation_failed", "reason" => inspect(reason)})
+        conn |> put_resp_content_type("application/json") |> send_resp(422, body)
+    end
+  rescue
+    _ -> send_resp(conn, 503, "")
+  catch
+    :exit, _ -> send_resp(conn, 503, "")
+  end
+
+  def create(conn, _params), do: send_resp(conn, 400, "")
+
+  # Deliberately different from RiptideWeb.LDP.ResourceController.show/2's own
+  # "never written" semantics (a 404) — a starting resource that's never been
+  # written is a legitimate query input here (the rules alone may or may not
+  # derive anything from nothing), not a broken request. Mirrors
+  # Riptide.Accounts's own read_graph/1 shape from 6o.
+  defp read_starting_graph(tenant_id, path_segments) do
+    stream_id = ResourceController.stream_id_for({:tenant, tenant_id}, path_segments)
+
+    case Riptide.Placement.lookup(stream_id) do
+      nil -> {:ok, RDF.Graph.new()}
+      _nodes -> read_existing_starting_graph(stream_id)
+    end
+  end
+
+  defp read_existing_starting_graph(stream_id) do
+    case stream_id |> StreamSupervisor.ensure_ready() |> StreamSupervisor.ensure_ready_status() do
+      :ok ->
+        case StreamServer.get_since(stream_id, 0) do
+          {:ok, events} -> {:ok, fold_events(events)}
+          {:gap, _oldest} -> {:ok, RDF.Graph.new()}
+        end
+
+      :error ->
+        {:error, :not_ready}
+    end
+  end
+
+  defp fold_events(events) do
+    Enum.reduce(events, RDF.Graph.new(), fn
+      %Event{operation: :replace, payload: payload}, _acc -> payload
+      %Event{operation: :delete}, _acc -> RDF.Graph.new()
+      %Event{operation: :patch, payload: %Patch{} = patch}, acc -> Patch.apply(acc, patch)
+    end)
+  end
+end

--- a/test/riptide/derivation/job_rdf_codec_test.exs
+++ b/test/riptide/derivation/job_rdf_codec_test.exs
@@ -63,8 +63,8 @@ defmodule Riptide.Derivation.JobRDFCodecTest do
     assert JobRDFCodec.from_rdf(node, graph) == job
   end
 
-  test "round-trips a Job with a resource_key set" do
-    job = sample_job(%{resource_key: "restart-payments-service"})
+  test "round-trips a Job with a mutex_key set" do
+    job = sample_job(%{mutex_key: "restart-payments-service"})
 
     {node, graph} = JobRDFCodec.to_rdf(job)
 

--- a/test/riptide/derivation/job_trigger_cluster_test.exs
+++ b/test/riptide/derivation/job_trigger_cluster_test.exs
@@ -285,7 +285,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
   # against the trivial fixture.wasm complete too fast to reliably observe
   # an overlap window one way or the other in a cluster test, so trying to
   # assert it here would be flaky, not more rigorous.
-  test "two Jobs for the same Tenant sharing a resource_key both eventually complete" do
+  test "two Jobs for the same Tenant sharing a mutex_key both eventually complete" do
     peers = bootstrap_peers(@peers)
     tenant_id = "job-trigger-resource-#{System.unique_integer([:positive])}"
 
@@ -324,7 +324,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
         %Riptide.Authz.Policy{effect: :allow, modes: [:invoke], matcher: :public}
       ])
 
-    resource_key = "shared-resource-#{System.unique_integer([:positive])}"
+    mutex_key = "shared-mutex-#{System.unique_integer([:positive])}"
 
     job = fn name ->
       %Riptide.Derivation.Job{
@@ -335,7 +335,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
         job_graph: nil,
         result: nil,
         error: nil,
-        resource_key: resource_key
+        mutex_key: mutex_key
       }
     end
 
@@ -351,7 +351,7 @@ defmodule Riptide.Derivation.JobTriggerClusterTest do
                job.("Bob")
              ])
 
-    # Whichever of the two Jobs loses the resource_key race on its own
+    # Whichever of the two Jobs loses the mutex_key race on its own
     # {:job_written, stream_id} broadcast gets skipped that round and only
     # retried on the next periodic_sweep — 30s in this test env too, since
     # :job_trigger_sweep_interval_ms has no test-config override. 250 * 200ms

--- a/test/riptide/derivation/job_trigger_test.exs
+++ b/test/riptide/derivation/job_trigger_test.exs
@@ -3,28 +3,28 @@ defmodule Riptide.Derivation.JobTriggerTest do
 
   alias Riptide.Derivation.JobTrigger
 
-  @resource_locks_table :job_trigger_resource_locks
-  @resource_monitors_table :job_trigger_resource_monitors
+  @mutex_locks_table :job_trigger_mutex_locks
+  @mutex_monitors_table :job_trigger_mutex_monitors
 
   setup do
     on_exit(fn ->
-      :ets.delete_all_objects(@resource_locks_table)
-      :ets.delete_all_objects(@resource_monitors_table)
+      :ets.delete_all_objects(@mutex_locks_table)
+      :ets.delete_all_objects(@mutex_monitors_table)
     end)
 
     :ok
   end
 
   describe "run_exclusively/2 (via test_run_exclusively/2, see its own moduledoc)" do
-    test "with resource_key nil, always runs the function, no reservation made" do
+    test "with mutex_key nil, always runs the function, no reservation made" do
       test_pid = self()
 
       assert :ok = JobTrigger.test_run_exclusively(nil, fn -> send(test_pid, :ran) end)
       assert_receive :ran, 1_000
     end
 
-    test "reserves the resource before returning, so a concurrent second call with the same key is skipped" do
-      resource = {"acme", "run-exclusively-test-#{System.unique_integer([:positive])}"}
+    test "reserves the mutex before returning, so a concurrent second call with the same key is skipped" do
+      mutex = {"acme", "run-exclusively-test-#{System.unique_integer([:positive])}"}
       test_pid = self()
 
       # The first task must stay in flight long enough for this test's own
@@ -37,44 +37,44 @@ defmodule Riptide.Derivation.JobTriggerTest do
       # microsecond-scale local ETS operations this test performs while
       # waiting, not a tight race.
       assert :ok =
-               JobTrigger.test_run_exclusively(resource, fn ->
+               JobTrigger.test_run_exclusively(mutex, fn ->
                  send(test_pid, :first_started)
                  Process.sleep(300)
                  send(test_pid, :first_done)
                end)
 
       assert_receive :first_started, 1_000
-      assert :ets.lookup(@resource_locks_table, resource) != []
+      assert :ets.lookup(@mutex_locks_table, mutex) != []
 
       assert :skipped =
-               JobTrigger.test_run_exclusively(resource, fn -> send(test_pid, :second_ran) end)
+               JobTrigger.test_run_exclusively(mutex, fn -> send(test_pid, :second_ran) end)
 
       refute_receive :second_ran, 500
       assert_receive :first_done, 1_000
     end
 
-    test "releases the resource once the function completes normally, allowing a later call to run" do
-      resource = {"acme", "run-exclusively-release-#{System.unique_integer([:positive])}"}
+    test "releases the mutex once the function completes normally, allowing a later call to run" do
+      mutex = {"acme", "run-exclusively-release-#{System.unique_integer([:positive])}"}
       test_pid = self()
 
-      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> send(test_pid, :done) end)
+      assert :ok = JobTrigger.test_run_exclusively(mutex, fn -> send(test_pid, :done) end)
       assert_receive :done, 1_000
 
-      assert eventually(fn -> :ets.lookup(@resource_locks_table, resource) == [] end)
+      assert eventually(fn -> :ets.lookup(@mutex_locks_table, mutex) == [] end)
 
-      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> send(test_pid, :ran_again) end)
+      assert :ok = JobTrigger.test_run_exclusively(mutex, fn -> send(test_pid, :ran_again) end)
       assert_receive :ran_again, 1_000
     end
 
-    test "releases the resource even if the function crashes abnormally, not just on a normal return" do
-      resource = {"acme", "run-exclusively-crash-#{System.unique_integer([:positive])}"}
+    test "releases the mutex even if the function crashes abnormally, not just on a normal return" do
+      mutex = {"acme", "run-exclusively-crash-#{System.unique_integer([:positive])}"}
 
-      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> raise "boom" end)
-      assert :ets.lookup(@resource_locks_table, resource) != []
+      assert :ok = JobTrigger.test_run_exclusively(mutex, fn -> raise "boom" end)
+      assert :ets.lookup(@mutex_locks_table, mutex) != []
 
-      assert eventually(fn -> :ets.lookup(@resource_locks_table, resource) == [] end)
+      assert eventually(fn -> :ets.lookup(@mutex_locks_table, mutex) == [] end)
 
-      assert :ok = JobTrigger.test_run_exclusively(resource, fn -> :ok end)
+      assert :ok = JobTrigger.test_run_exclusively(mutex, fn -> :ok end)
     end
   end
 

--- a/test/riptide_web/demo_backend_additions_capstone_test.exs
+++ b/test/riptide_web/demo_backend_additions_capstone_test.exs
@@ -1,0 +1,152 @@
+defmodule RiptideWeb.DemoBackendAdditionsCapstoneTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.{Catalog, Rule, Signature}
+  alias Riptide.Derivation.Literal.FactPattern
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+
+  test "query over an admitted rule + a named starting resource returns the derived facts" do
+    tenant_id = "capstone-6p-i-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    # Same deliberately-ground rule shape as TenantQueryControllerTest's own — proving the
+    # exit criterion end-to-end (propose/admit already covered elsewhere; this proves the new
+    # query endpoint reaches it), not re-testing QueryInterpreter's own recursion algorithm.
+    rule = %Rule{
+      signature: %Signature{
+        name: rel("unlocks"),
+        parameters: [],
+        reads: [rel("unlocks")],
+        produces: [rel("unlocks")]
+      },
+      head: %FactPattern{predicate: rel("unlocks"), args: [t("a"), t("c")]},
+      body: [%FactPattern{predicate: rel("unlocks"), args: [t("a"), t("b")]}]
+    }
+
+    :ok = Catalog.admit_entry({:tenant, tenant_id}, rule, nil)
+
+    :put
+    |> conn(
+      "/tenants/#{tenant_id}/resources/characters/alice",
+      "<urn:test:a> <urn:riptide:relation:unlocks> <urn:test:b> ."
+    )
+    |> put_req_header("authorization", "Bearer owner-token")
+    |> RiptideWeb.Endpoint.call(@opts)
+
+    query_body = Jason.encode!(%{"starting_resource_path" => ["characters", "alice"]})
+
+    query_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/query", query_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert query_conn.status == 200
+    assert query_conn.resp_body =~ "urn:test:c"
+  end
+
+  test "two same-mutex_key Task submissions never execute concurrently" do
+    tenant_id = "capstone-6p-i-mutex-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    bytes = File.read!("test/fixtures/riptide_capability/fixture.wasm")
+    {:ok, hash} = Riptide.BlobStore.put(bytes)
+
+    cap_name =
+      RDF.iri("urn:riptide:capability:capstone-6p-i-#{System.unique_integer([:positive])}")
+
+    entry = %Riptide.Derivation.CapabilityCatalogEntry{
+      name: cap_name,
+      kind: :effect,
+      component_hash: hash,
+      function: "greet",
+      fuel_limit: 100_000_000,
+      timeout_ms: 5_000,
+      memory_limits: %{
+        max_memory_size: nil,
+        max_table_elements: nil,
+        max_instances: nil,
+        max_tables: nil
+      }
+    }
+
+    :ok = Catalog.admit_capability(entry, nil)
+
+    local_name = cap_name |> RDF.IRI.to_string() |> String.trim_leading("urn:riptide:capability:")
+
+    :ok =
+      Riptide.Placement.add_policy(tenant_id, ["capabilities", local_name], %Riptide.Authz.Policy{
+        effect: :allow,
+        modes: [:invoke],
+        matcher: :public
+      })
+
+    mutex_key = "capstone-6p-i-shared-chest-#{System.unique_integer([:positive])}"
+
+    job = fn name ->
+      %Riptide.Derivation.Job{
+        tenant_id: tenant_id,
+        status: :pending,
+        reference: {:capability, cap_name},
+        args: [RDF.literal(name)],
+        job_graph: nil,
+        result: nil,
+        error: nil,
+        mutex_key: mutex_key
+      }
+    end
+
+    stream_id = Catalog.job_stream_id(tenant_id)
+    {:ok, _node1} = Catalog.write_job(tenant_id, job.("Alice"))
+    {:ok, _node2} = Catalog.write_job(tenant_id, job.("Bob"))
+
+    # Whichever Job loses the mutex_key race on its own {:job_written, stream_id} broadcast
+    # gets skipped that round and only retried on the next periodic_sweep — 30s in this test
+    # env too, since :job_trigger_sweep_interval_ms has no test-config override (same reasoning
+    # job_trigger_cluster_test.exs's own "sharing a mutex_key" test already documents). 250 *
+    # 200ms = 50s gives that a real margin.
+    assert eventually(
+             fn ->
+               {:ok, jobs} = Catalog.list_jobs(stream_id)
+               length(jobs) == 2 and Enum.all?(jobs, fn {_node, j} -> j.status == :done end)
+             end,
+             250
+           )
+  end
+
+  defp eventually(fun, attempts_left) do
+    cond do
+      fun.() -> true
+      attempts_left <= 1 -> false
+      true -> Process.sleep(200) && eventually(fun, attempts_left - 1)
+    end
+  end
+end

--- a/test/riptide_web/task_controller_test.exs
+++ b/test/riptide_web/task_controller_test.exs
@@ -196,4 +196,109 @@ defmodule RiptideWeb.TaskControllerTest do
     assert conn.status == 422
     assert {:ok, []} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
   end
+
+  defmodule MutexKeyLLMClient do
+    @behaviour Riptide.Derivation.LLMFallback.Client
+
+    @impl true
+    def complete(_prompt) do
+      {:ok,
+       "taskDone(<urn:test:line-1>, Result) :- capability(taskSubmitMutexGreet, \"World\", Result)."}
+    end
+  end
+
+  test "a submitted mutex_key lands on the written Job when resolved via Discovery" do
+    tenant_id = "task-submit-mutex-discovery-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id))
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    predicate_name = "tasksubmitmutex#{System.unique_integer([:positive])}"
+    seed_predicate = "tasksubmitmutexseed#{System.unique_integer([:positive])}"
+
+    rule = %Riptide.Derivation.Rule{
+      signature: %Riptide.Derivation.Signature{
+        name: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        parameters: [%Riptide.Derivation.Var{name: "Subject"}],
+        reads: [RDF.iri("urn:riptide:relation:#{seed_predicate}")],
+        produces: [RDF.iri("urn:riptide:relation:#{predicate_name}")]
+      },
+      head: %Riptide.Derivation.Literal.FactPattern{
+        predicate: RDF.iri("urn:riptide:relation:#{predicate_name}"),
+        args: [%Riptide.Derivation.Var{name: "Subject"}, RDF.literal("done")]
+      },
+      body: [
+        %Riptide.Derivation.Literal.FactPattern{
+          predicate: RDF.iri("urn:riptide:relation:#{seed_predicate}"),
+          args: [%Riptide.Derivation.Var{name: "Subject"}, RDF.literal("v1")]
+        }
+      ]
+    }
+
+    :ok = Catalog.admit_entry({:tenant, tenant_id}, rule, nil)
+
+    body =
+      Jason.encode!(%{
+        "description" => predicate_name,
+        "facts" => [
+          %{
+            "subject" => "urn:test:subject-1",
+            "predicate" => "urn:riptide:relation:#{seed_predicate}",
+            "object" => "v1"
+          }
+        ],
+        "mutex_key" => "shared-chest"
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/tasks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 202
+    response = Jason.decode!(conn.resp_body)
+    job_node = response["job_node"]
+
+    {:ok, jobs} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+    {_node, job} = Enum.find(jobs, fn {n, _j} -> RDF.BlankNode.value(n) == job_node end)
+    assert job.mutex_key == "shared-chest"
+
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(job.job_graph) end)
+  end
+
+  test "a submitted mutex_key lands on the written Job when resolved via LLMFallback" do
+    tenant_id = "task-submit-mutex-llm-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+    register_task_submit_capability(tenant_id, "taskSubmitMutexGreet")
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :llm_fallback_client, MutexKeyLLMClient)
+
+    on_exit(fn -> Riptide.RaTestHelpers.cleanup_stream(Catalog.job_stream_id(tenant_id)) end)
+
+    body =
+      Jason.encode!(%{
+        "description" => "mark this line done",
+        "facts" => [],
+        "mutex_key" => "shared-chest"
+      })
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/tasks", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 202
+    response = Jason.decode!(conn.resp_body)
+    job_node = response["job_node"]
+
+    {:ok, jobs} = Catalog.list_jobs(Catalog.job_stream_id(tenant_id))
+    {_node, job} = Enum.find(jobs, fn {n, _j} -> RDF.BlankNode.value(n) == job_node end)
+    assert job.mutex_key == "shared-chest"
+  end
 end

--- a/test/riptide_web/tenant_query_controller_test.exs
+++ b/test/riptide_web/tenant_query_controller_test.exs
@@ -1,0 +1,123 @@
+defmodule RiptideWeb.TenantQueryControllerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias Riptide.Authz.Store
+  alias Riptide.Derivation.{Catalog, Rule, Signature}
+  alias Riptide.Derivation.Literal.FactPattern
+
+  @opts RiptideWeb.Endpoint.init([])
+
+  defmodule StubVerifier do
+    @behaviour Riptide.Auth.Verifier
+    @impl true
+    def verify("owner-token"), do: {:ok, %{"sub" => "the-owner"}}
+    def verify(_token), do: {:error, :invalid_token}
+  end
+
+  setup do
+    Riptide.AppEnvTestHelpers.put_env(:riptide, :auth_verifier, StubVerifier)
+    :ok
+  end
+
+  defp claim_tenant(tenant_id) do
+    :claimed = Store.Placement.claim_tenant_if_unclaimed(tenant_id, "the-owner")
+  end
+
+  defp rel(name), do: RDF.iri("urn:riptide:relation:" <> name)
+  defp t(name), do: RDF.iri("urn:test:" <> name)
+
+  test "evaluates the Tenant's own admitted rule against a named starting resource" do
+    tenant_id = "query-ctl-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    on_exit(fn ->
+      Riptide.RaTestHelpers.cleanup_stream(Catalog.catalog_stream_id({:tenant, tenant_id}))
+    end)
+
+    # Deliberately a single ground implication (no Vars, no multi-hop chaining) — this test's
+    # only job is proving the HTTP endpoint correctly wires Catalog rules + a named starting
+    # resource + QueryInterpreter.evaluate/3 together; QueryInterpreter's own multi-hop
+    # fixpoint/recursion algorithm already has its own dedicated coverage from 6c-ii and doesn't
+    # need re-proving here.
+    base_rule = %Rule{
+      signature: %Signature{
+        name: rel("unlocks"),
+        parameters: [],
+        reads: [rel("unlocks")],
+        produces: [rel("unlocks")]
+      },
+      head: %FactPattern{predicate: rel("unlocks"), args: [t("a"), t("c")]},
+      body: [%FactPattern{predicate: rel("unlocks"), args: [t("a"), t("b")]}]
+    }
+
+    :ok = Catalog.admit_entry({:tenant, tenant_id}, base_rule, nil)
+
+    starting_body = "<urn:test:a> <urn:riptide:relation:unlocks> <urn:test:b> ."
+
+    write_conn =
+      :put
+      |> conn("/tenants/#{tenant_id}/resources/characters/alice", starting_body)
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert write_conn.status == 201
+
+    query_body = Jason.encode!(%{"starting_resource_path" => ["characters", "alice"]})
+
+    query_conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/query", query_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert query_conn.status == 200
+    assert query_conn.resp_body =~ "urn:test:c"
+  end
+
+  test "a starting_resource_path that's never been written evaluates against an empty starting graph, not 404" do
+    tenant_id = "query-ctl-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    query_body = Jason.encode!(%{"starting_resource_path" => ["characters", "nobody"]})
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/query", query_body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 200
+  end
+
+  test "a missing starting_resource_path returns 400" do
+    tenant_id = "query-ctl-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/query", Jason.encode!(%{}))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 400
+  end
+
+  test "an empty starting_resource_path returns 400" do
+    tenant_id = "query-ctl-" <> Uniq.UUID.uuid4()
+    claim_tenant(tenant_id)
+
+    conn =
+      :post
+      |> conn("/tenants/#{tenant_id}/query", Jason.encode!(%{"starting_resource_path" => []}))
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer owner-token")
+      |> RiptideWeb.Endpoint.call(@opts)
+
+    assert conn.status == 400
+  end
+end


### PR DESCRIPTION
## Summary
- Renames Job.resource_key to Job.mutex_key throughout (struct field, RDF predicate, and JobTrigger's own internal ETS table names/variables) -- the old name collided with Riptide's own, much more prominent LDP "resource" concept.
- Threads an optional mutex_key through POST /tenants/:id/tasks -- previously silently dropped even if a caller sent one.
- Adds POST /tenants/:id/query -- the first HTTP surface anywhere for QueryInterpreter's recursive/fixpoint evaluation, reusing existing storage entirely (the Tenant's own admitted Catalog rules + one named existing resource's current facts).

First of three 6p sub-phases (6p-i backend / 6p-ii WASM components / 6p-iii the demo page) -- the other two depend on this landing.

A real timing gap was caught only by running the capstone test, not assumed: the first draft's mutex_key concurrency test used a 10s window, but a Job that loses the mutex race only retries on JobTrigger's own 30s periodic sweep -- fixed by matching the same 50s margin job_trigger_cluster_test.exs's own pre-existing test already used for this exact reason.

Spec: `docs/superpowers/specs/2026-09-01-phase-6p-i-demo-backend-additions-design.md` (PR #128).

## Test plan
- [x] `mix test` -- full suite green (617 tests, 0 failures)
- [x] `mix format --check-formatted` / `mix credo --strict` -- clean
- [ ] CI green on the PR