### PR TITLE
Draft: Resolve: "guild-demo throws on non-secure-context digest call"

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,11 +8,17 @@ import Config
 # to bundle .js and .css sources.
 config :riptide, RiptideWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
-  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+  # BIND_ALL_INTERFACES=true switches to `{0, 0, 0, 0}` — needed to reach a local dev
+  # instance from outside the host it runs on (e.g. this box's own Service port-forward for
+  # examples/guild-demo, so an operator's own browser can reach it).
   # PORT is optional (defaults to Phoenix's own 4000) — lets a second local instance run
   # alongside another one already bound to the default port (e.g. examples/guild-demo's own
   # smoke-test.mjs, which needs a real dev server it fully controls the lifecycle of).
-  http: [ip: {127, 0, 0, 1}, port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [
+    ip:
+      if(System.get_env("BIND_ALL_INTERFACES") == "true", do: {0, 0, 0, 0}, else: {127, 0, 0, 1}),
+    port: String.to_integer(System.get_env("PORT") || "4000")
+  ],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/examples/guild-demo/index.html
+++ b/examples/guild-demo/index.html
@@ -125,9 +125,87 @@ async function putTurtle(path, token, turtle) {
   if (!res.ok) throw new HttpError(res.status, text);
 }
 
+// A pure-JS SHA-256 (FIPS 180-4), not `crypto.subtle.digest` — the latter is only defined in
+// secure contexts (HTTPS or localhost), so this demo would throw "Cannot read properties of
+// undefined (reading 'digest')" the moment it's served over plain http:// from any other origin
+// (confirmed live: exactly this admin box's own demo-serving setup). Verified against Node's
+// `crypto.createHash("sha256")` across several inputs including empty-string and 55/56/64-byte
+// boundary lengths before wiring in.
 async function sha256hex(text) {
-  const bytes = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
-  return [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  const K = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ];
+  let h0 = 0x6a09e667,
+    h1 = 0xbb67ae85,
+    h2 = 0x3c6ef372,
+    h3 = 0xa54ff53a,
+    h4 = 0x510e527f,
+    h5 = 0x9b05688c,
+    h6 = 0x1f83d9ab,
+    h7 = 0x5be0cd19;
+
+  const msgBytes = new TextEncoder().encode(text);
+  const l = msgBytes.length;
+  const withOne = new Uint8Array(((l + 9 + 63) >> 6) << 6);
+  withOne.set(msgBytes);
+  withOne[l] = 0x80;
+  const bitLen = BigInt(l) * 8n;
+  const dv = new DataView(withOne.buffer);
+  dv.setUint32(withOne.length - 4, Number(bitLen & 0xffffffffn));
+  dv.setUint32(withOne.length - 8, Number((bitLen >> 32n) & 0xffffffffn));
+
+  const rotr = (x, n) => (x >>> n) | (x << (32 - n));
+
+  for (let chunk = 0; chunk < withOne.length; chunk += 64) {
+    const w = new Uint32Array(64);
+    for (let i = 0; i < 16; i++) w[i] = dv.getUint32(chunk + i * 4);
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0;
+    }
+    let a = h0,
+      b = h1,
+      c = h2,
+      d = h3,
+      e = h4,
+      f = h5,
+      g = h6,
+      h = h7;
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + S1 + ch + K[i] + w[i]) | 0;
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (S0 + maj) | 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) | 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) | 0;
+    }
+    h0 = (h0 + a) | 0;
+    h1 = (h1 + b) | 0;
+    h2 = (h2 + c) | 0;
+    h3 = (h3 + d) | 0;
+    h4 = (h4 + e) | 0;
+    h5 = (h5 + f) | 0;
+    h6 = (h6 + g) | 0;
+    h7 = (h7 + h) | 0;
+  }
+  const toHex = (n) => (n >>> 0).toString(16).padStart(8, "0");
+  return [h0, h1, h2, h3, h4, h5, h6, h7].map(toHex).join("");
 }
 
 // Riptide's own RDF vocabulary IRIs — mirrors the exact terms the backend's own RDF codecs write


### PR DESCRIPTION
## Summary
- `sha256hex()` in `examples/guild-demo/index.html` used `crypto.subtle.digest`, which browsers only expose in secure contexts (HTTPS or `localhost`). Serving the demo over plain `http://` from any other origin makes clicking Begin throw `Cannot read properties of undefined (reading 'digest')` before any request is sent — found live while trying the shipped demo from a real browser.
- Replaced it with a pure-JS SHA-256 (FIPS 180-4), verified byte-for-byte against Node's `crypto.createHash("sha256")` across several inputs including empty-string and 55/56/64-byte block-boundary lengths, since the server's signup endpoint requires an exact 64-hex-char match.
- `smoke-test.mjs` never caught this because it opens the page via `file://`, which Chromium treats as a secure context.
- Also adds `BIND_ALL_INTERFACES` to `config/dev.exs` (mirrors the existing `PORT`/`WRITE_RATE_LIMIT` override pattern) — needed for a dev instance to be reachable by a browser on another host, which is what surfaced the bug above.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix credo --strict`
- [x] Verified the new `sha256hex` against Node's `crypto` module across boundary-length inputs
- [x] Drove the real page with Playwright against a live instance served over plain HTTP from a non-localhost origin — confirmed no more digest crash (failure mode changed from a JS exception to a clean server-side 409 on a re-claimed tenant name)
- [x] Reset the dev instance's Ra state and re-verified `sha256hex` executes correctly in-page without consuming the demo's tenant names, leaving a clean instance